### PR TITLE
fix service handling

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -237,10 +237,10 @@ def make_package(args):
 
     # Figure out if application has service part
     service = False
-    directory = args.private or args.dir
+    directory = args.dir
     if directory:
         service_main = join(realpath(directory), 'service', 'main.py')
-        if os.path.exists(service_main):
+        if os.path.exists(service_main) or os.path.exists(service_main + 'o'):
             service = True
 
     # Check if OUYA support is enabled


### PR DESCRIPTION
1. Private service does not work. Public service also does not work when specifying a private folder. `PythonService` seems to always look in the public folder, and the handling in `build.py` was poor anyway (e.g. always using private dir, without even checking for a private/service dir). I suppose it could check both directories, but until `build.py` passes that information to the `PythonService` class or `PythonService` itself checks both locations it wouldn't really matter.
2. Service flag does not get set if there is no `main.py`, however, `main.pyo` should be valid as well.
