### PR TITLE
Moved private and public archives to /res/raw for android library usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ src/default.properties
 dist
 *.pyc
 testsuite
+.packages
+src/libs/armeabi
 
 #ECLIPSE + PYDEV
 .project

--- a/distribute.sh
+++ b/distribute.sh
@@ -559,7 +559,7 @@ function run_distribute() {
 	cd "$DIST_PATH"
 
 	debug "Create initial layout"
-	try mkdir assets bin private res templates
+	try mkdir assets bin private res res/raw templates
 
 	debug "Copy default files"
 	try cp -a $SRC_PATH/default.properties .

--- a/src/build.py
+++ b/src/build.py
@@ -264,11 +264,11 @@ def make_package(args):
         sys.exit(-1)
 
     # Delete the old assets.
-    if os.path.exists('assets/public.mp3'):
-        os.unlink('assets/public.mp3')
+    if os.path.exists('res/raw/public_pack.tar'):
+        os.unlink('res/raw/public_pack.tar')
 
-    if os.path.exists('assets/private.mp3'):
-        os.unlink('assets/private.mp3')
+    if os.path.exists('res/raw/private_pack.tar'):
+        os.unlink('res/raw/private_pack.tar')
 
     # In order to speedup import and initial depack,
     # construct a python27.zip
@@ -276,12 +276,12 @@ def make_package(args):
 
     # Package up the private and public data.
     if args.private:
-        make_tar('assets/private.mp3', ['private', args.private])
+        make_tar('res/raw/private_pack.tar', ['private', args.private])
     else:
-        make_tar('assets/private.mp3', ['private'])
+        make_tar('res/raw/private_pack.tar', ['private'])
 
     if args.dir:
-        make_tar('assets/public.mp3', [args.dir], args.ignore_path)
+        make_tar('res/raw/public_pack.tar', [args.dir], args.ignore_path)
 
     # Copy over the icon and presplash files.
     shutil.copy(args.icon or default_icon, 'res/drawable/icon.png')

--- a/src/src/org/renpy/android/AssetExtract.java
+++ b/src/src/org/renpy/android/AssetExtract.java
@@ -17,18 +17,17 @@ import java.io.File;
 
 import java.util.zip.GZIPInputStream;
 
-import android.content.res.AssetManager;
+import android.content.Context;
+import android.content.res.Resources;
 
 import org.xeustechnologies.jtar.*;
 
 class AssetExtract {
 
-    private AssetManager mAssetManager = null;
     private Activity mActivity = null;
     
     AssetExtract(Activity act) {
         mActivity = act;
-        mAssetManager = act.getAssets();
     }
     
     public boolean extractTar(String asset, String target) {
@@ -38,8 +37,12 @@ class AssetExtract {
         InputStream assetStream = null;
         TarInputStream tis = null;
         
+        Context appContext = mActivity.getApplicationContext();
+        Resources res = appContext.getResources();  
+        int resId = res.getIdentifier(asset, "raw", appContext.getPackageName());	 
+        
         try {
-            assetStream = mAssetManager.open(asset, AssetManager.ACCESS_STREAMING);
+            assetStream = res.openRawResource(resId);
             tis = new TarInputStream(new BufferedInputStream(new GZIPInputStream(new BufferedInputStream(assetStream, 8192)), 8192));
         } catch (IOException e) {
             Log.e("python", "opening up extract tar", e);

--- a/src/src/org/renpy/android/PythonActivity.java
+++ b/src/src/org/renpy/android/PythonActivity.java
@@ -189,7 +189,7 @@ public class PythonActivity extends Activity implements Runnable {
             target.mkdirs();
 
             AssetExtract ae = new AssetExtract(this);
-            if (!ae.extractTar(resource + ".mp3", target.getAbsolutePath())) {
+            if (!ae.extractTar(resource + "_pack", target.getAbsolutePath())) {
                 toastError("Could not extract " + resource + " data.");
             }
 


### PR DESCRIPTION
* Moved archives to res/raw since android library projects cannot contain files in assets/ .

(Just in case someone wants to use the distribution as a library for another project.)