### PR TITLE
Fixing wrong use of ar when building numpy

### DIFF
--- a/recipes/numpy/patches/ar.patch
+++ b/recipes/numpy/patches/ar.patch
@@ -1,0 +1,11 @@
+--- numpy/distutils/unixccompiler.orig.py	2015-02-01 17:38:21.000000000 +0100
++++ numpy/distutils/unixccompiler.py	2015-07-08 17:21:05.742468485 +0200
+@@ -82,6 +82,8 @@
+             pass
+         self.mkpath(os.path.dirname(output_filename))
+         tmp_objects = objects + self.objects
++        self.archiver[0]="$AR"
++        print("#####Archiver: " + ', '.join(self.archiver) ) 
+         while tmp_objects:
+             objects = tmp_objects[:50]
+             tmp_objects = tmp_objects[50:]

--- a/recipes/numpy/patches/ar.patch
+++ b/recipes/numpy/patches/ar.patch
@@ -1,11 +1,11 @@
---- numpy/distutils/unixccompiler.orig.py	2015-02-01 17:38:21.000000000 +0100
-+++ numpy/distutils/unixccompiler.py	2015-07-08 17:21:05.742468485 +0200
+--- a/numpy/distutils/unixccompiler.py	2015-02-01 17:38:21.000000000 +0100
++++ b/numpy/distutils/unixccompiler.py	2015-07-08 17:21:05.742468485 +0200
 @@ -82,6 +82,8 @@
              pass
          self.mkpath(os.path.dirname(output_filename))
          tmp_objects = objects + self.objects
-+        self.archiver[0]="$AR"
-+        print("#####Archiver: " + ', '.join(self.archiver) ) 
++        from os import environ
++        self.archiver[0] = 'arm-linux-androideabi-ar'
          while tmp_objects:
              objects = tmp_objects[:50]
              tmp_objects = tmp_objects[50:]

--- a/recipes/numpy/patches/lib.patch
+++ b/recipes/numpy/patches/lib.patch
@@ -1,5 +1,5 @@
---- numpy/linalg/setup.orig.py	2015-07-09 14:15:59.850853336 +0200
-+++ numpy/linalg/setup.py	2015-07-09 14:21:59.403889000 +0200
+--- a/numpy/linalg/setup.py	2015-07-09 14:15:59.850853336 +0200
++++ b/numpy/linalg/setup.py	2015-07-09 14:21:59.403889000 +0200
 @@ -37,7 +37,8 @@
      config.add_extension('lapack_lite',
                           sources = [get_lapack_lite_sources],
@@ -19,8 +19,8 @@
                           )
  
      return config
---- numpy/fft/setup.orig.py	2015-07-09 14:35:22.299888028 +0200
-+++ numpy/fft/setup.py	2015-07-09 14:33:54.858392578 +0200
+--- a/numpy/fft/setup.py	2015-07-09 14:35:22.299888028 +0200
++++ b/numpy/fft/setup.py	2015-07-09 14:33:54.858392578 +0200
 @@ -9,7 +9,8 @@
  
      # Configure fftpack_lite
@@ -31,8 +31,8 @@
                           )
  
  
---- numpy/random/setup.orig.py	2015-07-09 14:44:41.105174826 +0200
-+++ numpy/random/setup.py	2015-07-09 14:46:08.592679877 +0200
+--- a/numpy/random/setup.orig.py	2015-07-09 14:44:41.105174826 +0200
++++ b/numpy/random/setup.py	2015-07-09 14:46:08.592679877 +0200
 @@ -38,7 +38,7 @@
      if needs_mingw_ftime_workaround():
          defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))

--- a/recipes/numpy/patches/lib.patch
+++ b/recipes/numpy/patches/lib.patch
@@ -1,0 +1,44 @@
+--- numpy/linalg/setup.orig.py	2015-07-09 14:15:59.850853336 +0200
++++ numpy/linalg/setup.py	2015-07-09 14:21:59.403889000 +0200
+@@ -37,7 +37,8 @@
+     config.add_extension('lapack_lite',
+                          sources = [get_lapack_lite_sources],
+                          depends = ['lapack_litemodule.c'] + lapack_lite_src,
+-                         extra_info = lapack_info
++                         extra_info = lapack_info,
++                         libraries = ['m'],
+                          )
+ 
+     # umath_linalg module
+@@ -46,7 +47,7 @@
+                          sources = [get_lapack_lite_sources],
+                          depends =  ['umath_linalg.c.src'] + lapack_lite_src,
+                          extra_info = lapack_info,
+-                         libraries = ['npymath'],
++                         libraries = ['npymath','m'],
+                          )
+ 
+     return config
+--- numpy/fft/setup.orig.py	2015-07-09 14:35:22.299888028 +0200
++++ numpy/fft/setup.py	2015-07-09 14:33:54.858392578 +0200
+@@ -9,7 +9,8 @@
+ 
+     # Configure fftpack_lite
+     config.add_extension('fftpack_lite',
+-                         sources=['fftpack_litemodule.c', 'fftpack.c']
++                         sources=['fftpack_litemodule.c', 'fftpack.c'],
++                         libraries = ['m']
+                          )
+ 
+ 
+--- numpy/random/setup.orig.py	2015-07-09 14:44:41.105174826 +0200
++++ numpy/random/setup.py	2015-07-09 14:46:08.592679877 +0200
+@@ -38,7 +38,7 @@
+     if needs_mingw_ftime_workaround():
+         defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
+ 
+-    libs = []
++    libs = ['m']
+     # Configure mtrand
+     config.add_extension('mtrand',
+                          sources=[join('mtrand', x) for x in

--- a/recipes/numpy/patches/prevent_libs_check.patch
+++ b/recipes/numpy/patches/prevent_libs_check.patch
@@ -1,0 +1,12 @@
+diff --git a/numpy/distutils/system_info.py b/numpy/distutils/system_info.py
+index a050430..471e958 100644
+--- a/numpy/distutils/system_info.py
++++ b/numpy/distutils/system_info.py
+@@ -610,6 +610,7 @@ class system_info:
+         return self.get_paths(self.section, key)
+ 
+     def get_libs(self, key, default):
++        return []
+         try:
+             libs = self.cp.get(self.section, key)
+         except NoOptionError:

--- a/recipes/numpy/recipe.sh
+++ b/recipes/numpy/recipe.sh
@@ -15,8 +15,9 @@ function prebuild_numpy() {
 	fi
 
 	try patch -p1 < $RECIPE_numpy/patches/fix-numpy.patch
-	try patch -p0 < $RECIPE_numpy/patches/ar.patch
-	try patch -p0 < $RECIPE_numpy/patches/lib.patch
+	try patch -p1 < $RECIPE_numpy/patches/ar.patch
+	try patch -p1 < $RECIPE_numpy/patches/lib.patch
+	try patch -p1 < $RECIPE_numpy/patches/prevent_libs_check.patch
 	touch .patched
 }
 

--- a/recipes/numpy/recipe.sh
+++ b/recipes/numpy/recipe.sh
@@ -15,6 +15,8 @@ function prebuild_numpy() {
 	fi
 
 	try patch -p1 < $RECIPE_numpy/patches/fix-numpy.patch
+	try patch -p0 < $RECIPE_numpy/patches/ar.patch
+	try patch -p0 < $RECIPE_numpy/patches/lib.patch
 	touch .patched
 }
 
@@ -29,9 +31,9 @@ function build_numpy() {
 	cd $BUILD_numpy
 
 	push_arm
-
 	try $HOSTPYTHON setup.py build_ext -v
 	try find build/lib.* -name "*.o" -exec $STRIP {} \;
+	env
 	try $HOSTPYTHON setup.py install -O2
 
 	pop_arm


### PR DESCRIPTION
numpy does not build ( see issue 409 ).

https://github.com/kivy/python-for-android/issues/409

Though the correct version of ar is found

Found executable /usr/bin/gfortran
Found executable /opt/android-ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ld
Found executable /opt/android-ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar
Found executable /opt/android-ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ranlib

the build process uses ar instead of arm-linux-androideabi-ar.

I fixed this by using $AR which is set by distribute.sh

In addition I found that lapack_lite.so and some other libs require linking against libm.so when running on android-21.

I fixed this, too.
