### PR TITLE
Converted --minsdk option input to int

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -446,6 +446,7 @@ tools directory of the Android SDK.
     ap.add_argument('--sdk', dest='sdk_version', default=android_api,
                     help='Android SDK version to use. Default to 8')
     ap.add_argument('--minsdk', dest='min_sdk_version', default=android_api,
+                    type=int,
                     help='Minimum Android SDK version to use. Default to 8')
     ap.add_argument('--window', dest='window', action='store_true',
                     help='Indicate if the application will be windowed')


### PR DESCRIPTION
This should fix a python3 error where this value is compared with an int in the AndroidManifest.xml template - currently it's a str vs int comparison which only works in python2.