### PR TITLE
Enabling android-21 builds

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -168,7 +168,7 @@ function push_arm() {
 	export CXXFLAGS="$CFLAGS"
 
 	# that could be done only for darwin platform, but it doesn't hurt.
-	export LDFLAGS="-lm"
+	# export LDFLAGS="-lm"
 
 	# this must be something depending of the API level of Android
 	PYPLATFORM=$($PYTHON -c 'from __future__ import print_function; import sys; print(sys.platform)')
@@ -338,8 +338,11 @@ function run_prepare() {
 	debug "API level set to $ANDROIDAPI"
 
 	export NDKPLATFORM="$ANDROIDNDK/platforms/android-$ANDROIDAPI/arch-arm"
-	export ARCH="armeabi"
-	#export ARCH="armeabi-v7a" # not tested yet.
+	if [ $ANDROIDAPI -lt 21 ]; then
+		export ARCH="armeabi"
+	else
+		export ARCH="armeabi-v7a" # Required for android 21
+	fi	
 
 	info "Check NDK location"
 	if [ ! -d "$NDKPLATFORM" ]; then

--- a/recipes/python/patches/android-21.patch
+++ b/recipes/python/patches/android-21.patch
@@ -1,0 +1,24 @@
+--- Python-2.7.2/Modules/timemodule.orig.c	2015-06-17 09:45:56.170192962 +0200
++++ Python-2.7.2/Modules/timemodule.c	2015-06-17 09:49:25.069947821 +0200
+@@ -27,6 +27,10 @@
+ #include <io.h>
+ #endif
+ 
++#ifdef ANDROID
++#undef HAVE_FTIME
++#endif /* ANdroid-21 has no timeb.h */
++
+ #ifdef HAVE_FTIME
+ #include <sys/timeb.h>
+ #if !defined(MS_WINDOWS) && !defined(PYOS_OS2)
+--- Python-2.7.2/configure.orig	2015-06-24 17:47:39.181473779 +0200
++++ Python-2.7.2/configure	2015-06-24 17:48:31.646173137 +0200
+@@ -5731,7 +5731,7 @@
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether gcc supports ParseTuple __format__" >&5
+ $as_echo_n "checking whether gcc supports ParseTuple __format__... " >&6; }
+   save_CFLAGS=$CFLAGS
+-  CFLAGS="$CFLAGS -Werror"
++  CFLAGS="$CFLAGS -Werror -Wformat"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 

--- a/recipes/python/recipe.sh
+++ b/recipes/python/recipe.sh
@@ -33,6 +33,9 @@ function prebuild_python() {
 	try patch -p1 < $RECIPE_python/patches/fix-dynamic-lookup.patch
 	try patch -p1 < $RECIPE_python/patches/fix-dlfcn.patch
 	try patch -p1 < $RECIPE_python/patches/ctypes-find-library.patch
+	if [ $ANDROIDAPI -gt 19 ]; then
+	        try patch -p1 < $RECIPE_python/patches/android-21.patch
+	fi
 
 	system=$(uname -s)
 	if [ "X$system" == "XDarwin" ]; then


### PR DESCRIPTION
This patch enables python to be build for android-21 and fixes the problems for using gcc >=4.8, too