### PR TITLE
unpack into subdirectories __kivy_root__ of private and external storage...

### DIFF
--- a/recipes/python/patches/custom-loader.patch
+++ b/recipes/python/patches/custom-loader.patch
@@ -18,7 +18,7 @@
 +    /* Ensure we have access to libpymodules. */
 +    if (libpymodules == NULL) {
 +        printf("ANDROID_PRIVATE = %s\n", getenv("ANDROID_PRIVATE"));
-+        PyOS_snprintf(pathbuf, sizeof(pathbuf), "%s/libpymodules.so", getenv("ANDROID_PRIVATE"));
++        PyOS_snprintf(pathbuf, sizeof(pathbuf), "%s/__kivy_root__/libpymodules.so", getenv("ANDROID_PRIVATE"));
 +        libpymodules = dlopen(pathbuf, RTLD_NOW);
 +
 +        if (libpymodules == NULL) {

--- a/recipes/python/patches/custom-loader.patch
+++ b/recipes/python/patches/custom-loader.patch
@@ -18,7 +18,7 @@
 +    /* Ensure we have access to libpymodules. */
 +    if (libpymodules == NULL) {
 +        printf("ANDROID_PRIVATE = %s\n", getenv("ANDROID_PRIVATE"));
-+        PyOS_snprintf(pathbuf, sizeof(pathbuf), "%s/__kivy_root__/libpymodules.so", getenv("ANDROID_PRIVATE"));
++        PyOS_snprintf(pathbuf, sizeof(pathbuf), "%s/app/libpymodules.so", getenv("ANDROID_PRIVATE"));
 +        libpymodules = dlopen(pathbuf, RTLD_NOW);
 +
 +        if (libpymodules == NULL) {

--- a/src/jni/application/python/start.c
+++ b/src/jni/application/python/start.c
@@ -73,10 +73,10 @@ int main(int argc, char **argv) {
         "private = posix.environ['ANDROID_PRIVATE']\n" \
         "argument = posix.environ['ANDROID_ARGUMENT']\n" \
         "sys.path[:] = [ \n" \
-		"    private + '/__kivy_root__/lib/python27.zip', \n" \
-		"    private + '/__kivy_root__/lib/python2.7/', \n" \
-		"    private + '/__kivy_root__/lib/python2.7/lib-dynload/', \n" \
-		"    private + '/__kivy_root__/lib/python2.7/site-packages/', \n" \
+		"    private + '/app/lib/python27.zip', \n" \
+		"    private + '/app/lib/python2.7/', \n" \
+		"    private + '/app/lib/python2.7/lib-dynload/', \n" \
+		"    private + '/app/lib/python2.7/site-packages/', \n" \
 		"    argument ]\n" \
         "import androidembed\n" \
         "class LogFile(object):\n" \

--- a/src/jni/application/python/start.c
+++ b/src/jni/application/python/start.c
@@ -73,10 +73,10 @@ int main(int argc, char **argv) {
         "private = posix.environ['ANDROID_PRIVATE']\n" \
         "argument = posix.environ['ANDROID_ARGUMENT']\n" \
         "sys.path[:] = [ \n" \
-		"    private + '/lib/python27.zip', \n" \
-		"    private + '/lib/python2.7/', \n" \
-		"    private + '/lib/python2.7/lib-dynload/', \n" \
-		"    private + '/lib/python2.7/site-packages/', \n" \
+		"    private + '/__kivy_root__/lib/python27.zip', \n" \
+		"    private + '/__kivy_root__/lib/python2.7/', \n" \
+		"    private + '/__kivy_root__/lib/python2.7/lib-dynload/', \n" \
+		"    private + '/__kivy_root__/lib/python2.7/site-packages/', \n" \
 		"    argument ]\n" \
         "import androidembed\n" \
         "class LogFile(object):\n" \

--- a/src/src/org/renpy/android/PythonActivity.java
+++ b/src/src/org/renpy/android/PythonActivity.java
@@ -186,11 +186,11 @@ public class PythonActivity extends Activity implements Runnable {
 
 
     public String getKivyRoot() {
-	return getFilesDir().getAbsolutePath() + "/__kivy_root__";
+	return getFilesDir().getAbsolutePath() + "/app";
     }
 
     public String getKivyPublicRoot() {
-	return externalStorage.getAbsolutePath() + "/__kivy_root__";
+	return externalStorage.getAbsolutePath() + "/app";
     }
 
     /**

--- a/src/src/org/renpy/android/PythonActivity.java
+++ b/src/src/org/renpy/android/PythonActivity.java
@@ -116,7 +116,7 @@ public class PythonActivity extends Activity implements Runnable {
         } else if (resourceManager.getString("public_version") != null) {
             mPath = externalStorage;
         } else {
-            mPath = getFilesDir();
+            mPath = new File(getKivyRoot());
         }
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
@@ -185,6 +185,14 @@ public class PythonActivity extends Activity implements Runnable {
     }
 
 
+    public String getKivyRoot() {
+	return getFilesDir().getAbsolutePath() + "/__kivy_root__";
+    }
+
+    public String getKivyPublicRoot() {
+	return externalStorage.getAbsolutePath() + "/__kivy_root__";
+    }
+
     /**
      * This determines if unpacking one the zip files included in
      * the .apk is necessary. If it is, the zip file is unpacked.
@@ -243,9 +251,12 @@ public class PythonActivity extends Activity implements Runnable {
     }
 
     public void run() {
+	String kivy_root = getKivyRoot();
+	File kivy_root_dir = new File(kivy_root);
+	File kivy_public_root_dir = new File(getKivyPublicRoot());
 
-        unpackData("private", getFilesDir());
-        unpackData("public", externalStorage);
+        unpackData("private", kivy_root_dir);
+        unpackData("public", kivy_public_root_dir);
 
         System.loadLibrary("sdl");
         System.loadLibrary("sdl_image");
@@ -255,19 +266,19 @@ public class PythonActivity extends Activity implements Runnable {
         System.loadLibrary("application");
         System.loadLibrary("sdl_main");
 
-        System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_io.so");
-        System.load(getFilesDir() + "/lib/python2.7/lib-dynload/unicodedata.so");
+        System.load(kivy_root + "/lib/python2.7/lib-dynload/_io.so");
+        System.load(kivy_root + "/lib/python2.7/lib-dynload/unicodedata.so");
 
         try {
             System.loadLibrary("sqlite3");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_sqlite3.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_sqlite3.so");
         } catch(UnsatisfiedLinkError e) {
         }
 
         try {
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imaging.so");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imagingft.so");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imagingmath.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imaging.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imagingft.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imagingmath.so");
         } catch(UnsatisfiedLinkError e) {
         }
 
@@ -349,10 +360,11 @@ public class PythonActivity extends Activity implements Runnable {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = PythonActivity.mActivity.mPath.getAbsolutePath();
+	String kivy_root = PythonActivity.mActivity.getKivyRoot();
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", filesDirectory);
-        serviceIntent.putExtra("pythonHome", argument);
-        serviceIntent.putExtra("pythonPath", argument + ":" + filesDirectory + "/lib");
+        serviceIntent.putExtra("pythonHome", kivy_root);
+        serviceIntent.putExtra("pythonPath", kivy_root + ":" + kivy_root + "/lib");
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/src/src/org/renpy/android/PythonService.java
+++ b/src/src/org/renpy/android/PythonService.java
@@ -77,7 +77,7 @@ public class PythonService extends Service  implements Runnable {
     }
 
     public String getKivyRoot() {
-	return getFilesDir().getAbsolutePath() + "/__kivy_root__";
+	return getFilesDir().getAbsolutePath() + "/app";
     }
 
     @Override

--- a/src/src/org/renpy/android/PythonService.java
+++ b/src/src/org/renpy/android/PythonService.java
@@ -1,5 +1,7 @@
 package org.renpy.android;
 
+import java.io.File;
+
 import android.app.Service;
 import android.os.IBinder;
 import android.os.Bundle;
@@ -74,8 +76,14 @@ public class PythonService extends Service  implements Runnable {
         Process.killProcess(Process.myPid());
     }
 
+    public String getKivyRoot() {
+	return getFilesDir().getAbsolutePath() + "/__kivy_root__";
+    }
+
     @Override
     public void run(){
+	String kivy_root = getKivyRoot();
+	File kivy_root_dir = new File(kivy_root);
 
         // libraries loading, the same way PythonActivity.run() do
         System.loadLibrary("sdl");
@@ -86,26 +94,25 @@ public class PythonService extends Service  implements Runnable {
         System.loadLibrary("application");
         System.loadLibrary("sdl_main");
         
-
-        System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_io.so");
-        System.load(getFilesDir() + "/lib/python2.7/lib-dynload/unicodedata.so");
+        System.load(kivy_root + "/lib/python2.7/lib-dynload/_io.so");
+        System.load(kivy_root + "/lib/python2.7/lib-dynload/unicodedata.so");
         
         try {
             System.loadLibrary("ctypes");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_ctypes.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_ctypes.so");
         } catch(UnsatisfiedLinkError e) {
         }
 
         try {
             System.loadLibrary("sqlite3");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_sqlite3.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_sqlite3.so");
         } catch(UnsatisfiedLinkError e) {
         }
 
         try {
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imaging.so");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imagingft.so");
-            System.load(getFilesDir() + "/lib/python2.7/lib-dynload/_imagingmath.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imaging.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imagingft.so");
+            System.load(kivy_root + "/lib/python2.7/lib-dynload/_imagingmath.so");
         } catch(UnsatisfiedLinkError e) {
         }
 


### PR DESCRIPTION
....

Since unpacking performs first a recursiveDelete, everything stored in an
unpack root is lost after an app update.  In order for e.g. a database on
private storage to persist across app updates it was necessary to make
the private unpack root a subdirectory of private storage rather than
the top level.
