### PR TITLE
Fixed kivy recipe to work on repeated runs with P4A_kivy_DIR

### DIFF
--- a/recipes/kivy/recipe.sh
+++ b/recipes/kivy/recipe.sh
@@ -27,7 +27,7 @@ function build_kivy() {
 
 	# fake try to be able to cythonize generated files
 	$HOSTPYTHON setup.py build_ext
-	try find . -iname '*.pyx' -exec $CYTHON {} \;
+	try find . -iname '*.pyx' -exec cython {} \;
 	try $HOSTPYTHON setup.py build_ext -v
 	try find build/lib.* -name "*.o" -exec $STRIP {} \;
 	try $HOSTPYTHON setup.py install -O2


### PR DESCRIPTION
Not for merging without discussion!

This would fix https://github.com/kivy/python-for-android/issues/234

I'm not sure if this is the right fix, but I'm doing a pr in the hope that someone who knows what's going on will see it. As far as I can tell, it *does* resolve the linked issue.

Without this pr, something doesn't work - the build_ext lines don't place object files where the biglink script can see them. I think the issue is that they recognise the pyx source files haven't changed and therefore don't rebuild the object files, whereas with this fix cython is always called and the files are always rebuilt.

As discussed with tito, maybe there is a better solution, but I'm not even completely sure what's going on and I couldn't track it down better than this.