### PR TITLE
[revamp] Adding direct git support to toolchain.py

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1390,8 +1390,10 @@ class Recipe(object):
             return target
         elif parsed_url.scheme in ('git',):
             if os.path.isdir(target):
-                with current_directory(self.get_build_dir(arch.arch)):
-                    shprint(sh.git, 'pull', '--all')
+                with current_directory(target):
+                    shprint(sh.git, 'pull')
+                    shprint(sh.git, 'pull', '--recurse-submodules')
+                    shprint(sh.git, 'submodule', 'update', '--recursive')
             else:
                 shprint(sh.git, 'clone', '--recursive', url, target)
             return target
@@ -1588,7 +1590,7 @@ class Recipe(object):
             do_download = True
 
             marker_filename = '.mark-{}'.format(filename)
-            if exists(filename):
+            if exists(filename) and os.path.isfile(filename):
                 if not exists(marker_filename):
                     shprint(sh.rm, filename)
                 elif self.md5sum:
@@ -1680,7 +1682,7 @@ class Recipe(object):
                         raise Exception('Could not extract {} download, it must be .zip, '
                                         '.tar.gz or .tar.bz2')
                 elif os.path.isdir(extraction_filename):
-                    os.symlink(extraction_filename, directory_name)
+                    shutil.copytree(extraction_filename, directory_name)
                 else:
                     raise Exception('Given path is neither a file nor a directory: {}'.format(extraction_filename))
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1682,7 +1682,10 @@ class Recipe(object):
                         raise Exception('Could not extract {} download, it must be .zip, '
                                         '.tar.gz or .tar.bz2')
                 elif os.path.isdir(extraction_filename):
-                    shutil.copytree(extraction_filename, directory_name)
+                    os.mkdir(directory_name)
+                    for entry in os.listdir(extraction_filename):
+                        if entry not in ('.git',):
+                            shprint(sh.cp, '-Rv',  os.path.join(extraction_filename, entry), directory_name)
                 else:
                     raise Exception('Given path is neither a file nor a directory: {}'.format(extraction_filename))
 


### PR DESCRIPTION
While working on the Qt5 recipe, I wanted to download the latest code from git. I know there is the possibility to download a tar or zip archive, but Qt5 uses submodules for their branch.
These won't be packaged by GitHub, so I started to add git support.

While coding I found out that a function, which should extract data from an archive isn't used anymore. But I can be wrong: https://github.com/kivy/python-for-android/compare/kivy:revamp...thopiekar:toolchain_git_support?expand=1#diff-9386f079c34547ba8b06a93309463a72L1365 