### PR TITLE
ignore deps when installing via pip

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -580,7 +580,7 @@ def run_pymodules_install(ctx, modules):
         # It works but should be replaced with something better
         shprint(sh.bash, '-c', (
             "source venv/bin/activate && env CC=/bin/false CXX=/bin/false "
-            "PYTHONPATH={0} pip install --target '{0}' -r requirements.txt"
+            "PYTHONPATH={0} pip install --target '{0}' --no-deps -r requirements.txt"
         ).format(ctx.get_site_packages_dir()))
 
 


### PR DESCRIPTION
This avoids pip trying to overwrite packages which were installed via recipes (and sometimes throwing an error due to the package already existing in the destination, depending on pip version). This does mean you must specify every dependency package.