### PR TITLE
support crystax ndk

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -39,7 +39,10 @@ class Arch(object):
 
         env["CXXFLAGS"] = env["CFLAGS"]
 
-        env["LDFLAGS"] = " ".join(['-lm'])
+        env["LDFLAGS"] = " ".join(['-lm', '-L' + self.ctx.get_libs_dir(self.arch)])
+
+        if self.ctx.ndk == 'crystax':
+            env['LDFLAGS'] += ' -L{}/sources/crystax/libs/{} -lcrystax'.format(self.ctx.ndk_dir, self.arch)
 
         py_platform = sys.platform
         if py_platform in ['linux2', 'linux3']:
@@ -84,6 +87,7 @@ class Arch(object):
         env['STRIP'] = '{}-strip --strip-unneeded'.format(command_prefix)
         env['MAKE'] = 'make -j5'
         env['READELF'] = '{}-readelf'.format(command_prefix)
+        env['NM'] = '{}-nm'.format(command_prefix)
 
         hostpython_recipe = Recipe.get_recipe('hostpython2', self.ctx)
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -274,12 +274,17 @@ class Context(object):
             if ndk_dir is not None:
                 info('Got NDK version from $ANDROIDNDKVER')
 
+        self.ndk = 'google'
+
         try:
             with open(join(ndk_dir, 'RELEASE.TXT')) as fileh:
-                reported_ndk_ver = fileh.read().split(' ')[0]
+                reported_ndk_ver = fileh.read().split(' ')[0].strip()
         except IOError:
             pass
         else:
+            if reported_ndk_ver.startswith('crystax-ndk-'):
+                reported_ndk_ver = reported_ndk_ver[12:]
+                self.ndk = 'crystax'
             if ndk_ver is None:
                 ndk_ver = reported_ndk_ver
                 info(('Got Android NDK version from the NDK dir: '
@@ -297,6 +302,8 @@ class Context(object):
         if ndk_ver is None:
             warning('Android NDK version could not be found, exiting.')
         self.ndk_ver = ndk_ver
+
+        info('Using {} NDK {}'.format(self.ndk.capitalize(), self.ndk_ver))
 
         virtualenv = None
         if virtualenv is None:
@@ -407,6 +414,7 @@ class Context(object):
         self._ndk_dir = None
         self._android_api = None
         self._ndk_ver = None
+        self.ndk = None
 
         self.toolchain_prefix = None
         self.toolchain_version = None

--- a/pythonforandroid/patching.py
+++ b/pythonforandroid/patching.py
@@ -63,3 +63,9 @@ def will_build(recipe_name):
         return recipe_name in recipe.ctx.recipe_build_order
     return will
 
+
+def is_ndk(ndk):
+    def is_x(recipe, **kwargs):
+        return recipe.ctx.ndk == ndk
+    return is_x
+


### PR DESCRIPTION
Automatically detect Crystax NDK and add libcrystax and its path to link flags. Stores the NDK being used ('google' or 'crystax') in Context for recipe usage.