### PR TITLE
Make presplash image fit the screen

### DIFF
--- a/src/src/org/renpy/android/SDLSurfaceView.java
+++ b/src/src/org/renpy/android/SDLSurfaceView.java
@@ -808,8 +808,11 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
         GLES20.glViewport(0, 0, mWidth, mHeight);
 
         if (bitmap != null) {
-            float mx = ((float)mWidth / bitmap.getWidth()) / 2.0f;
-            float my = ((float)mHeight / bitmap.getHeight()) / 2.0f;
+            int bitmapWidth = bitmap.getWidth();
+            int bitmapHeight = bitmap.getHeight();
+            float bitmapMultiplier = (float)Math.sqrt(2f * mWidth * mHeight / bitmapWidth / bitmapHeight);
+            float mx = (float)mWidth / bitmapWidth / bitmapMultiplier;
+            float my = (float)mHeight / bitmapHeight / bitmapMultiplier;
             Matrix.orthoM(mProjMatrix, 0, -mx, mx, my, -my, 0, 10);
             int value = bitmap.getPixel(0, 0);
             Color color = new Color();


### PR DESCRIPTION
I made my presplash image to look good on all my devices with different screen resolutions.
Tested image sizes: 416x530, 256x256, 512x512, 1024x1024.
Tested screen resolutions (both -- portrait and landscape): 320x480, 480x800.

I am not math expert so more testing needed with different image sizes and screen resolutions. May be I just lucky. :)