### PR TITLE
fix pycrypto recipe; add recipe for apsw

### DIFF
--- a/recipes/apsw/recipe.sh
+++ b/recipes/apsw/recipe.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# version of your package
+VERSION_apsw=${VERSION_apsw:-3.8.4.1-r1}
+
+# dependencies of this recipe
+DEPS_apsw=(python)
+
+# url of the package
+URL_apsw=https://github.com/rogerbinns/apsw/releases/download/3.8.4.1-r1/apsw-3.8.4.1-r1.zip
+
+# md5 of the package
+MD5_apsw=5ad3098489576929b90f4215eb5b2621
+
+# default build path
+BUILD_apsw=$BUILD_PATH/apsw/$(get_directory $URL_apsw)
+
+# default recipe path
+RECIPE_apsw=$RECIPES_PATH/apsw
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_apsw() {
+
+    # fetch sqlite if necessary
+    cd ${BUILD_apsw}
+    if [ ! -d ${BUILD_apsw}/sqlite3 ]; then
+        echo "fetching sqlite..."
+        # using /usr/bin/python for this
+	python setup.py fetch --sqlite --version=3.8.4.1 --missing-checksum-ok
+    fi
+
+    # apsw insists on configuring sqlite, but it's for the host, not the target.
+    # So, put in the correct values.
+
+    cat >sqlite3/sqlite3config.h <<EOF
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_UNISTD_H 1
+#define HAVE_DLFCN_H 1
+#define HAVE_FDATASYNC 0
+#define HAVE_USLEEP 1
+#define HAVE_LOCALTIME_R 1
+#define HAVE_GMTIME_R 1
+#define HAVE_DECL_STRERROR_R 1
+#define HAVE_STRERROR_R 1
+#define HAVE_POSIX_FALLOCATE 0
+EOF
+
+}
+
+function shouldbuild_apsw() {
+    if [ -d "$SITEPACKAGES_PATH/apsw" ]; then
+	DO_BUILD=0
+    fi
+}
+
+# function called to build the source code
+function build_apsw() {
+
+    cd ${BUILD_apsw}
+
+    export NDK=$ANDROIDNDK
+    push_arm
+
+    # HOSTPYTHON can't do zipfile or tarfile modules because of
+    # buildozer bug (missing LD_LIBRARY_PATH is what it looks like),
+    # but we don't need them at this stage
+    cp setup.py setup.py.backup
+    sed -e 's/import zipfile, tarfile/# import zipfile, tarfile/g' <setup.py.backup >setup.py
+
+    # build python extension
+    export LDFLAGS="$LDFLAGS -L$LIBS_PATH"
+    export LDSHARED="$LIBLINK"
+
+    echo "building apsw in `pwd`..."
+    # now we can build; enable the FTS4 sqlite extension for full-text search
+    try ${HOSTPYTHON} setup.py build --enable=fts4
+    echo "installing apsw..."
+    try ${HOSTPYTHON} setup.py install
+    echo "done with apsw."
+
+    pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_apsw() {
+    echo "apsw built"
+}

--- a/recipes/pycrypto/patches/add_length.patch
+++ b/recipes/pycrypto/patches/add_length.patch
@@ -1,0 +1,11 @@
+--- pycrypto-2.6.1/src/hash_SHA2_template.c.orig	2013-10-14 14:38:10.000000000 -0700
++++ pycrypto-2.6.1/src/hash_SHA2_template.c	2014-05-19 10:15:51.000000000 -0700
+@@ -87,7 +87,7 @@
+  * return 1 on success
+  * return 0 if the length overflows
+  */
+-int add_length(hash_state *hs, sha2_word_t inc) {
++static int add_length(hash_state *hs, sha2_word_t inc) {
+     sha2_word_t overflow_detector;
+     overflow_detector = hs->length_lower;
+     hs->length_lower += inc;

--- a/recipes/pycrypto/recipe.sh
+++ b/recipes/pycrypto/recipe.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
-VERSION_pycrypto=${VERSION_pycrypto:-2.5}
+VERSION_pycrypto=${VERSION_pycrypto:-2.6.1}
 URL_pycrypto=http://pypi.python.org/packages/source/p/pycrypto/pycrypto-$VERSION_pycrypto.tar.gz
 DEPS_pycrypto=(openssl python)
-MD5_pycrypto=783e45d4a1a309e03ab378b00f97b291
+MD5_pycrypto=55a61a054aa66812daf5161a0d5d7eda
 BUILD_pycrypto=$BUILD_PATH/pycrypto/$(get_directory $URL_pycrypto)
 RECIPE_pycrypto=$RECIPES_PATH/pycrypto
 
 function prebuild_pycrypto() {
-	true
+	cd $BUILD_pycrypto
+
+	# check marker in our source build
+	if [ -f .patched ]; then
+		# no patch needed
+		return
+	fi
+
+	try patch -p1 < $RECIPE_pycrypto/patches/add_length.patch
+
+	# everything done, touch the marker !
+	touch .patched
 }
 
 function shouldbuild_pycrypto() {


### PR DESCRIPTION
This updates pycrypto to 2.6.1, and adds a patch to work around the bug (which only affects Android, because of biglink) in pycrypto 2.5 and 2.6.  It also includes a recipe for apsw, an alternative Python API for SQLite.
