### PR TITLE
Multi-window support and Two new recipes: WebOb and CJK

### DIFF
--- a/recipes/cjklib/recipe.sh
+++ b/recipes/cjklib/recipe.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+VERSION_cjklib=${VERSION_cjklib:-0.3.2}
+DEPS_cjklib=(setuptools android)
+URL_cjklib=http://pypi.python.org/packages/source/c/cjklib/cjklib-${VERSION_cjklib}.tar.gz
+MD5_cjklib=32780bc5cc0b132204d1c9b8a1642157
+BUILD_cjklib=$BUILD_PATH/cjklib/$(get_directory $URL_cjklib)
+RECIPE_cjklib=$RECIPES_PATH/cjklib
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_cjklib() {
+	true
+}
+
+function shouldbuild_cjklib() {
+    if [ -d "$SITEPACKAGES_PATH/cjklib" ]; then
+		DO_BUILD=0
+    fi
+}
+
+function build_cjklib() {
+	cd $BUILD_cjklib
+	push_arm
+	export EXTRA_CFLAGS="--host linux-armv"
+	try $HOSTPYTHON setup.py install -O2
+	pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_cjklib() {
+	true
+}
+

--- a/recipes/webob/recipe.sh
+++ b/recipes/webob/recipe.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+VERSION_webob=${VERSION_webob:-1.4}
+DEPS_webob=(setuptools android)
+URL_webob=http://pypi.python.org/packages/source/W/WebOb/WebOb-${VERSION_webob}.tar.gz
+MD5_webob=8437607c0cc00c35f658f972516ffb55
+BUILD_webob=$BUILD_PATH/webob/$(get_directory $URL_webob)
+RECIPE_webob=$RECIPES_PATH/webob
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_webob() {
+	true
+}
+
+function shouldbuild_webob() {
+    if [ -d "$SITEPACKAGES_PATH/webob" ]; then
+		DO_BUILD=0
+	fi
+}
+
+function build_webob() {
+	cd $BUILD_webob
+	push_arm
+	export EXTRA_CFLAGS="--host linux-armv"
+	try $HOSTPYTHON setup.py install -O2
+
+	pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_webob() {
+	true
+}
+

--- a/src/templates/AndroidManifest.tmpl.xml
+++ b/src/templates/AndroidManifest.tmpl.xml
@@ -94,6 +94,7 @@
 	</receiver>
 	{% endif %}
 
+  <uses-library required="false" name="com.sec.android.app.multiwindow" />
   </application>
 
   <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.sdk_version }}"/>


### PR DESCRIPTION
1. cjklib ('cjklib' on pypi) is a pure-python swiss-army knife translation library for character-oriented languages like Chinese.
2. WebOb ('webob' on pypi) is a popular python WSGI middleware library for building reusable python web applications.
3. One extra line in AndroidManifest.xml.tmpl to support Samsung Multi-window support.
    
I've tested both of these in my buildozer-created APK and they work great. No patches required as they do not have C-extensions.
    
One warning: cjklib uses sqlite and creates a pretty "hefty" 45 MB database upon it's 'setup.py' installation for the purposes of translating different languages. I've submitted a request on their mailing list for options for pruning the size of this database. Hope to get a response from them soon.

Comments welcome!
