### PR TITLE
Fixed version number logic for non-int versions

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -220,7 +220,15 @@ def make_package(args):
     if not args.numeric_version:
         for i in args.version.split('.'):
             version_code *= 100
-            version_code += int(i)
+            try:
+                version_code += int(i)
+            except:
+                try:
+                    for j in i.split('-'):
+                        version_code += int(j)
+                        break
+                except:
+                    pass
 
         args.numeric_version = str(version_code)
 


### PR DESCRIPTION
build.py would fail here on versions such as 0.1.1-r4. This fixed it for me - I also checked the resulting string in AndroidManifest, it seems proper.