### PR TITLE
Repeatable and prebuild-worthy igraph recipe

### DIFF
--- a/recipes/c_igraph/recipe.sh
+++ b/recipes/c_igraph/recipe.sh
@@ -39,13 +39,12 @@ function build_c_igraph() {
     cd $BUILD_c_igraph
 
     push_arm
-    if [ ! -e $BUILD_c_igraph/config.h ]; then {
-            export OLD_CPPFLAGS="$CPPFLAGS";
-            export CPPFLAGS="$CPPFLAGS -I$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/include -I$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/libs/armeabi/include -L$ANDROIDNDK/platforms/android-$ANDROIDAPI/arch-arm/usr/lib";
-            try ./configure --prefix="$BUILD_PATH/python-install" --build=i686-pc-linux-gnu --host=arm-linux-eabi;
-            try patch $BUILD_c_igraph/config.h $RECIPE_c_igraph/config.h.patch;
-            export CPPFLAGS="$OLD_CPPFLAGS";
-        }
+    if [ ! -e $BUILD_c_igraph/config.h ]; then
+        export OLD_CPPFLAGS="$CPPFLAGS";
+        export CPPFLAGS="$CPPFLAGS -I$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/include -I$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/4.4.3/libs/armeabi/include -L$ANDROIDNDK/platforms/android-$ANDROIDAPI/arch-arm/usr/lib";
+        try ./configure --prefix="$BUILD_PATH/python-install" --build=i686-pc-linux-gnu --host=arm-linux-eabi;
+        try patch $BUILD_c_igraph/config.h $RECIPE_c_igraph/config.h.patch;
+        export CPPFLAGS="$OLD_CPPFLAGS";
     fi
 
 

--- a/recipes/igraph/recipe.sh
+++ b/recipes/igraph/recipe.sh
@@ -18,11 +18,10 @@ RECIPE_igraph=$RECIPES_PATH/igraph
 
 
 function prebuild_igraph() {
-    if [ ! -f "$BUILD_igraph/.patched" ]; then {
-            try patch $BUILD_igraph/setup.py $RECIPE_igraph/setup.py.patch
-            try patch $BUILD_igraph/setup.cfg $RECIPE_igraph/setup.cfg.patch
-            touch $BUILD_igraph/.patched
-        };
+    if [ ! -f "$BUILD_igraph/.patched" ]; then
+        try patch $BUILD_igraph/setup.py $RECIPE_igraph/setup.py.patch
+        try patch $BUILD_igraph/setup.cfg $RECIPE_igraph/setup.cfg.patch
+        touch $BUILD_igraph/.patched
     fi
 }
 


### PR DESCRIPTION
It no longer chokes up when you make a new distribution with igraph already compiled.
