### PR TITLE
Revert "fix touch offset in window mode" (needs testing)

### DIFF
--- a/src/src/org/renpy/android/SDLSurfaceView.java
+++ b/src/src/org/renpy/android/SDLSurfaceView.java
@@ -904,8 +904,6 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
         int sdlAction = -1;
         int pointerId = -1;
         int pointerIndex = -1;
-        int[] coords = new int[2];
-        this.getLocationInWindow(coords);
 
         switch ( action ) {
             case MotionEvent.ACTION_DOWN:
@@ -955,8 +953,8 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
                       ));
                      **/
                     SDLSurfaceView.nativeMouse(
-                            (int)event.getX(i) - coords[0],
-                            (int)event.getY(i) - coords[1],
+                            (int)event.getX(i),
+                            (int)event.getY(i),
                             sdlAction,
                             event.getPointerId(i),
                             (int)(event.getPressure(i) * 1000.0),


### PR DESCRIPTION
This reverts commit 9eddd5e96382f55a1ed8db8b74979aac91aafd0a.

As per the issue at https://github.com/kivy/python-for-android/issues/153 , the recent commit at https://github.com/kivy/python-for-android/commit/bc4a45c848b95e90557693221a29c60a145fdf4d caused a touch offset bug. However, the bug could also be fixed by reverting the original fix for at https://github.com/kivy/python-for-android/commit/9eddd5e96382f55a1ed8db8b74979aac91aafd0a .

It seems that perhaps the new commit makes the old one redundant by doing the touch offset due to the android status bar somewhere else. That would mean the older fix is now a bug, by repeating the touch offset and making touches be in the wrong place again!

This pull request reverts the original touch fix (now redundant), which seems to resolve the issue. I've tested it successfully, and @denspb confirms at https://github.com/kivy/python-for-android/commit/bc4a45c848b95e90557693221a29c60a145fdf4d . However, I don't fully understand what's going on behind the scenes, so this PR probably needs confirmation and/or testing by someone familiar with what's really going on.
