### PR TITLE
This is needed to get the ndk-build command.

### DIFF
--- a/docs/source/prerequisites.rst
+++ b/docs/source/prerequisites.rst
@@ -49,5 +49,5 @@ After installing them, export both installation path, NDK version and API to use
 
 Also, you must configure you're PATH to add the ``android`` binary::
 
-    export PATH=/path/to/android-sdk-linux/tools:$PATH
+    export PATH=/path/to/android-ndk:/path/to/android-sdk-linux/tools:$PATH
 


### PR DESCRIPTION
On Debian Wheezy, working in a virtual environment, in the directory of python-for-android, I do the following :

 $ ./distribute.sh -m "sqlite3 kivy"
[lots of debug]
./distribute.sh: line 45: ndk-build: command not found

A simple way to fix that is to add the path to the android NDK to PATH.

Code version : 26e8ea0b48c1befc13cfca9faafe588b7441ca43 
