### PR TITLE
.gitignore: add a couple of rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@ build
 src/obj
 src/local.properties
 src/default.properties
+src/libs/armeabi
 dist
 *.pyc
 testsuite
+.packages
 
 #ECLIPSE + PYDEV
 .project


### PR DESCRIPTION
src/libs/armeabi contains generated *.so files, and .packages
contains downloaded *.tar.gz packages.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
