### PR TITLE
remove "and" from dependencies for 64bit

### DIFF
--- a/docs/source/prerequisites.rst
+++ b/docs/source/prerequisites.rst
@@ -18,7 +18,7 @@ might need other tools (cython is used by some recipes, and ccache to speedup th
 
 If you are on a 64 bit distro, you should install these packages too ::
 
-    sudo apt-get install ia32-libs and libc6-dev-i386
+    sudo apt-get install ia32-libs  libc6-dev-i386
 
 On debian Squeeze amd64, those packages were found to be necessary ::
 


### PR DESCRIPTION
I suspect that the and package (an automated renice daemon) is not intended as a requirement.
