### PR TITLE
Add apt-get install libsqlite3-dev to FAQ on sqlite3

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -12,6 +12,10 @@ _sqlite3.so not found
 
 We recently fixed sqlite3 compilation. In case of, you must:
 
+* Install development headers for sqlite3 if it's not already installed. On Ubuntu:
+
+    apt-get install libsqlite3-dev
+
 * Compile the distribution with (sqlite3 must be the first argument)::
 
     ./distribute.sh -m 'sqlite3 kivy'


### PR DESCRIPTION
Ubuntu was chosen for the example because the pre-installed VM is Ubuntu.

This took me a while to figure out, quite embarassingly. But for someone with less linux development experience it would be an enbarassment to the documentation, not the user.
