### PR TITLE
[FIX] Launcher APK does not enable PythonService

### DIFF
--- a/src/templates/AndroidManifest.tmpl.xml
+++ b/src/templates/AndroidManifest.tmpl.xml
@@ -65,7 +65,7 @@
     </activity>
     {% endif %}
 
-    {% if service %}
+    {% if service or args.launcher %}
     <service android:name="org.renpy.android.PythonService"
              android:process=":PythonService"/>
     {% endif %}


### PR DESCRIPTION
When using the Launcher APK, apps using PythonService got "PythonService not found" on `.service.start()`:

```
01-11 05:43:10.866  1385  2905 W ActivityManager: Unable to start service Intent { cmp=org.kivy.pygame/org.renpy.android.PythonService (has extras) }: not found
```

This PR:
- Enabled PythonService for `launcher` APK too.
