### PR TITLE
build.py: Fail when ant process fails

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -325,7 +325,8 @@ def make_package(args):
 
     # Build.
     try:
-        map(lambda arg: subprocess.call([ANT, arg]), args.command)
+        for arg in args.command:
+            subprocess.check_call([ANT, arg])
     except (OSError, IOError):
         print 'An error occured while calling', ANT
         print 'Did you install ant on your system ?'


### PR DESCRIPTION
- Use check_call to raise CalledProcessError if somethig goes wrong
- Use a for loop instead of map()
