### PR TITLE
remove build dir before copying for IncludedFilesBehaviour

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -591,6 +591,7 @@ class IncludedFilesBehaviour(object):
         if self.src_filename is None:
             print('IncludedFilesBehaviour failed: no src_filename specified')
             exit(1)
+        shprint(sh.rm, '-rf', self.get_build_dir(arch))
         shprint(sh.cp, '-a', join(self.get_recipe_dir(), self.src_filename),
                 self.get_build_dir(arch))
 


### PR DESCRIPTION
Otherwise if the dir has already been copied, the new copy will be nested.