### PR TITLE
Fixing missing Colo

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -204,7 +204,7 @@ def shprint(command, *args, **kwargs):
                 logger.debug(''.join(['\t', line.rstrip()]))
         if need_closing_newline:
             sys.stdout.write('{}\r{:>{width}}\r'.format(
-                Style.RESET_ALL, ' ', width=(columns - 1)))
+                Colo_Style.RESET_ALL, ' ', width=(columns - 1)))
     except sh.ErrorReturnCode as err:
         if need_closing_newline:
             sys.stdout.write('{}\r{:>{width}}\r'.format(


### PR DESCRIPTION
Latest toolchain.py has typo error:

      File "/usr/lib64/python2.7/site-packages/python_for_android-0.3-py2.7.egg/pythonforandroid/toolchain.py", line 1822, in download
    filename = shprint(sh.basename, url).stdout[:-1].decode('utf-8')
      File "/usr/lib64/python2.7/site-packages/python_for_android-0.3-py2.7.egg/pythonforandroid/toolchain.py", line 207, in shprint
    Style.RESET_ALL, ' ', width=(columns - 1)))
    NameError: global name 'Style' is not defined

This patch fixes this error