### PR TITLE
seek, get_pos  and get_length support for mediaplayer

### DIFF
--- a/recipes/android/src/android_mixer.py
+++ b/recipes/android/src/android_mixer.py
@@ -113,6 +113,8 @@ class ChannelImpl(object):
         with condition:
             condition.notify()
 
+    def seek(self, position):
+        sound.seek(self.id, position)
 
     def stop(self):
         self.loop = None
@@ -159,6 +161,12 @@ class ChannelImpl(object):
     def get_queue(self):
         return self.queued
 
+    def get_pos(self):
+        return sound.get_pos(self.id)/1000.
+
+    def get_length(self):
+        return sound.get_length(self.id)/1000.
+
 
 def Channel(n):
     """
@@ -204,6 +212,7 @@ class Sound(object):
         self._channel = channel = find_channel(True)
         channel.play(self, loops=loops)
         return channel
+
 
     def stop(self):
         for i in range(0, num_channels):
@@ -255,6 +264,10 @@ class music(object):
         music_channel.play(music_sound)
 
     @staticmethod
+    def seek(position):
+        music_channel.seek(position)
+
+    @staticmethod
     def stop():
         music_channel.stop()
 
@@ -284,7 +297,7 @@ class music(object):
 
     @staticmethod
     def get_pos():
-        return 0
+        return music_channel.get_pos()
 
     @staticmethod
     def queue(filename):

--- a/recipes/android/src/android_sound.pyx
+++ b/recipes/android/src/android_sound.pyx
@@ -1,6 +1,7 @@
 cdef extern void android_sound_queue(int, char *, char *, long long, long long)
 cdef extern void android_sound_play(int, char *, char *, long long, long long)
 cdef extern void android_sound_stop(int)
+cdef extern void android_sound_seek(int, float)
 cdef extern void android_sound_dequeue(int)
 cdef extern void android_sound_playing_name(int, char *, int)
 cdef extern void android_sound_pause(int)
@@ -11,6 +12,8 @@ cdef extern void android_sound_set_secondary_volume(int, float)
 cdef extern void android_sound_set_pan(int, float)
 
 cdef extern int android_sound_queue_depth(int)
+cdef extern int android_sound_get_pos(int)
+cdef extern int android_sound_get_length(int)
 
 channels = set()
 volumes = { }
@@ -18,8 +21,8 @@ volumes = { }
 def queue(channel, file, name, fadein=0, tight=False):
 
     channels.add(channel)
-    
-    real_fn = file.name    
+
+    real_fn = file.name
     base = getattr(file, "base", -1)
     length = getattr(file, "length", -1)
 
@@ -28,12 +31,15 @@ def queue(channel, file, name, fadein=0, tight=False):
 def play(channel, file, name, paused=False, fadein=0, tight=False):
 
     channels.add(channel)
-    
+
     real_fn = file.name    
     base = getattr(file, "base", -1)
     length = getattr(file, "length", -1)
 
     android_sound_play(channel, name, real_fn, base, length)
+
+def seek(channel, position):
+   android_sound_seek(channel, position)
 
 def stop(channel):
     android_sound_stop(channel)
@@ -70,7 +76,7 @@ def unpause_all():
 def pause_all():
     for i in channels:
         pause(i)
-        
+
 def fadeout(channel, ms):
     stop(channel)
 
@@ -78,12 +84,15 @@ def busy(channel):
     return playing_name(channel) != None
 
 def get_pos(channel):
-    return 0
+    return android_sound_get_pos(channel)
+
+def get_length(channel):
+    return android_sound_get_length(channel)
 
 def set_volume(channel, volume):
     android_sound_set_volume(channel, volume)
     volumes[channel] = volume
-    
+
 def set_secondary_volume(channel, volume):
     android_sound_set_secondary_volume(channel, volume)
 

--- a/recipes/android/src/android_sound_jni.c
+++ b/recipes/android/src/android_sound_jni.c
@@ -25,14 +25,14 @@ void android_sound_queue(int channel, char *filename, char *real_fn, long long b
     }
 
     PUSH_FRAME;
-    
+
     (*env)->CallStaticVoidMethod(
         env, cls, mid,
         channel,
         (*env)->NewStringUTF(env, filename),
         (*env)->NewStringUTF(env, real_fn),
         (jlong) base,
-        (jlong) length);        
+        (jlong) length);
 
     POP_FRAME;
 }
@@ -41,7 +41,7 @@ void android_sound_play(int channel, char *filename, char *real_fn, long long ba
     static JNIEnv *env = NULL;
     static jclass *cls = NULL;
     static jmethodID mid = NULL;
-    
+
     if (env == NULL) {
         env = SDL_ANDROID_GetJNIEnv();
         aassert(env);
@@ -52,7 +52,7 @@ void android_sound_play(int channel, char *filename, char *real_fn, long long ba
     }
 
     PUSH_FRAME;
-    
+
     (*env)->CallStaticVoidMethod(
         env, cls, mid,
         channel,
@@ -62,6 +62,26 @@ void android_sound_play(int channel, char *filename, char *real_fn, long long ba
         (jlong) length);
 
     POP_FRAME;
+}
+
+void android_sound_seek(int channel, float position){
+    static JNIEnv *env = NULL;
+    static jclass *cls = NULL;
+    static jmethodID mid = NULL;
+
+    if (env == NULL) {
+        env = SDL_ANDROID_GetJNIEnv();
+        aassert(env);
+        cls = (*env)->FindClass(env, "org/renpy/android/RenPySound");
+        aassert(cls);
+        mid = (*env)->GetStaticMethodID(env, cls, "seek", "(IF)V");
+        aassert(mid);
+    }
+
+    (*env)->CallStaticVoidMethod(
+        env, cls, mid,
+        channel,
+        (jfloat) position);
 }
 
 void android_sound_stop(int channel) {
@@ -128,7 +148,7 @@ void android_sound_playing_name(int channel, char *buf, int buflen) {
 
     jobject s = NULL;
     char *jbuf;
-    
+
     if (env == NULL) {
         env = SDL_ANDROID_GetJNIEnv();
         aassert(env);
@@ -139,7 +159,7 @@ void android_sound_playing_name(int channel, char *buf, int buflen) {
     }
 
     PUSH_FRAME;
-    
+
     s = (*env)->CallStaticObjectMethod(
         env, cls, mid,
         channel);
@@ -245,6 +265,44 @@ void android_sound_unpause(int channel) {
     }
 
     (*env)->CallStaticVoidMethod(
+        env, cls, mid,
+        channel);
+}
+
+int android_sound_get_pos(int channel) {
+    static JNIEnv *env = NULL;
+    static jclass *cls = NULL;
+    static jmethodID mid = NULL;
+
+    if (env == NULL) {
+        env = SDL_ANDROID_GetJNIEnv();
+        aassert(env);
+        cls = (*env)->FindClass(env, "org/renpy/android/RenPySound");
+        aassert(cls);
+        mid = (*env)->GetStaticMethodID(env, cls, "get_pos", "(I)I");
+        aassert(mid);
+    }
+
+    (*env)->CallStaticIntMethod(
+        env, cls, mid,
+        channel);
+}
+
+int android_sound_get_length(int channel) {
+    static JNIEnv *env = NULL;
+    static jclass *cls = NULL;
+    static jmethodID mid = NULL;
+
+    if (env == NULL) {
+        env = SDL_ANDROID_GetJNIEnv();
+        aassert(env);
+        cls = (*env)->FindClass(env, "org/renpy/android/RenPySound");
+        aassert(cls);
+        mid = (*env)->GetStaticMethodID(env, cls, "get_length", "(I)I");
+        aassert(mid);
+    }
+
+    (*env)->CallStaticIntMethod(
         env, cls, mid,
         channel);
 }

--- a/src/src/org/renpy/android/RenPySound.java
+++ b/src/src/org/renpy/android/RenPySound.java
@@ -7,37 +7,37 @@ import java.io.IOException;
 import java.util.HashMap;
 
 public class RenPySound {
-    
+
     private static class Channel implements MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener {
 
         // MediaPlayers for the currently playing and queued up
         // sounds.
         MediaPlayer player[];
-        
+
         // Filenames for the currently playing and queued up sounds.
         String filename[];
 
         // Is the corresponding player prepareD?
         boolean prepared[];
-        
+
         // The volume for the left and right channel.
         double volume;
         double secondary_volume;
         double left_volume;
         double right_volume;
-        
+
         Channel() {
             player = new MediaPlayer[2];
             filename = new String[2];
             prepared = new boolean[2];
-            
+
             player[0] = new MediaPlayer();
             player[1] = new MediaPlayer();
 
             volume = 1.0;
             secondary_volume = 1.0;
             left_volume = 1.0;
-            right_volume = 1.0;            
+            right_volume = 1.0;
         }
 
         /**
@@ -50,7 +50,7 @@ public class RenPySound {
 
             try {
                 FileInputStream f = new FileInputStream(real_fn);
-                
+
                 if (length >= 0) {
                     mp.setDataSource(f.getFD(), base, length);
                 } else {
@@ -59,18 +59,18 @@ public class RenPySound {
 
                 mp.setOnCompletionListener(this);
                 mp.setOnPreparedListener(this);
-                
+
                 mp.prepareAsync();
-                
+
                 f.close();
             } catch (IOException e) {
                 Log.w("RenPySound", e);
                 return;
             }
-            
 
-            filename[1] = fn;           
-            
+
+            filename[1] = fn;
+
         }
 
         /**
@@ -80,26 +80,36 @@ public class RenPySound {
             MediaPlayer tmp;
 
             player[0].reset();
-            
+
             tmp = player[0];
             player[0] = player[1];
             player[1] = tmp;
-            
+
             filename[0] = filename[1];
             filename[1] = null;
 
             prepared[0] = prepared[1];
             prepared[1] = false;
-            
+
             if (filename[0] != null) {
                 updateVolume();
 
-                if (prepared[0]) {                
+                if (prepared[0]) {
                     player[0].start();
                 }
             }
         }
-        
+
+        /**
+        * Seek to the position specified on this channel
+        */
+
+        synchronized void seek(float position) {
+            if (prepared[0]){
+                player[0].seekTo((int)position*1000);
+                }
+        }
+
         /**
          * Stop playback on this channel.
          */
@@ -161,7 +171,7 @@ public class RenPySound {
                 left_volume = 1.0 - pan;
                 right_volume = 1.0;
             }
-            
+
             updateVolume();
          }
 
@@ -177,6 +187,17 @@ public class RenPySound {
             }
         }
 
+        synchronized int get_pos(){
+            return player[0].getCurrentPosition();
+        }
+
+        synchronized int get_length(){
+            if (prepared[0]) {
+                return player[0].getDuration();
+                }
+            return 1;
+        }
+
         synchronized public void onPrepared(MediaPlayer mp) {
             if (mp == player[0]) {
                 prepared[0] = true;
@@ -187,7 +208,7 @@ public class RenPySound {
                 prepared[1] = true;
             }
         }
-                
+
         /**
          * Called on completion.
          */
@@ -197,7 +218,7 @@ public class RenPySound {
             }
         }
 
-        
+
     }
 
     // A map from channel number to channel object.
@@ -224,7 +245,7 @@ public class RenPySound {
         if (c.filename[0] == null) {
           c.play();
         }
-        
+
     }
 
     static void play(int channel,
@@ -236,6 +257,11 @@ public class RenPySound {
         Channel c = getChannel(channel);
         c.queue(filename, real_fn, base, length);
         c.play();
+    }
+
+    static void seek(int channel, float position){
+        Channel c = getChannel(channel);
+        c.seek(position);
     }
 
     static void stop(int channel) {
@@ -291,8 +317,18 @@ public class RenPySound {
         c.unpause();
     }
 
+    static int get_pos(int channel){
+        Channel c = getChannel(channel);
+        return c.get_pos();
+    }
+
+    static int get_length(int channel){
+        Channel c = getChannel(channel);
+        return c.get_length();
+    }
+
     static {
         new MediaPlayer();
     }
-    
+
 }


### PR DESCRIPTION
Testing with the following code and [android_mediaplayer_seek_length](https://github.com/kivy/kivy/pull/new/android_mediaplayer_seek_length) branch of kivy for the changes that were needed to audio_pygame.  Currently wrong pos(off by a few secs) is displayed with vorbis files (known issue with Android MediaPlayer).

```
from kivy.app import App
from kivy.core.audio import SoundLoader
from kivy.clock import Clock
from kivy.logger import Logger
from kivy.lang import Builder

root = Builder.load_string('''
BoxLayout:
    audio_pos: 0
    orientation: 'vertical'
    Label:
        text: str(slider.value)
    Slider:
        id: slider
        min: 0.0
        value: root.audio_pos
    BoxLayout
        Button:
            text: "play"
            on_press:
                root.sound.play()
                root.upd_pos()
        Button:
            text: 'stop'
            on_release:
                root.sound.stop()
                slider.value = 0.0
                root.upd_pos(stop=True)
        Button:
            text: 'seek to 20.0'
            on_release: root.sound.seek(20.0)
''')

class TestApp(App):
    def build(self):
        root.sound = SoundLoader.load('audio02.ogg')
        root.upd_pos = self.upd_pos
        return root

    def upd_pos(self, stop=False):
        if stop:
            Clock.unschedule(self.get_pos)
        else:
            Clock.unschedule(self.get_pos)
            Clock.schedule_interval(self.get_pos, 1./9.)

    def get_pos(self, dt):
        root.ids.slider.max = root.sound._get_length()
        root.audio_pos = root.sound.get_pos()

if __name__ == '__main__':
    TestApp().run()
```
