### PR TITLE
removed reference to ARM from audiostream and pyparsing recipes

### DIFF
--- a/recipes/audiostream/recipe.sh
+++ b/recipes/audiostream/recipe.sh
@@ -26,7 +26,6 @@ function build_audiostream() {
 	export JNI_PATH=$JNI_PATH
 	export CFLAGS="$CFLAGS -I$JNI_PATH/sdl/include -I$JNI_PATH/sdl_mixer/"
 	export LDFLAGS="$LDFLAGS -lm -L$LIBS_PATH"
-	export AUDIOSTREAM_ROOT="$BUILD_audiostream/build/audiostream/armeabi-v7a"
 	try cd $BUILD_audiostream
 	$HOSTPYTHON setup.py build_ext &>/dev/null
 	try find . -iname '*.pyx' -exec $CYTHON {} \;

--- a/recipes/pyparsing/recipe.sh
+++ b/recipes/pyparsing/recipe.sh
@@ -22,7 +22,6 @@ function shouldbuild_pyparsing() {
 function build_pyparsing() {
 	cd $BUILD_pyparsing
 	push_arm
-	export EXTRA_CFLAGS="--host linux-armv"
 	try $HOSTPYTHON setup.py install -O2
 	pop_arm
 }


### PR DESCRIPTION
pyparsing is pure python, and AUDIOSTREAM_ROOT
is not used anywhere. The audiostream module builds both
in arm and x86 without setting the envvar.