### PR TITLE
Recipe for eventlet lib

### DIFF
--- a/recipes/eventlet/patches/fix-setuptools.patch
+++ b/recipes/eventlet/patches/fix-setuptools.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.py b/setup.py
+index 7a601d5..56491a0 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,8 +1,17 @@
+ #!/usr/bin/env python
+-from setuptools import find_packages, setup
++from distutils.core import setup
+ from eventlet import __version__
+ from os import path
+ 
++import re, os
++def find_packages(path='.', exclude=[]):
++    ret = []
++    for root, dirs, files in os.walk(path):
++        if '__init__.py' in files:
++            ret.append(re.sub('^[^A-z0-9_]+', '', root.replace('/', '.')))
++    ret = [i for i in ret if i not in exclude]
++    return ret
++
+ 
+ setup(
+     name='eventlet',
+

--- a/recipes/eventlet/recipe.sh
+++ b/recipes/eventlet/recipe.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+VERSION_eventlet=${VERSION_eventlet:-0.15.2}
+URL_eventlet=https://pypi.python.org/packages/source/e/eventlet/eventlet-$VERSION_eventlet.tar.gz
+DEPS_eventlet=(libevent greenlet)
+MD5_eventlet=c5b0217cc1da6fcf4bcf6957df57f3cd
+BUILD_eventlet=$BUILD_PATH/eventlet/$(get_directory $URL_eventlet)
+RECIPE_eventlet=$RECIPES_PATH/eventlet
+
+function prebuild_eventlet() {
+    # TODO: patch setup.py to use distutils instead of setuptools
+    true
+}
+
+function shouldbuild_eventlet() {
+	if [ -d "$SITEPACKAGES_PATH/eventlet" ]; then
+		DO_BUILD=0
+	fi
+}
+
+function build_eventlet() {
+    cd $BUILD_eventlet
+
+    push_arm
+    export CFLAGS="$CFLAGS -I$BUILD_libevent/build/include"
+    export LDFLAGS="$LDFLAGS -L$LIBS_PATH -L$BUILD_libevent/build/lib/"
+
+    try $HOSTPYTHON setup.py install -O2
+    pop_arm
+}
+
+function postbuild_eventlet() {
+    true
+}

--- a/recipes/eventlet/recipe.sh
+++ b/recipes/eventlet/recipe.sh
@@ -8,8 +8,18 @@ BUILD_eventlet=$BUILD_PATH/eventlet/$(get_directory $URL_eventlet)
 RECIPE_eventlet=$RECIPES_PATH/eventlet
 
 function prebuild_eventlet() {
-    # TODO: patch setup.py to use distutils instead of setuptools
-    true
+    cd $BUILD_eventlet
+
+	# check marker in our source build
+	if [ -f .patched ]; then
+		# no patch needed
+		return
+	fi
+
+    try patch -p1 < $RECIPE_eventlet/patches/fix-setuptools.patch
+
+	# everything done, touch the marker !
+	touch .patched
 }
 
 function shouldbuild_eventlet() {


### PR DESCRIPTION
Uses distutils to install, as setuptools is not available by default (yet).

Can be cleaned up after https://github.com/kivy/python-for-android/tree/recipe-pynacl gets merged