### PR TITLE
Revert "fix mktemp usage for OS X"

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -662,8 +662,8 @@ function run_get_packages() {
 }
 
 function envfn() {
-	envsave=$(mktemp -t envsave)
-	envrestore=$(mktemp -t envsave)
+	envsave=$(mktemp)
+	envrestore=$(mktemp)
 	set > $envsave
 	$1
 	set > $envrestore


### PR DESCRIPTION
Reverts kivy/python-for-android#344

This was not tested on Linux, which is now broken.