### PR TITLE
Various fixes

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -471,6 +471,13 @@ class Context(object):
         return join(self.libs_dir, arch)
 
     def has_package(self, name, arch=None):
+        try:
+            recipe = Recipe.get_recipe(name, self)
+        except IOError:
+            pass
+        else:
+            name = getattr(recipe, 'site_packages_name', None) or name
+        name = name.replace('.', '/')
         site_packages_dir = self.get_site_packages_dir(arch)
         return (exists(join(site_packages_dir, name)) or
                 exists(join(site_packages_dir, name + '.py')) or

--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -92,8 +92,27 @@ def shorten_string(string, max_width):
         return string
     visible = max_width - 16 - int(log10(string_len))
     # expected suffix len "...(and XXXXX more)"
-    return ''.join((string[:visible], '...(and ', str(string_len - visible),
-                    ' more)'))
+    return u''.join((string[:visible], u'...(and ', str(string_len - visible),
+                    u' more)'))
+
+
+def get_console_width():
+    try:
+        cols = int(os.environ['COLUMNS'])
+    except (KeyError, ValueError):
+        pass
+    else:
+        if cols >= 25:
+            return cols
+
+    try:
+        cols = max(25, int(os.popen('stty size', 'r').read().split()[1]))
+    except Exception:
+        pass
+    else:
+        return cols
+
+    return 100
 
 
 def shprint(command, *args, **kwargs):
@@ -109,10 +128,7 @@ def shprint(command, *args, **kwargs):
     filter_out = kwargs.pop('_filterout', None)
     if len(logger.handlers) > 1:
         logger.removeHandler(logger.handlers[1])
-    try:
-        columns = max(25, int(os.popen('stty size', 'r').read().split()[1]))
-    except:
-        columns = 100
+    columns = get_console_width()
     command_path = str(command).split('/')
     command_string = command_path[-1]
     string = ' '.join(['running', command_string] + list(args))


### PR DESCRIPTION
Improve installed package detection:
    Always use `site_packages_name` if possible, and replace `.` with `/` to handle namespaced packages (i.e. `zope.interface`).

Fix decode error on py2:
    `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)`

Allow console width to be set via `COLUMNS` env var:
    Avoids `invalid ioctl` errors and allows custom console width when running in a non-standard terminal (like PyCharm debugger).