### PR TITLE
fix root directory for tgz extraction

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1925,7 +1925,7 @@ class Recipe(object):
                         sh.tar('xzf', extraction_filename)
                         root_directory = shprint(
                             sh.tar, 'tzf', extraction_filename).stdout.decode(
-                                'utf-8').split('\n')[0].strip('/')
+                                'utf-8').split('\n')[0].split('/')[0]
                         if root_directory != directory_name:
                             shprint(sh.mv, root_directory, directory_name)
                     elif (extraction_filename.endswith('.tar.bz2') or


### PR DESCRIPTION
Makes the OpenSSL recipe work (otherwise, it was renaming OpenSSL-x.y.z/ACKNOWLEDGEMENTS to openssl instead of the directory).