### PR TITLE
[revamp] toolchain: Update DEFAULT_ANDROID_API to 15

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -43,7 +43,7 @@ curdir = dirname(__file__)
 sys.path.insert(0, join(curdir, "tools", "external"))
 
 
-DEFAULT_ANDROID_API = 14
+DEFAULT_ANDROID_API = 15
 
 class LevelDifferentiatingFormatter(logging.Formatter):
     def format(self, record):


### PR DESCRIPTION
ANDROID_API = 14 is obsolete according to the Android SDK Manager.
Thats why I would suggest to update the DEFAULT_ANDROID_API at least to the next supported version.