### PR TITLE
Force wget or curl to save files using the expected filename

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -52,8 +52,10 @@ if [ "X$WGET" == "X" ]; then
 		echo "Error: you need at least wget or curl installed."
 		exit 1
 	else
-		WGET="$WGET -L -O"
+		WGET="$WGET -L -O -o"
 	fi
+else
+	WGET="$WGET -O"
 fi
 
 case $OSTYPE in
@@ -470,7 +472,7 @@ function run_get_packages() {
 		# download if needed
 		if [ $do_download -eq 1 ]; then
 			info "Downloading $url"
-			try $WGET $url
+			try $WGET $filename $url
 		else
 			debug "Module $module already downloaded"
 		fi


### PR DESCRIPTION
Since wget will rename files if redirected to a url other than the one originally requested, add -O $filename (or -o $filename for curl) to make sure downloads are named as expected.
