### PR TITLE
make get_keyboard_height more dynamic

### DIFF
--- a/recipes/android/src/android/_android.pyx
+++ b/recipes/android/src/android/_android.pyx
@@ -183,9 +183,10 @@ rctx = autoclass('android.graphics.Rect')()
 mActivity = python_act.mActivity
 if mActivity:
     decor_view = mActivity.getWindow().getDecorView()
-    height = mActivity.getWindowManager().getDefaultDisplay().getHeight()
+    default_display = mActivity.getWindowManager().getDefaultDisplay()
     # get keyboard height
     def get_keyboard_height():
+        height = default_display.getHeight()
         decor_view.getWindowVisibleDisplayFrame(rctx)
         return height - rctx.bottom
 else:


### PR DESCRIPTION
when using WIndow.softinput_mode='pan' with kivy. I noticed that changing the orientation of the screen (on android) (e.g. from portrait to landscape), caused the display to misbehave: eventhough the system keyboard had not be requested, the whole screen seem to be offset as if it had been.

The problem was that get_keyboard_height from the android module had a static notion of height.  My patch causes it to reevaluate the height (this is especially important in case of dispaly orientation change).

With my app, I now get the expected behaviour.