### PR TITLE
Get Android network state by direct query or with BroadcastReciever

### DIFF
--- a/src/src/org/renpy/android/Hardware.java
+++ b/src/src/org/renpy/android/Hardware.java
@@ -253,9 +253,9 @@ public class Hardware {
 
 		final NetworkInfo activeNetwork = conMgr.getActiveNetworkInfo();
 		if (activeNetwork != null && activeNetwork.isConnected()) {
-			network_state = true;
+			state = true;
 		} else {
-			network_state = false;
+			state = false;
 		}
 
         return state;
@@ -272,7 +272,7 @@ public class Hardware {
 
             @Override
             public void onReceive(Context c, Intent i) {
-				checkNetwork();
+				network_state = checkNetwork();
             }
 
         }, i);


### PR DESCRIPTION
Two methods added to Hardware.java to check network availability. First one make a direct query, the other registers a BroadcastReciever to catch changes and represent the state in network_state property.
Both method tested in my project amd seems to work ok. Nevertheless I'm not a java guy, so any advice appreciated.
