### PR TITLE
Apply ignore_path filter to private data

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -318,7 +318,7 @@ def make_package(args):
 
     # Package up the private and public data.
     if args.private:
-        make_tar('assets/private.mp3', ['private', args.private])
+        make_tar('assets/private.mp3', ['private', args.private], args.ignore_path)
     else:
         make_tar('assets/private.mp3', ['private'])
 


### PR DESCRIPTION
Currently the --ignore-path option only applies for public data.
Since installing "release" apk version on /data requires using private data, the ignore filter is also needed here.