### PR TITLE
Update NDK download link as NumPy can't be built using NDK r8c

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Global overview
 
 #. Download Android NDK, SDK
  
-   * NDK: http://dl.google.com/android/ndk/android-ndk-r8c-linux-x86.tar.bz2
+   * NDK: http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86.tar.bz2
    * More details at: http://developer.android.com/tools/sdk/ndk/index.html
    * SDK: http://dl.google.com/android/android-sdk_r21.0.1-linux.tgz
    * More details at:http://developer.android.com/sdk/index.html


### PR DESCRIPTION
It's not an issue of python-for-android. NumPy can't be built using ndr8c - gcc segfaults during processing of this command:
```
./distribute.sh -m "sqlite3 numpy kivy"
```
Fails with this log:
```
ccache: build/src.linux-x86_64-2.7/numpy/core/src/multiarray/lowlevel_strided_loops.c
numpy/core/src/multiarray/lowlevel_strided_loops.c.src: In function '_cast_ubyte_to_ulonglong':
numpy/core/src/multiarray/lowlevel_strided_loops.c.src:886: internal compiler error: Segmentation fault
Please submit a full bug report,
with preprocessed source if appropriate.
See <http://gcc.gnu.org/bugs.html> for instructions.
numpy/core/src/multiarray/lowlevel_strided_loops.c.src: In function '_cast_ubyte_to_ulonglong':
numpy/core/src/multiarray/lowlevel_strided_loops.c.src:886: internal compiler error: Segmentation fault
Please submit a full bug report,
with preprocessed source if appropriate.
See <http://gcc.gnu.org/bugs.html> for instructions.
```
Updating to a newer version of NDK (r9d) worked for me.