### PR TITLE
Added pyopenssl recipe

### DIFF
--- a/recipes/pyopenssl/recipe.sh
+++ b/recipes/pyopenssl/recipe.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+VERSION_pyopenssl=0.13
+URL_pyopenssl=http://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-$VERSION_pyopenssl.tar.gz
+DEPS_pyopenssl=(openssl hostpython python)
+MD5_pyopenssl= 767bca18a71178ca353dff9e10941929
+BUILD_pyopenssl=$BUILD_PATH/pyopenssl/$(get_directory $URL_pyopenssl)
+RECIPE_pyopenssl=$RECIPES_PATH/pyopenssl
+
+function prebuild_pyopenssl() {
+	true
+}
+
+function build_pyopenssl() {
+
+	if [ -d "$BUILD_PATH/python-install/lib/python2.7/site-packages/pyOpenSSL" ]; then
+		return
+	fi
+
+	cd $BUILD_pyopenssl
+
+	push_arm
+
+	export CC="$CC -I$BUILD_openssl/include"
+	export LDFLAGS="$LDFLAGS -L$LIBS_PATH -L$BUILD_openssl"
+
+	try $BUILD_PATH/python-install/bin/python.host setup.py build_ext -v
+	try find build/lib.* -name "*.o" -exec $STRIP {} \;
+
+	try $BUILD_PATH/python-install/bin/python.host setup.py install -O2
+
+	try rm -rf $BUILD_PATH/python-install/lib/python*/site-packages/OpenSSL/test
+
+	pop_arm
+}
+
+function postbuild_pyopenssl() {
+	true
+}


### PR DESCRIPTION
This recipe works reliably if openssl is explicitly placed at the start of the modules line for distribute.sh and pyopenssl is placed after python, ie:

./distribute.sh -m "openssl python pyopenssl kivy"

If this is not done python sometimes misses the _ssl.so module upon which ssl/pyopenssl depends. 

I have tried adding openssl as a dependency of python, and setting the dependencies of pyopenssl to "openssl python", but it seems that the only reliable way to build pyopenssl is by making the order explicit in the arguments.

If you require ssl support in twisted, use something like:

./distribute.sh -m "openssl python pyopenssl twisted kivy"
