### PR TITLE
add new error message and improve existing

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -85,7 +85,11 @@ DEFAULT_ANDROID_API = 15
 
 class LevelDifferentiatingFormatter(logging.Formatter):
     def format(self, record):
-        if record.levelno > 20:
+        if record.levelno > 30:
+            record.msg = '{}{}[ERROR]{}{}:   '.format(
+                Err_Style.BRIGHT, Err_Fore.RED, Err_Fore.RESET,
+                Err_Style.RESET_ALL) + record.msg
+        elif record.levelno > 20:
             record.msg = '{}{}[WARNING]{}{}: '.format(
                 Err_Style.BRIGHT, Err_Fore.RED, Err_Fore.RESET,
                 Err_Style.RESET_ALL) + record.msg
@@ -111,6 +115,7 @@ if not hasattr(logger, 'touched'):  # Necessary as importlib reloads
 info = logger.info
 debug = logger.debug
 warning = logger.warning
+error = logger.error
 
 
 IS_PY3 = sys.version_info[0] >= 3
@@ -1065,6 +1070,7 @@ class Context(object):
                     executable))
 
         if not ok:
+            error('{}python-for-android cannot continue; aborting{}'.format(Err_Fore.RED, Err_Fore.RESET))
             sys.exit(1)
 
     def __init__(self):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1008,7 +1008,7 @@ class Context(object):
             'android-{}'.format(self.android_api),
             platform_dir)
         if not exists(self.ndk_platform):
-            warning('ndk_platform doesn\'t exist')
+            warning('ndk_platform doesn\'t exist: {}'.format(self.ndk_platform))
             ok = False
 
         py_platform = sys.platform


### PR DESCRIPTION
Shows the path to the `ndk_platform` when it is not found, and shows a final error if `prepare_build_environment` is not `ok`.