### PR TITLE
fix pymodules install

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -610,7 +610,7 @@ class PythonRecipe(Recipe):
         name = self.site_packages_name
         if name is None:
             name = self.name
-        if exists(join(self.ctx.get_site_packages_dir(), name)):
+        if self.ctx.has_package(name):
             info('Python package already exists in site-packages')
             return False
         info('{} apparently isn\'t already in site-packages'.format(name))


### PR DESCRIPTION
Prevents errors when rebuilding a dist and the packages already exist, and errors when building a dist with pure-Python modules which depend on recipe modules.