### PR TITLE
Updated pylibpd recipe.

### DIFF
--- a/recipes/pylibpd/patches/makefilefix.patch
+++ b/recipes/pylibpd/patches/makefilefix.patch
@@ -1,0 +1,11 @@
+--- Makefile	2015-08-19 10:42:49.160410592 +0200
++++ Makefile-threadfix	2015-08-19 11:08:49.458350964 +0200
+@@ -150,7 +150,7 @@
+ libpd: $(LIBPD)
+ 
+ $(LIBPD): ${PD_FILES:.c=.o} ${UTIL_FILES:.c=.o} ${EXTRA_FILES:.c=.o}
+-	$(CC) -o $(LIBPD) $^ $(LDFLAGS) -lm -lpthread 
++	$(CC) -o $(LIBPD) $^ $(LDFLAGS) -lm
+ 
+ javalib: $(JNIH_FILE) $(PDJAVA_JAR)
+ 

--- a/recipes/pylibpd/patches/threadfix.patch
+++ b/recipes/pylibpd/patches/threadfix.patch
@@ -1,10 +1,10 @@
---- python/setup-threadfix.py	2013-05-29 13:10:16.000000000 -0400
-+++ python/setup.py	2013-06-07 11:53:34.447298388 -0400
-@@ -22,7 +22,6 @@
+--- python/setup.py     2015-08-18 11:15:35.546257493 +0200
++++ python/setup-threadfix.py   2015-08-18 11:32:16.784394028 +0200
+@@ -24,7 +24,6 @@
                    libraries = [
                      'm',
                      'dl',
--                    'pthread',
+-                    'pthread'
                    ],
-                   sources=[
+                   sources = [
                      'pylibpd.i',

--- a/recipes/pylibpd/recipe.sh
+++ b/recipes/pylibpd/recipe.sh
@@ -6,14 +6,25 @@ URL_pylibpd=https://github.com/libpd/libpd/archive/$VERSION_pylibpd.zip
 MD5_pylibpd=
 BUILD_pylibpd=$BUILD_PATH/pylibpd/$(get_directory $URL_pylibpd)
 RECIPE_pylibpd=$RECIPES_PATH/pylibpd
+GIT_pylibpd=https://github.com/libpd/libpd
 
 function prebuild_pylibpd() {
+    # Clone recursively libpd repository
+    rm -rf $BUILD_pylibpd
+    git clone --recursive $GIT_pylibpd $BUILD_pylibpd
     # Apply thread removal patch
     cd $BUILD_pylibpd/python
     if [ -f .patched ]; then
         return
     fi
     try patch -p1 < $RECIPE_pylibpd/patches/threadfix.patch
+    touch .patched
+    # Apply Makefile patch
+    cd $BUILD_pylibpd
+    if [ -f .patched ]; then
+        return
+    fi
+    try patch < $RECIPE_pylibpd/patches/makefilefix.patch
     touch .patched
 }
 
@@ -24,8 +35,10 @@ function shouldbuild_pylibpd() {
 }
 
 function build_pylibpd() {
-    cd $BUILD_pylibpd/python
     push_arm
+    cd $BUILD_pylibpd
+    try make
+    cd python 
     try $HOSTPYTHON setup.py build
     try $HOSTPYTHON setup.py install -O2
     try $HOSTPYTHON setup.py clean


### PR DESCRIPTION
The old version of the patch refers to wrong line numbers and fails to patch the setup.py file.
I've updated the patch file creating a diff with the github repo version of setup.py.
Now the recipe uses git clone --recursive for downloading libpd so we can include all the submodules in one step.
The libpd makefile has been patched to be coherent with the pylibpd patch.