### PR TITLE
[FIX] Launcher APK does not contain PythonService

### DIFF
--- a/src/templates/AndroidManifest.tmpl.xml
+++ b/src/templates/AndroidManifest.tmpl.xml
@@ -65,7 +65,7 @@
     </activity>
     {% endif %}
 
-    {% if service or args.launche %}
+    {% if service or args.launcher %}
     <service android:name="org.renpy.android.PythonService"
              android:process=":PythonService"/>
     {% endif %}


### PR DESCRIPTION
After building my Kivy Launcher with updated 1.8.0-dev, noticed that the service `service/main.py` is not running anymore for the existing Kivy apps. I dont know when it stopped to work, but this brings it back.
