### PR TITLE
[revamp] Undefine HAVE_FTIME for Android API > 19

### DIFF
--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -11,7 +11,7 @@ class Python2Recipe(Recipe):
     url = 'http://python.org/ftp/python/{version}/Python-{version}.tar.bz2'
     name = 'python2'
 
-    depends = ['hostpython2']  
+    depends = ['hostpython2']
     conflicts = ['python3']
 
     def prebuild_armeabi(self):
@@ -38,6 +38,9 @@ class Python2Recipe(Recipe):
         if uname()[0] == 'Linux':
             self.apply_patch(join('patches', 'fix-configure-darwin.patch'))
             self.apply_patch(join('patches', 'fix-distutils-darwin.patch'))
+
+        if self.ctx.android_api > 19:
+            self.apply_patch(join('patches', 'fix-ftime-removal.patch'))
 
         shprint(sh.touch, join(build_dir, '.patched'))
 
@@ -125,7 +128,7 @@ class Python2Recipe(Recipe):
                         _env=env)
             except sh.ErrorReturnCode_2:
                 print('First python2 make failed. This is expected, trying again.')
-                
+
 
             print('Second install (expected to work)')
             shprint(sh.touch, 'python.exe', 'python')

--- a/pythonforandroid/recipes/python2/patches/fix-ftime-removal.patch
+++ b/pythonforandroid/recipes/python2/patches/fix-ftime-removal.patch
@@ -1,0 +1,11 @@
+diff -u -r Python-2.7.2.orig/Modules/timemodule.c Python-2.7.2/Modules/timemodule.c
+--- Python-2.7.2.orig/Modules/timemodule.c	2011-06-11 15:46:27.000000000 +0000
++++ Python-2.7.2/Modules/timemodule.c	2015-09-11 10:37:36.708661691 +0000
+@@ -27,6 +27,7 @@
+ #include <io.h>
+ #endif
+ 
++#undef HAVE_FTIME
+ #ifdef HAVE_FTIME
+ #include <sys/timeb.h>
+ #if !defined(MS_WINDOWS) && !defined(PYOS_OS2)


### PR DESCRIPTION
The `sys/timeb.h` header was removed in Android 21, because this header and the
`ftime` function were removed from the POSIX 2008 specification.
(Info reference: https://rbcommons.com/s/OpenH264/r/683/diff/1/ )

Closes #261, and replaces #410. The only difference is that in #410 the `#undef` is surrounded by an `#ifdef ANDROID`, which I didn't think was necessary (because this is only ever going to be patched for Android, because... `python-for-android`), but I can add it if desired.