### PR TITLE
save and restore environment when running recipe functions

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -666,13 +666,23 @@ function run_get_packages() {
 	done
 }
 
+function envfn() {
+	envsave=$(mktemp)
+	envrestore=$(mktemp)
+	set > $envsave
+	$1
+	set > $envrestore
+	eval $(grep -v -F -f$envrestore $envsave)
+	rm -f $envsave $envrestore
+}
+
 function run_prebuild() {
 	info "Run prebuild"
 	cd $BUILD_PATH
 	for module in $MODULES; do
 		fn=$(echo prebuild_$module)
 		debug "Call $fn"
-		$fn
+		envfn $fn
 	done
 }
 
@@ -707,7 +717,7 @@ function run_build() {
 		if [ "X$DO_BUILD" == "X1" ] || [ ! -f "$MARKER_FN" ]; then
 			debug "Call $fn"
 			rm -f "$MARKER_FN"
-			$fn
+			envfn $fn
 			touch "$MARKER_FN"
 		else
 			debug "Skipped $fn"
@@ -721,7 +731,7 @@ function run_postbuild() {
 	for module in $MODULES; do
 		fn=$(echo postbuild_$module)
 		debug "Call $fn"
-		$fn
+		envfn $fn
 	done
 }
 


### PR DESCRIPTION
Prevents env vars set in one recipe build function from affecting other recipe build functions.