### PR TITLE
add python_depends to recipe

### DIFF
--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -163,6 +163,7 @@ def get_recipe_order_and_bootstrap(ctx, names, bs=None):
                 warning(
                     'Due to this conflict the build cannot continue, exiting.')
                 exit(1)
+        python_modules += recipe.python_depends
         recipe_loaded.append(name)
     graph.remove_remaining_conflicts(ctx)
     if len(graph.graphs) > 1:

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -80,6 +80,12 @@ class Recipe(object):
     string patch file and a callable, which will receive the kwargs `arch` and
     `recipe`, which should return True if the patch should be applied.'''
 
+    python_depends = []
+    '''A list of pure-Python packages that this package requires. These
+    packages will NOT be available at build time, but will be added to the
+    list of pure-Python packages to install via pip. If you need these packages
+    at build time, you must create a recipe.'''
+
     archs = ['armeabi']  # Not currently implemented properly
 
     @property


### PR DESCRIPTION
Currently you can add pure-Python packages to the requirements on the command line, but if added to the depends in a recipe they will only work if there is a recipe for that package. This allows you to specify pure-Python packages which you need installed without creating recipes for them.