### PR TITLE
Support agave froyo api 8 android2.2

### DIFF
--- a/src/src/org/renpy/android/SDLSurfaceView.java
+++ b/src/src/org/renpy/android/SDLSurfaceView.java
@@ -1223,7 +1223,7 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
                 return super.sendKeyEvent(event);
             }
 
-            @Override
+            //@Override (not in API 8!)
             public boolean setComposingRegion(int start, int end){
                 if (DEBUG) Log.d("Python:", String.format("Set Composing Region %s %s", start, end));
                 finishComposingText();
@@ -1276,10 +1276,10 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
                     return super.getExtractedText(request, flags);
             }
 
-            @Override
+            //@Override (NOT in API 8)
             public CharSequence getSelectedText(int flags){
                 if (DEBUG) Log.d("Python:", String.format("getSelectedText %s", flags));
-                    return super.getSelectedText(flags);
+                    return ""; // not a valid method for API 8
             }
 
             @Override

--- a/src/templates/AndroidManifest.tmpl.xml
+++ b/src/templates/AndroidManifest.tmpl.xml
@@ -18,7 +18,9 @@
 
   <application android:label="@string/appName"
                android:icon="@drawable/icon"
+        {% if android_api >= 9 %}
 			   android:hardwareAccelerated="true"
+        {% endif %}
                >
 
 	{% for m in args.meta_data %}


### PR DESCRIPTION
resolves issues that prevent building against API 8 for android 2.2 Agave-Froyo.  easy changes to do manually but it was suggested on the freenode IRC channel that a do a pull request with my changes and you could potentially make a branch for (limited) 2.2 support?