### PR TITLE
Custom actions and categories for BroadcastReceiver

### DIFF
--- a/recipes/android/src/android/broadcast.py
+++ b/recipes/android/src/android/broadcast.py
@@ -35,8 +35,8 @@ class BroadcastReceiver(object):
 
         # resolve actions/categories first
         Intent = autoclass('android.content.Intent')
-        resolved_actions = [_expand_partial_name(x) for x in actions]
-        resolved_categories = [_expand_partial_name(x) for x in categories]
+        resolved_actions = [_expand_partial_name(x) for x in actions or []]
+        resolved_categories = [_expand_partial_name(x) for x in categories or []]
 
         # resolve android API
         PythonActivity = autoclass('org.renpy.android.PythonActivity')


### PR DESCRIPTION
`android.broadcast.BroadcastReceiver` now accepts user-defined actions & categories, opposed to only default ones as before. Detects by checking the presence of '.' on the name of it. Its a backwards-compatible change.

The code on the 1st commit works, and was refactored on the 2 others. Feel free to stick with the maintainers original style by cherry-picking only the 1st commit if the refactor is disliked.
