### PR TITLE
add libsodium recipe

### DIFF
--- a/recipes/libsodium/recipe.sh
+++ b/recipes/libsodium/recipe.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This recipe was tested with the libnacl module
+VERSION_libsodium=${VERSION_libsodium:-1.0.3}
+URL_libsodium=https://github.com/jedisct1/libsodium/releases/download/${VERSION_libsodium}/libsodium-${VERSION_libsodium}.tar.gz
+DEPS_libsodium=(python)
+MD5_libsodium=b3bcc98e34d3250f55ae196822307fab
+BUILD_libsodium=$BUILD_PATH/libsodium/$(get_directory $URL_libsodium)
+RECIPE_libsodium=$RECIPES_PATH/libsodium
+
+function prebuild_libsodium() {
+	true
+}
+
+function shouldbuild_libsodium() {
+	if [ -e "$LIBS_PATH/libsodium.so" ]; then
+		DO_BUILD=0
+	fi
+}
+
+function build_libsodium() {
+	cd $BUILD_libsodium
+
+	push_arm
+
+	try ./configure --enable-minimal --disable-soname-versions --host="arm-linux-androideabi" --enable-shared
+	try make
+
+	try cp -L $BUILD_libsodium/src/libsodium/.libs/libsodium.so $LIBS_PATH
+
+	pop_arm
+}
+
+function postbuild_libsodium() {
+	true
+}


### PR DESCRIPTION
This recipe was tested with the following app:

```python
__version__ = "1.0.0"

import kivy
import libnacl
import time
import sys
from libnacl import public

kivy.require('1.9.0')

from kivy.app import App
from kivy.uix.label import Label
from kivy.logger import Logger

class MyApp(App):

    def build(self):
	    # Asymmetric encryption example from libnacl/libsodium site
		msg = b'You\'ve got two empty halves of coconut and you\'re bangin\' \'em together.'

		bob = libnacl.public.SecretKey()
		alice = libnacl.public.SecretKey()

		bob_box = libnacl.public.Box(bob.sk, alice.pk)
		alice_box = libnacl.public.Box(alice.sk, bob.pk)

		bob_ctxt = bob_box.encrypt(msg)
		bclear = alice_box.decrypt(bob_ctxt)
		alice_ctxt = alice_box.encrypt(msg)
		aclear = alice_box.decrypt(alice_ctxt)
		return Label(text=aclear)

if __name__ == '__main__':
    MyApp().run()
```

If `libsodium` compiles and is copied correctly, the encryption code completes without error and the created label will be shown on the screen. The dependencies in the `buildozer.spec` file are `kivy, libnacl,` and `libsodium`.