### PR TITLE
fix hard coded python2 path in sdl2 Android.mk

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -12,12 +12,12 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include
 LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 	start.c
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/python2/$(ARCH)/python2/python-install/include/python2.7
+LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7
 
 LOCAL_SHARED_LIBRARIES := SDL2
 
 LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog -lpython2.7
 
-LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/python2/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
+LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
 
 include $(BUILD_SHARED_LIBRARY)

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -21,6 +21,12 @@ class LibSDL2Recipe(NDKRecipe):
         self.apply_patch('add_nativeSetEnv.patch', arch.arch)
         shprint(sh.touch, join(build_dir, '.patched'))
 
+    def get_recipe_env(self, arch=None):
+        env = super(LibSDL2Recipe, self).get_recipe_env(arch)
+        py2 = self.get_recipe('python2', arch.ctx)
+        env['PYTHON2_NAME'] = py2.get_dir_name()
+        return env
+
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1809,9 +1809,13 @@ class Recipe(object):
         This returns a different directory depending on what
         alternative or optional dependencies are being built.
         '''
+        dir_name = self.get_dir_name()
+        return join(self.ctx.build_dir, 'other_builds', dir_name, arch)
+
+    def get_dir_name(self):
         choices = self.check_recipe_choices()
         dir_name = '-'.join([self.name] + choices)
-        return join(self.ctx.build_dir, 'other_builds', dir_name, arch)
+        return dir_name
 
     def get_build_dir(self, arch):
         '''Given the arch name, returns the directory where the


### PR DESCRIPTION
Makes things compile when you have openssl in your requirements, making the python2 directory `python2-openssl` instead of `python2`.