### PR TITLE
Add a recipe for building astropy

### DIFF
--- a/recipes/astropy/patches/add_numpy_include.patch
+++ b/recipes/astropy/patches/add_numpy_include.patch
@@ -1,0 +1,14 @@
+--- astropy-0.4.4.orig/astropy_helpers/astropy_helpers/setup_helpers.py	2015-02-15 18:16:02.135642283 -0600
++++ astropy-0.4.4/astropy_helpers/astropy_helpers/setup_helpers.py	2015-02-15 18:28:03.482778786 -0600
+@@ -1307,6 +1307,11 @@
+     # install, since Numpy may still think it's in "setup mode", when
+     # in fact we're ready to use it to build astropy now.
+ 
++    # Allow the environment to override the include path, to allow
++    # cross-compilation
++    if 'NUMPY_INCLUDE_PATH' in os.environ:
++        return os.environ['NUMPY_INCLUDE_PATH']
++
+     if sys.version_info[0] >= 3:
+         import builtins
+         if hasattr(builtins, '__NUMPY_SETUP__'):

--- a/recipes/astropy/patches/lconv_fix.patch
+++ b/recipes/astropy/patches/lconv_fix.patch
@@ -1,0 +1,40 @@
+--- astropy-0.4.4.orig/cextern/wcslib/C/wcsutil.c	2015-02-15 18:07:46.549935299 -0600
++++ astropy-0.4.4/cextern/wcslib/C/wcsutil.c	2015-02-15 18:36:07.062452345 -0600
+@@ -247,7 +247,7 @@
+ 
+ {
+   struct lconv *locale_data = localeconv();
+-  const char *decimal_point = locale_data->decimal_point;
++  const char *decimal_point = ".";
+ 
+   if (decimal_point[0] != '.' || decimal_point[1] != 0) {
+     size_t decimal_point_len = strlen(decimal_point);
+@@ -311,7 +311,7 @@
+ 
+ {
+   struct lconv *locale_data = localeconv();
+-  const char *decimal_point = locale_data->decimal_point;
++  const char *decimal_point = ".";
+ 
+   if (decimal_point[0] != '.' || decimal_point[1] != 0) {
+     char *out = outbuf;
+--- astropy-0.4.4.orig/cextern/cfitsio/fitscore.c	2015-02-15 18:07:46.553935299 -0600
++++ astropy-0.4.4/cextern/cfitsio/fitscore.c	2015-02-15 18:41:16.626440539 -0600
+@@ -9226,7 +9226,7 @@
+ 
+     if (!decimalpt) { /* only do this once for efficiency */
+        lcc = localeconv();   /* set structure containing local decimal point symbol */
+-       decimalpt = *(lcc->decimal_point);
++       decimalpt = '.';
+     }
+ 
+     errno = 0;
+@@ -9296,7 +9296,7 @@
+ 
+     if (!decimalpt) { /* only do this once for efficiency */
+        lcc = localeconv();   /* set structure containing local decimal point symbol */
+-       decimalpt = *(lcc->decimal_point);
++       decimalpt = '.';
+     }
+    
+     errno = 0;

--- a/recipes/astropy/recipe.sh
+++ b/recipes/astropy/recipe.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# version of your package
+VERSION_astropy=0.4.4
+
+# dependencies of this recipe
+DEPS_astropy=(numpy)
+
+# url of the package
+URL_astropy=https://pypi.python.org/packages/source/a/astropy/astropy-0.4.4.tar.gz
+
+# md5 of the package
+MD5_astropy=68da956109c5968aaa8fdab8256049ba
+
+# default build path
+BUILD_astropy=$BUILD_PATH/astropy/$(get_directory $URL_astropy)
+
+# default recipe path
+RECIPE_astropy=$RECIPES_PATH/astropy
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_astropy() {
+	cd $BUILD_astropy
+
+	if [ -f .patched ]; then
+		return
+	fi
+
+	try patch -p1 < $RECIPE_astropy/patches/add_numpy_include.patch
+	try patch -p1 < $RECIPE_astropy/patches/lconv_fix.patch
+	touch .patched
+	true
+}
+
+# function called to build the source code
+function build_astropy() {
+	cd $BUILD_astropy
+    export BUILDLIB_PATH="$BUILD_hostpython/build/lib.linux-`uname -m`-2.7/"
+    export PYTHONPATH=$SITEPACKAGES_PATH:$BUILDLIB_PATH
+    export NUMPY_INCLUDE_PATH="$BUILD_PATH/python-install/lib/python2.7/site-packages/numpy/core/include"
+	push_arm
+	try $BUILD_PATH/python-install/bin/python.host setup.py install
+	pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_astropy() {
+	true
+}


### PR DESCRIPTION
This pull request adds a recipe for building the astropy Python module.

This recipe was generated to answer the following stackoverflow question: http://stackoverflow.com/questions/28143288/how-can-i-compile-astropy-which-uses-numpy-for-a-kivy-android-installation