### PR TITLE
[revamp] Correcting check for libtool

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -859,11 +859,11 @@ class Context(object):
 
         # AND: Are these necessary? Where to check for and and ndk-build?
         # check the basic tools
-        for tool in ("pkg-config", "autoconf", "automake", "libtool",
+        for executable in ("pkg-config", "autoconf", "automake", "libtoolize",
                      "tar", "bzip2", "unzip", "make", "gcc", "g++"):
-            if not sh.which(tool):
-                warning("Missing requirement: {} is not installed".format(
-                    tool))
+            if not sh.which(executable):
+                warning("Missing executable: {} is not installed".format(
+                    executable))
 
         if not ok:
             sys.exit(1)


### PR DESCRIPTION
It is correct that we need libtool, but the executable is called libtoolize. Therefore sh.which(executable) won't work in this case. I renamed the variable "tool" to "executable", so other developers won't get confused and also add package names here.