### PR TITLE
fix logger unicode errors on py2

### DIFF
--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -92,8 +92,12 @@ def shorten_string(string, max_width):
         return string
     visible = max_width - 16 - int(log10(string_len))
     # expected suffix len "...(and XXXXX more)"
-    return u''.join((string[:visible], u'...(and ', str(string_len - visible),
-                    u' more)'))
+    if not isinstance(string, unistr):
+        visstring = unistr(string[:visible], errors='ignore')
+    else:
+        visstring = string[:visible]
+    return u''.join((visstring, u'...(and ',
+                     unistr(string_len - visible), u' more)'))
 
 
 def get_console_width():
@@ -204,3 +208,6 @@ def shprint(command, *args, **kwargs):
             raise
 
     return output
+
+
+from pythonforandroid.util import unistr

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -15,6 +15,11 @@ from pythonforandroid.logger import (logger, Err_Fore)
 
 IS_PY3 = sys.version_info[0] >= 3
 
+if IS_PY3:
+    unistr = str
+else:
+    unistr = unicode
+
 
 class ChromeDownloader(FancyURLopener):
     version = (


### PR DESCRIPTION
Unicode errors happen randomly due to UTF8 output from cp (the quotes). This prevents those errors.