### PR TITLE
Improvements to build.py to reduce APK size and reduce command-line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/default.properties
 dist
 *.pyc
 testsuite
+.packages
 
 #ECLIPSE + PYDEV
 .project

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ Global overview
 ---------------
 
 #. Download Android NDK, SDK
- 
+
  * NDK: http://dl.google.com/android/ndk/android-ndk-r8c-linux-x86.tar.bz2
- 
+
  * More details at: http://developer.android.com/tools/sdk/ndk/index.html
- 
+
  * SDK: http://dl.google.com/android/android-sdk_r21.0.1-linux.tgz
- 
+
  * More details at:http://developer.android.com/sdk/index.html
 
 #. Launch "android", and download latest Android platform, here API 14, which would be Android 4.0
@@ -54,6 +54,35 @@ Global overview
     adb install bin/touchtracer-1.0-debug.apk
 
 #. Enjoy.
+
+
+Build Configuration File
+------------------------
+
+You may end up with a very long build.py command-line invocation so to make
+things easier you can store the arguments in a configuration file like so::
+
+    package=net.mechanicalcat.match3
+    name=Match 3
+    version=1.3.3
+    numeric-version=133
+    dir=~/src/projects/games/match3
+    orientation=portrait
+    icon=~/src/projects/games/match3/art/android-icon.png
+    presplash=~/src/projects/games/match3/art/android-presplash.jpg
+    blacklist=blacklist.txt
+    sdk=14
+
+and then use the configuration file as your only build argument:
+
+    python build.py -c match3_build.ini release
+
+The parameters in the configuration file match the names in the command-line
+arguments. List parameters (permission, ignore_path) may have multiple items
+on new lines:
+
+    permission=VIBRATE
+        INTERNET
 
 
 Troubleshooting

--- a/src/build.py
+++ b/src/build.py
@@ -4,6 +4,7 @@ import re
 from os.path import dirname, join, isfile, realpath, relpath, split
 from zipfile import ZipFile
 import ConfigParser
+import tempfile
 import sys
 sys.path.insert(0, 'buildlib/jinja2.egg')
 sys.path.insert(0, 'buildlib')
@@ -210,6 +211,12 @@ def make_tar(tfn, source_dirs, ignore_path=[]):
 
         # put the file
         tf.add(fn, afn)
+
+    fn = os.path.basename(tfn)
+    with tempfile.NamedTemporaryFile() as t:
+        t.write('\n'.join(afn for x, afn in files))
+        t.flush()
+        tf.add(t.name, fn + '.MANIFEST')
     tf.close()
 
 

--- a/src/build.py
+++ b/src/build.py
@@ -77,7 +77,7 @@ def compile_dir(dfn):
     '''
 
     # -OO = strip docstrings
-    subprocess.call([PYTHON, '-OO', '-m', 'compileall', '-f', dfn])
+    subprocess.call([PYTHON, '-OO', '-m', 'compileall', '-f', dfn, '-q'])
 
 
 def is_blacklist(name):
@@ -123,6 +123,9 @@ def make_pythonzip():
         fn = fn[len(d):]
         if fn.startswith('/site-packages/') or \
             fn.startswith('/config/') or \
+            fn.startswith('/distutils/') or \
+            fn.startswith('/plat-mac/') or \
+            fn.startswith('/plat-darwin/') or \
             fn.startswith('/lib-dynload/') or \
             fn.startswith('/libpymodules.so'):
                 return False


### PR DESCRIPTION
- include the 'quiet' flag to compileall to reduce noise
- fix bug in non-zip packaging to not include files in the ZIP bundle
- switch to more flexible and enlargeable definition of files to not bundle in ZIP and at all
- don't bundle distutils, compiler and other Python libs that are big and unnecessary
- add ability to configure build.py from a configuration file

(these changes - apart from the "quiet" flag of course - reduced my APK from 8MB to 6MB)