### PR TITLE
Use metadata to select a fitting method for the presplash screen

### DIFF
--- a/src/src/org/renpy/android/SDLSurfaceView.java
+++ b/src/src/org/renpy/android/SDLSurfaceView.java
@@ -812,8 +812,36 @@ public class SDLSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
         GLES20.glViewport(0, 0, mWidth, mHeight);
 
         if (bitmap != null) {
-            float mx = ((float)mWidth / bitmap.getWidth()) / 2.0f;
-            float my = ((float)mHeight / bitmap.getHeight()) / 2.0f;
+            String fit = (String) ai.metaData.get("presplash-fit");
+
+            Log.i("python","presplash-fit is "+fit);
+
+            int bitmapWidth = bitmap.getWidth();
+            int bitmapHeight = bitmap.getHeight();
+
+            float mx;
+            float my;
+
+            if (fit != null && fit.equals("fit")) {
+                float bitmapMultiplier = (float) Math.sqrt(2f * mWidth * mHeight / bitmapWidth / bitmapHeight);
+                mx = (float) mWidth / bitmapWidth / bitmapMultiplier;
+                my = (float) mHeight / bitmapHeight / bitmapMultiplier;
+            } else if (fit != null && fit.equals("width")) {
+                float bitmapMultiplier = ((float) mWidth) / bitmapWidth;
+                mx = (float) mWidth / bitmapWidth / 2.0f /bitmapMultiplier;
+                my = (float) mHeight / bitmapHeight / 2.0f /bitmapMultiplier;
+            } else if (fit != null && fit.equals("height")) {
+                float bitmapMultiplier = ((float) mHeight) / bitmapHeight;
+                mx = (float) mWidth / bitmapWidth / 2.0f / bitmapMultiplier;
+                my = (float) mHeight / bitmapHeight / 2.0f / bitmapMultiplier;
+            } else {
+                // default
+                mx = ((float) mWidth / bitmapWidth) / 2.0f;
+                my = ((float) mHeight / bitmapWidth) / 2.0f;
+            }
+
+            Log.i("python", String.format("presplash (fit=%s) mx=%f,my=%f", fit,mx, my));
+
             Matrix.orthoM(mProjMatrix, 0, -mx, mx, my, -my, 0, 10);
             int value = bitmap.getPixel(0, 0);
             Color color = new Color();


### PR DESCRIPTION
This is based on pull request #372 
I've modified the original pull request by @Mystic-Mirage, making it controllable by a metadata property ("presplash-fit").

I've kept the transformation coded by @Mystic-Mirage as "fit" (not sure if it is correct, for a square image, in my screen, it shows with a border surrounding the image).

I've added two additional transformations, "width" will make the image fit the screen horizontally, while "height" will make the image fit the screen vertically.

Any other option, or the absence of the metadata property will use the default (existing) transformation that renders the image at the current screen resolution.