### PR TITLE
use ccache for cross compilation

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -52,6 +52,13 @@ class Arch(object):
         env['TOOLCHAIN_PREFIX'] = toolchain_prefix
         env['TOOLCHAIN_VERSION'] = toolchain_version
 
+        ccache = ''
+        if self.ctx.ccache and bool(int(environ.get('USE_CCACHE', '1'))):
+            print('ccache found, will optimize builds')
+            ccache = self.ctx.ccache + ' '
+            env['USE_CCACHE'] = '1'
+            env['NDK_CCACHE'] = self.ctx.ccache
+
         print('path is', environ['PATH'])
         cc = find_executable('{command_prefix}-gcc'.format(
             command_prefix=command_prefix), path=environ['PATH'])
@@ -62,11 +69,13 @@ class Arch(object):
                     'installed. Exiting.')
             exit(1)
 
-        env['CC'] = '{command_prefix}-gcc {cflags}'.format(
+        env['CC'] = '{ccache}{command_prefix}-gcc {cflags}'.format(
             command_prefix=command_prefix,
+            ccache=ccache,
             cflags=env['CFLAGS'])
-        env['CXX'] = '{command_prefix}-g++ {cxxflags}'.format(
+        env['CXX'] = '{ccache}{command_prefix}-g++ {cxxflags}'.format(
             command_prefix=command_prefix,
+            ccache=ccache,
             cxxflags=env['CXXFLAGS'])
 
         env['AR'] = '{}-ar'.format(command_prefix)


### PR DESCRIPTION
ccache is already used for building hostpython (if `/usr/lib/ccache` is added to the `PATH`), but not for any cross compiles.

This adds ccache to the `CC` and `CXX` env vars for standard and Cython builds, and sets `NDK_CCACHE` to the ccache binary for NDK builds. ccache usage is enabled by default, for convenience, but will respect the `USE_CCACHE` var (if set to `0`, ccache will not be used).

My distribution
- recipes: `hostpython2, jpeg, libffi, openssl, png, sdl2_image, sdl2_mixer, sdl2_ttf, python2, cdecimal, cnotify, eesentinel, enum34, evdev, ipaddress, pil, pyasn1, pycrypto, pytz, pyusb, sdl2, setuptools, six, zope_event, zope_interface, babel, gryphus, idna, pycparser, pyjnius, pyopenssl, sqlalchemy, twisted, zope_component, cffi, kivy, cryptography, aeris2`, which includes some custom recipes
- pure python: `pyasn1_modules, alembic, characteristic, bitstring, qrcode, service_identity, tenjin, pymysql, phonenumbers, mako`

For this distribution, these changes greatly decreased my rebuild time. Tested with deleting `build` and `dists`, but leaving `packages` alone to keep the download cache, then rebuilding the entire distribution as well as packaging an APK: `time p4a apk --private ../new-private/ --package=com.aerispos.aeris2 --name="AerisPOS" --version=2.2.19 --bootstrap=sdl2 --requirements=aeris2 --dist_name=aeris2-dist --copy-libs --debug`

Previous build time was around 30 minutes (estimated, not measured); with ccache the build time is 6m22s.

ccache stats:
````
cache hit (direct)                  2046
cache hit (preprocessed)              17
cache miss                             2
called for link                      153
called for preprocessing             183
compile failed                       165
preprocessor error                    78
bad compiler arguments                13
unsupported source language           19
autoconf compile/link                417
no input file                         52
files in cache                      4558
cache size                         145.1 MB
max cache size                       5.0 GB
````