### PR TITLE
Replaced 'python' with '$PYTHON' for compatibility

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -410,7 +410,7 @@ function run_source_modules() {
 		fi
 	done
 
-	MODULES="$(python tools/depsort.py --optional $fn_optional_deps < $fn_deps)"
+	MODULES="$($PYTHON tools/depsort.py --optional $fn_optional_deps < $fn_deps)"
 
 	info "Modules changed to $MODULES"
 }


### PR DESCRIPTION
Python is called with 'python' rather than '$PYTHON' on line 413 or distribute.sh. This fails on systems where the python binary is python3 (i.e. Arch linux), as the depsort.py script uses a python2 style print statement.

This fix just replaces python with $PYTHON, as in the rest of distribute.sh.
