### PR TITLE
A fix for the bug where subprocess.call() hangs forever.

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -75,8 +75,7 @@ def compile_dir(dfn):
     '''
 
     # -OO = strip docstrings
-    subprocess.call([PYTHON,'-OO','-m','compileall','-f', dfn],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.call([PYTHON,'-OO','-m','compileall','-f', dfn])
 
 def is_blacklist(name):
     for pattern in BLACKLIST_PATTERNS:


### PR DESCRIPTION
This is a fix for bug #29.

With this commit, the subprocess.call() doesn't hang forever anymore.
