### PR TITLE
Add warning and description for P4A in a venv...

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -29,3 +29,13 @@ must:
     lib-dynload/_sqlite3.so
 
 Then sqlite3 will be compiled and included in your APK.
+
+Too many levels of symbolic links
+-----------------------------------------------------
+
+Python for Android does not work within a virtual enviroment. The Python for 
+Android directory must be outside of the virtual enviroment prior to running
+
+    ./distribute.sh -m "kivy"
+
+or else you may encounter OSError: [Errno 40] Too many levels of symbolic links.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,6 +8,9 @@ If you want to compile the toolchain with only the kivy module::
 
     ./distribute.sh -m "kivy"
 
+.. warning::
+    Do not run the above command from `within a virtual enviroment <../faq/#too-many-levels-of-symbolic-links>`_.
+
 After a long time, you'll get a "dist/default" directory containing
 all the compiled libraries and a build.py script to package your
 application using thoses libraries.


### PR DESCRIPTION
Adds a full description of the error caused by using P4A from within a
virtual enviroment to the FAQ. Also adds a Warning in usuage that links
to the FAQ in reference to the command that could result in the error.
Tells users how to avoid OSError: [Errno 40] Too many levels of 
symbolic links.

The only thing I am uncertian about is whether the relative link will 
map correctly but I wrote it with readthedocs.org in mind.