### PR TITLE
Fix keyboard height issue

### DIFF
--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -190,8 +190,14 @@ if mActivity:
         @java_method('()V')
         def onGlobalLayout(self):
             rctx = Rect()
+            # print('rctx_bottom: {0}, top: {1}'.format(rctx.bottom, rctx.top))
             mActivity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rctx)
+            # print('rctx_bottom: {0}, top: {1}'.format(rctx.bottom, rctx.top))
+            # print('activity height: {0}'.format(mActivity.getWindowManager().getDefaultDisplay().getHeight())) 
+            # NOTE top should always be zero
+            rctx.top = 0
             self.height = mActivity.getWindowManager().getDefaultDisplay().getHeight() - (rctx.bottom - rctx.top)
+            # print('final height: {0}'.format(self.height))
 
     ll = LayoutListener()
     python_act.mView.getViewTreeObserver().addOnGlobalLayoutListener(ll)


### PR DESCRIPTION
Use the print lines to debug. It seems that mActivity.getWindow()... changes rctx.top to a non-zero number, which causes the app to permanently shift upwards . To replicate this error, make an app that calls the keyboard. The hotfix I added was to set rctx.top to zero.