### PR TITLE
small Macosx fixes

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -27,6 +27,10 @@ MD5SUM=$(which md5sum)
 if [ "X$MD5SUM" == "X" ]; then
 	MD5SUM="md5 -r"
 fi
+WGET=$(which wget)
+if [ "X$WGET" == "X" ]; then
+	WGET="curl -L -O"
+fi
 
 # Internals
 CRED="\x1b[31;01m"
@@ -397,7 +401,7 @@ function run_get_packages() {
 		# download if needed
 		if [ $do_download -eq 1 ]; then
 			info "Downloading $url"
-			try wget $url
+			try $WGET $url
 		else
 			debug "Module $module already downloaded"
 		fi

--- a/recipes/pil/recipe.sh
+++ b/recipes/pil/recipe.sh
@@ -21,9 +21,9 @@ function prebuild_pil() {
 
 	LIBS="$SRC_PATH/obj/local/$ARCH"
 	try cp setup.py.tmpl setup.py
-	try sed -i s:_LIBS_:$LIBS: setup.py
-	try sed -i s:_JNI_:$JNI_PATH: setup.py
-	try sed -i s:_NDKPLATFORM_:$NDKPLATFORM: setup.py
+	try sed -i '' s:_LIBS_:$LIBS: setup.py
+	try sed -i '' s:_JNI_:$JNI_PATH: setup.py
+	try sed -i '' s:_NDKPLATFORM_:$NDKPLATFORM: setup.py
 
 	# everything done, touch the marker !
 	touch .patched


### PR DESCRIPTION
minor improvments :
- detect wget and change to curl if not present
- sed syntax fix

This makes me go further but then i end up with `cannot find -lpython2.7`:

```
SharedLibrary  : libapplication.so
/Applications/android-ndk-r8/toolchains/arm-linux-androideabi-4.4.3/prebuilt/darwin-x86/bin/arm-linux-androideabi-g++  -Wl,-soname,libapplication.so -shared --sysroot=/Applications/android-ndk-r8/platforms/android-14/arch-arm /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/objs/application/src//start.o /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libjpeg.a /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libpng.a /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libsdl.so /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libsdl_ttf.so /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libsdl_image.so /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libsdl_mixer.so  -L/Users/juju/Documents/projects/kivysrc/python-for-android/src/jni/../jni/application/../../../build/python-install/lib -Xlinker -export-dynamic -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,--no-undefined -Wl,-z,noexecstack -L/Applications/android-ndk-r8/platforms/android-14/arch-arm/usr/lib -lpython2.7 -lGLESv1_CM -ldl -llog -lz -lc -lm -o /Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libapplication.so
/Applications/android-ndk-r8/toolchains/arm-linux-androideabi-4.4.3/prebuilt/darwin-x86/bin/../lib/gcc/arm-linux-androideabi/4.4.3/../../../../arm-linux-androideabi/bin/ld: cannot find -lpython2.7
collect2: ld returned 1 exit status
make: *** [/Users/juju/Documents/projects/kivysrc/python-for-android/src/obj/local/armeabi/libapplication.so] Error 1
```

any idea ?
