### PR TITLE
Fix UnicodeDecodeError on build.py

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -206,6 +206,10 @@ def make_package(args):
 
         args.numeric_version = str(version_code)
 
+    args.name = args.name.decode('utf-8')
+    if args.icon_name:
+        args.icon_name = args.icon_name.decode('utf-8')
+
     versioned_name = args.name.replace(' ', '').replace('\'', '') + '-' + args.version
 
     # Android SDK rev14 needs two ant execs (ex: debug installd) and new build.xml


### PR DESCRIPTION
Fix this:

./build.py --dir "$build_dir" --name "Интеграл по-шагам" --package "org.myapp.$service" --version "1.0.0" --orientation "portrait" --icon "$build_dir/media/$service.png" debug installd

Traceback (most recent call last):
  File "./build.py", line 408, in <module>
    make_package(args)
  File "./build.py", line 272, in make_package
    versioned_name=versioned_name)
  File "./build.py", line 67, in render
    text = template.render(**kwargs)
  File "buildlib/jinja2.egg/jinja2/environment.py", line 868, in render
    return self.environment.handle_exception(exc_info, True)
  File "./templates/build.xml", line 2, in top-level template code
    <project name="{{ versioned_name }}" default="help">
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)

and

Traceback (most recent call last):
  File "./build.py", line 408, in <module>
    make_package(args)
  File "./build.py", line 280, in make_package
    args=args)
  File "./build.py", line 67, in render
    text = template.render(**kwargs)
  File "buildlib/jinja2.egg/jinja2/environment.py", line 868, in render
    return self.environment.handle_exception(exc_info, True)
  File "./templates/strings.xml", line 4, in top-level template code
    <string name="iconName">{{args.icon_name}}</string>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
