### PR TITLE
Fix ANDROIDAPI

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -299,7 +299,7 @@ def make_package(args):
     # Update the project to a recent version.
     try:
         subprocess.call([ANDROID, 'update', 'project', '-p', '.', '-t',
-                         'android-{}'.format(args['sdk_version'])])
+                         'android-{}'.format(args.sdk_version)])
     except (OSError, IOError):
         print 'An error occured while calling', ANDROID, 'update'
         print 'Your PATH must include android tools.'

--- a/src/templates/AndroidManifest.tmpl.xml
+++ b/src/templates/AndroidManifest.tmpl.xml
@@ -11,7 +11,7 @@
         android:normalScreens="true"
         android:largeScreens="true"
         android:anyDensity="true"
-        {% if android_api >= 9 %}
+        {% if args.min_sdk_version >= 9 %}
         android:xlargeScreens="true"
         {% endif %}
         />
@@ -29,7 +29,7 @@
 
     <activity android:name="org.renpy.android.PythonActivity"
               android:label="@string/iconName"
-			  android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if android_api >= 13 %}|screenSize{% endif %}"
+			  android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
               android:launchMode="singleTask"
               android:process=":python"
               android:screenOrientation="{{ args.orientation }}"


### PR DESCRIPTION
Doesn't it make sense to get the defaults from the shell env and then use them to default add_argument?

I removed android_api from the AndroidManifest template.  The useage was contradictory anyway since it was possible to have min_sdk > 13 but android_api < 13 etc.
