### PR TITLE
Recipes

### DIFF
--- a/pythonforandroid/recipes/enum34/__init__.py
+++ b/pythonforandroid/recipes/enum34/__init__.py
@@ -1,0 +1,10 @@
+
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class Enum34Recipe(PythonRecipe):
+    version = '1.0.4'
+    url = 'https://pypi.python.org/packages/source/e/enum34/enum34-{version}.tar.gz'
+    depends = ['python2']
+
+recipe = Enum34Recipe()

--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -1,0 +1,23 @@
+
+from pythonforandroid.toolchain import Recipe, shprint, current_directory
+from os.path import exists, join
+import sh
+
+
+class OpenSSLRecipe(Recipe):
+    version = '1.0.2d'
+    url = 'https://www.openssl.org/source/openssl-{version}.tar.gz'
+
+    def should_build(self):
+        return not exists(join(self.get_build_dir('armeabi'), 'libssl.a'))
+
+    def build_arch(self, arch):
+        env = self.get_recipe_env(arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            # sh fails with code 255 trying to execute ./Configure
+            # so instead we manually run perl passing in Configure
+            perl = sh.Command('perl')
+            shprint(perl, 'Configure', 'no-dso', 'no-krb5', 'linux-armv4', _env=env)
+            shprint(sh.make, 'build_libs', _env=env)
+
+recipe = OpenSSLRecipe()

--- a/pythonforandroid/recipes/pyasn1/__init__.py
+++ b/pythonforandroid/recipes/pyasn1/__init__.py
@@ -1,0 +1,10 @@
+
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class PyASN1Recipe(PythonRecipe):
+    version = '0.1.8'
+    url = 'https://pypi.python.org/packages/source/p/pyasn1/pyasn1-{version}.tar.gz'
+    depends = ['python2']
+
+recipe = PyASN1Recipe()

--- a/pythonforandroid/recipes/pycrypto/__init__.py
+++ b/pythonforandroid/recipes/pycrypto/__init__.py
@@ -1,0 +1,51 @@
+
+from pythonforandroid.toolchain import (
+    CompiledComponentsPythonRecipe,
+    Recipe,
+    current_directory,
+    info,
+    shprint,
+)
+from os.path import exists, join, realpath
+import sh
+import glob
+
+
+class PyCryptoRecipe(CompiledComponentsPythonRecipe):
+    version = '2.6.1'
+    url = 'https://pypi.python.org/packages/source/p/pycrypto/pycrypto-{version}.tar.gz'
+    depends = ['openssl', 'python2']
+
+    def prebuild_arch(self, arch):
+        super(PyCryptoRecipe, self).prebuild_arch(arch)
+        build_dir = self.get_build_dir(arch.arch)
+        if exists(join(build_dir, '.patched')):
+            print('pycrypto already patched, skipping')
+            return
+        self.apply_patch('add_length.patch')
+        shprint(sh.touch, join(build_dir, '.patched'))
+
+    def get_recipe_env(self, arch):
+        env = super(PyCryptoRecipe, self).get_recipe_env(arch)
+        openssl_build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
+        env['CC'] = '%s -I%s' % (env['CC'], join(openssl_build_dir, 'include'))
+        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
+            self.ctx.get_libs_dir(arch.arch) +
+            '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
+            openssl_build_dir)
+        env['EXTRA_CFLAGS'] = '--host linux-armv'
+        env['ac_cv_func_malloc_0_nonnull'] = 'yes'
+        return env
+
+    def build_compiled_components(self, arch):
+        info('Configuring compiled components in {}'.format(self.name))
+
+        env = self.get_recipe_env(arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            configure = sh.Command('./configure')
+            shprint(configure, '--host=arm-eabi',
+                    '--prefix={}'.format(self.ctx.get_python_install_dir()),
+                    '--enable-shared', _env=env)
+        super(PyCryptoRecipe, self).build_compiled_components(arch)
+
+recipe = PyCryptoRecipe()

--- a/pythonforandroid/recipes/pycrypto/add_length.patch
+++ b/pythonforandroid/recipes/pycrypto/add_length.patch
@@ -1,0 +1,11 @@
+--- pycrypto-2.6.1/src/hash_SHA2_template.c.orig	2013-10-14 14:38:10.000000000 -0700
++++ pycrypto-2.6.1/src/hash_SHA2_template.c	2014-05-19 10:15:51.000000000 -0700
+@@ -87,7 +87,7 @@
+  * return 1 on success
+  * return 0 if the length overflows
+  */
+-int add_length(hash_state *hs, sha2_word_t inc) {
++static int add_length(hash_state *hs, sha2_word_t inc) {
+     sha2_word_t overflow_detector;
+     overflow_detector = hs->length_lower;
+     hs->length_lower += inc;

--- a/pythonforandroid/recipes/pyopenssl/__init__.py
+++ b/pythonforandroid/recipes/pyopenssl/__init__.py
@@ -1,0 +1,38 @@
+
+from pythonforandroid.toolchain import (
+    CompiledComponentsPythonRecipe,
+    Recipe,
+    current_directory,
+    info,
+    shprint,
+)
+from os.path import exists, join
+import sh
+import glob
+
+
+class PyOpenSSLRecipe(CompiledComponentsPythonRecipe):
+    version = '0.13'
+    url = 'https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-{version}.tar.gz'
+    depends = ['openssl', 'python2']
+
+    def prebuild_arch(self, arch):
+        super(PyOpenSSLRecipe, self).prebuild_arch(arch)
+        build_dir = self.get_build_dir(arch.arch)
+        if exists(join(build_dir, '.patched')):
+            print('pyOpenSSL already patched, skipping')
+            return
+        self.apply_patch('fix-dlfcn.patch')
+        shprint(sh.touch, join(build_dir, '.patched'))
+
+    def get_recipe_env(self, arch):
+        env = super(PyOpenSSLRecipe, self).get_recipe_env(arch)
+        openssl_build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
+        env['CC'] = '%s -I%s' % (env['CC'], join(openssl_build_dir, 'include'))
+        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
+            self.ctx.get_libs_dir(arch.arch) +
+            '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
+            openssl_build_dir)
+        return env
+
+recipe = PyOpenSSLRecipe()

--- a/pythonforandroid/recipes/pyopenssl/fix-dlfcn.patch
+++ b/pythonforandroid/recipes/pyopenssl/fix-dlfcn.patch
@@ -1,0 +1,22 @@
+--- pyOpenSSL-0.13.orig/OpenSSL/__init__.py	2011-09-02 17:46:13.000000000 +0200
++++ pyOpenSSL-0.13/OpenSSL/__init__.py	2013-07-29 17:20:15.750079894 +0200
+@@ -12,6 +12,11 @@
+ except AttributeError:
+     from OpenSSL import crypto
+ else:
++    # XXX android fix
++    # linux: RTLD_NOW (0x2) | RTLD_GLOBAL (0x100 / 256)
++    # android: RTLD_NOW (0x0) | RTLD_GLOBAL (0x2)
++    flags = 0x2
++    '''
+     try:
+         import DLFCN
+     except ImportError:
+@@ -31,6 +36,7 @@
+     else:
+         flags = DLFCN.RTLD_NOW | DLFCN.RTLD_GLOBAL
+         del DLFCN
++    '''
+ 
+     sys.setdlopenflags(flags)
+     from OpenSSL import crypto

--- a/pythonforandroid/recipes/six/__init__.py
+++ b/pythonforandroid/recipes/six/__init__.py
@@ -1,0 +1,10 @@
+
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class SixRecipe(PythonRecipe):
+    version = '1.9.0'
+    url = 'https://pypi.python.org/packages/source/s/six/six-{version}.tar.gz'
+    depends = ['python2']
+
+recipe = SixRecipe()


### PR DESCRIPTION
More recipes. All recipes appear to build correctly (except maybe pyOpenSSL), but for some reason, the OpenSSL recipe causes problems in SDL2:

```
$ ANDROIDSDK=/home/str4d/dev/android/sdk ANDROIDAPI=19 ANDROIDNDK=/home/str4d/dev/android/android-ndk-r10e p4a apk --private /src/ --package org.example.recipestest --name "Hello Recipes" --version 1.0 --requirements sdl2,openssl --dist_name recipes --debug
...
[DEBUG]:   	/home/str4d/dev/android/android-ndk-r10e/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc -MMD -MP -MF /home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/obj/local/armeabi/objs/main/start.o.d -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float -mthumb -Os -g -DNDEBUG -fomit-frame-pointer -fno-strict-aliasing -finline-limit=64 -I/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/src/../SDL/include -I/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/SDL/include -I/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/src -DANDROID -I/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/src/../../../../other_builds/python2/armeabi/python2/python-install/include/python2.7 -Wa,--noexecstack -Wformat -Werror=format-security    -I/home/str4d/dev/android/android-ndk-r10e/platforms/android-19/arch-arm/usr/include -c  /home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/src/start.c -o /home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/obj/local/armeabi/objs/main/start.o
[DEBUG]:   	/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/jni/src/start.c:3:20: fatal error: Python.h: No such file or directory
[DEBUG]:   	 #include "Python.h"
[DEBUG]:   	                    ^
[DEBUG]:   	compilation terminated.
[DEBUG]:   	/home/str4d/dev/android/android-ndk-r10e/build/core/build-binary.mk:464: recipe for target '/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/obj/local/armeabi/objs/main/start.o' failed
[DEBUG]:   	make: *** [/home/str4d/.local/share/python-for-android/build/bootstrap_builds/sdl2/obj/local/armeabi/objs/main/start.o] Error 1
```

The problem remains even if I remove the modification to the Python2 recipe (so therefore the OpenSSL recipe should be completely independent of the SDL2 one). However, if I run a build that does not contain `--requirements openssl` (or anything with a dependency on it) then the SDL2 recipe builds fine even with the Python2 recipe modifications.