### PR TITLE
suppress colorization if stdout is not a tty

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -78,7 +78,7 @@ if not hasattr(logger, 'touched'):  # Necessary as importlib reloads
                                     # handler and reset the level
     logger.setLevel(logging.INFO)
     logger.touched = True
-    ch = logging.StreamHandler(stdout)
+    ch = logging.StreamHandler(stdout) if sys.stdout.isatty() else logging.NullHandler()
     formatter = LevelDifferentiatingFormatter('%(message)s')
     ch.setFormatter(formatter)
     logger.addHandler(ch)

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -41,7 +41,16 @@ except ImportError:
 import argparse
 from appdirs import user_data_dir
 import sh
-from colorama import Style, Fore
+if sys.stdout.isatty():
+    from colorama import Style, Fore
+else:
+    from collections import defaultdict
+    class colorama_shim(object):
+        def __init__(self):
+            self._dict = defaultdict(str)
+        def __getattr__(self, key):
+            return self._dict[key]
+    Style = Fore = colorama_shim()
 
 user_dir = dirname(realpath(os.path.curdir))
 toolchain_dir = dirname(__file__)


### PR DESCRIPTION
suppressing colorization makes the output easier to process by other scripts.