### PR TITLE
fix prebuild for armeabi-v7a, make missing recipe error more informative

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -448,7 +448,7 @@ class Recipe(object):
         '''Run any pre-build tasks for the Recipe. By default, this checks if
         any prebuild_archname methods exist for the archname of the current
         architecture, and runs them if so.'''
-        prebuild = "prebuild_{}".format(arch.arch)
+        prebuild = "prebuild_{}".format(arch.arch.replace('-', '_'))
         if hasattr(self, prebuild):
             getattr(self, prebuild)()
         else:
@@ -570,7 +570,7 @@ class Recipe(object):
             recipe_file = None
 
         if not recipe_file:
-            raise IOError('Recipe folder does not exist')
+            raise IOError('Recipe does not exist: {}'.format(name))
 
         mod = import_recipe('pythonforandroid.recipes.{}'.format(name), recipe_file)
         if len(logger.handlers) > 1:


### PR DESCRIPTION
For armeabi-v7a, p4a will look for a function named `prebuild_armeabi-v7a`, which is an invalid name. This PR will make it look for `prebuild_armeabi_v7a` instead.