### PR TITLE
Fix for build fails when no java files to copy.

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -548,7 +548,7 @@ function run_distribute() {
 	try cp -a $BUILD_PATH/libs/* libs/$ARCH/
 
 	debug "Copy java files from various libs"
-	try cp -a $BUILD_PATH/java/* src
+	cp -a $BUILD_PATH/java/* src
 
 	debug "Fill private directory"
 	try cp -a python-install/lib private/


### PR DESCRIPTION
Commit https://github.com/kivy/python-for-android/commit/668cedc7b07ce20a98e787941b379c0f81a13e8a
introduced line 551 which had a try clause before it copied java files, but often there are no java files to copy. This would cause the build to fail. I removed the try clause so the build will continue whether there are java files to copy or not.
