### PR TITLE
fix mktemp usage for OS X

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -654,8 +654,8 @@ function run_get_packages() {
 }
 
 function envfn() {
-	envsave=$(mktemp)
-	envrestore=$(mktemp)
+	envsave=$(mktemp -t envsave)
+	envrestore=$(mktemp -t envsave)
 	set > $envsave
 	$1
 	set > $envrestore


### PR DESCRIPTION
This fixes the invocation of mktemp so it works on OS X also.