### PR TITLE
Fixing unicode error

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -182,7 +182,7 @@ def shprint(command, *args, **kwargs):
                         '\t', ' ').replace(
                             '\b', ' ').rstrip()
                 if msg:
-                    sys.stdout.write('{}\r{}{:<{width}}'.format(
+                    sys.stdout.write(u'{}\r{}{:<{width}}'.format(
                         Err_Style.RESET_ALL, msg_hdr,
                         shorten_string(msg, msg_width), width=msg_width))
                     sys.stdout.flush()


### PR DESCRIPTION
The updated toolchain.py fails if the output of shprint contains unicode characters.
This can happen if you use something like:

shprint(sh.cp, '-v', entry,  self.ctx.get_libs_dir(arch.arch))

and results in:

    File "/usr/lib64/python2.7/site-packages/python_for_android-0.3-py2.7.egg/pythonforandroid/toolchain.py", line 2312, in build_recipes
    recipe.postbuild_arch(arch)
    File "/usr/lib64/python2.7/site-packages/python_for_android-0.3-py2.7.egg/pythonforandroid/recipes/qt5base/__init__.py", line 118, in postbuild_arch
      shprint(sh.cp, '-v', entry,  self.ctx.get_libs_dir(arch.arch))
    File "/usr/lib64/python2.7/site-packages/python_for_android-0.3-py2.7.egg/pythonforandroid/toolchain.py", line 187, in shprint
    shorten_string(msg, msg_width), width=msg_width))
    UnicodeEncodeError: 'ascii' codec can't encode character u'\u201e' in position 0: ordinal not in range(128)

This fixed by this patch.