### PR TITLE
Update for pylibpd

### DIFF
--- a/recipes/audiostream/recipe.sh
+++ b/recipes/audiostream/recipe.sh
@@ -3,10 +3,10 @@
 # Only h264+aac build are working.
 
 VERSION_audiostream=
-URL_audiostream=https://github.com/kivy/audiostream/zipball/master/audiostream.zip
+URL_audiostream=https://github.com/kivy/audiostream/zipball/master/kivy-audiostream-b5bc9d5.zip
 DEPS_audiostream=(python sdl)
 MD5_audiostream=
-BUILD_audiostream=$BUILD_PATH/audiostream/audiostream
+BUILD_audiostream=$BUILD_PATH/audiostream/kivy-audiostream-b5bc9d5
 RECIPE_audiostream=$RECIPES_PATH/audiostream
 
 function prebuild_audiostream() {

--- a/recipes/pylibpd/recipe.sh
+++ b/recipes/pylibpd/recipe.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+
+# version of your package
+VERSION_pylibpd=1.3
+
+# dependencies of this recipe
+DEPS_pylibpd=()
+
+# url of the
+URL_pylibpd=http://ticklestep.com/pylibpd.tar.gz
+
+# md5 of the package
+MD5_pylibpd=647f813726c21445c42bc2fc77a4b146
+
+# default build path
+BUILD_pylibpd=$BUILD_PATH/pylibpd/$(get_directory $URL_pylibpd)
+
+# default recipe path
+RECIPE_pylibpd=$RECIPES_PATH/pylibpd
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_pylibpd() {
+	true
+}
+
+# function called to build the source code
+function build_pylibpd() {
+    cd $BUILD_pylibpd/python
+    push_arm
+    $BUILD_PATH/python-install/bin/python.host setup.py install -O2
+    pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_pylibpd() {
+	true
+}


### PR DESCRIPTION
When you go to compile libpd it will complain that it cannot link to pthread. This is because the Android C runtime provides pthread.

I have just copied the last compile command, removed the -lpthread option and run it manually to finish the compilation.

I tried removing pthread from the setup.py file but it seemed to have no affect.
