### PR TITLE
Fix bug in igraph recipe

### DIFF
--- a/recipes/igraph/get_platform.py
+++ b/recipes/igraph/get_platform.py
@@ -1,3 +1,0 @@
-from distutils.util import get_platform
-from sys import version
-print get_platform() + '-' + version[:3]

--- a/recipes/igraph/recipe.sh
+++ b/recipes/igraph/recipe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+b#!/bin/bash
 
 # Recipe for the Python interface to igraph, a high-performance graph library in C: http://igraph.org/
 #
@@ -18,7 +18,7 @@ RECIPE_igraph=$RECIPES_PATH/igraph
 
 
 function prebuild_igraph() {
-    patch setup.py $RECIPE_igraph/setup.py.patch
+    true
 }
 
 function shouldbuild_igraph() {
@@ -29,6 +29,8 @@ function shouldbuild_igraph() {
 
 function build_igraph() {
     cd $BUILD_igraph
+    patch setup.py $RECIPE_igraph/setup.py.patch
+    patch setup.cfg $RECIPE_igraph/setup.cfg.patch
     push_arm
 
     try $HOSTPYTHON setup.py build_ext -I"$BUILD_PATH/python-install/include/igraph:$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/libs/armeabi/include" -L"$BUILD_PATH/python-install/lib:$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/libs/armeabi" -l gnustl_static -p arm-gnueabi install

--- a/recipes/igraph/setup.cfg.patch
+++ b/recipes/igraph/setup.cfg.patch
@@ -1,0 +1,6 @@
+2,3c2,3
+< include_dirs = ../../build/include:../../include:/usr/local/include:/usr/include
+< library_dirs = ../../build/src/.libs:../../src/.libs:/usr/local/lib:/usr/lib
+---
+> include_dirs = ../../build/include:../../include
+> library_dirs = ../../build/src/.libs:../../src/.libs


### PR DESCRIPTION
igraph was failing to build when the build machine (x64) had its own igraph libraries. setup.py links against stuff in /usr/local/lib by default. Now I've patched it so it doesn't.
