### PR TITLE
Added support for setting string resources in generated strings.xml

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -456,6 +456,9 @@ tools directory of the Android SDK.
     ap.add_argument('--meta-data', dest='meta_data', action='append',
                     help='Custom key=value to add in application metadata')
 
+    ap.add_argument('--resource', dest='resource', action='append',
+                    help='Custom key=value to add in strings.xml resource file')
+
     args = ap.parse_args()
 
     if not args.dir and not args.private and not args.launcher:
@@ -469,6 +472,9 @@ tools directory of the Android SDK.
 
     if args.meta_data is None:
         args.meta_data = []
+
+    if args.resource is None:
+        args.resource = []
 
     if args.compile_pyo:
         if PYTHON is None:

--- a/src/templates/strings.xml
+++ b/src/templates/strings.xml
@@ -9,4 +9,8 @@
 <string name="public_version">{{ public_version }}</string>
 {% endif %}
 <string name="urlScheme">{{ url_scheme }}</string>
+{% for m in args.resource %}
+<string name="{{ m.split('=', 1)[0] }}">{{ m.split('=', 1)[-1] }}</string>
+{% endfor %}
+
 </resources>


### PR DESCRIPTION
The following adds support for setting resources to add in strings.xml - it works very similar to setting the --meta-data tag. Here is the syntax:

./build.py ... --resource [KEY]=[VALUE]

where KEY is the string name / key and VALUE is the value for that specific KEY. Here is a sample usage:

./build.py ... --resource app_id=616xxxxxxxxxx

The generated strings.xml file now contains:
...
<string name="app_id">616xxxxxxxxxx</string>
