### PR TITLE
Change hash-bang for maximum compatability

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2.7
 
 from os.path import dirname, join, isfile, realpath, relpath, split
 from zipfile import ZipFile


### PR DESCRIPTION
This is to fix https://github.com/kivy/python-for-android/issues/88
The ideal solution, according to Python PEP 0394, would seem to be 
'#!/usr/bin/env python2', however that PEP is unfortunately not 
well-followed by OSX and even Linux distros like Arch and Debian 
Squeeze. Because of this, and because Kivy currently only supports 
Python2.7, the more practical solution is '#!/usr/bin/env python2.7'.
