### PR TITLE
Fix -m compileall

### DIFF
--- a/pythonforandroid/bootstraps/pygame/__init__.py
+++ b/pythonforandroid/bootstraps/pygame/__init__.py
@@ -41,12 +41,15 @@ class PygameBootstrap(Bootstrap):
             shprint(sh.cp, '-a', join(src_path, 'res'), '.')
             shprint(sh.cp, '-a', join(src_path, 'blacklist.txt'), '.')
             shprint(sh.cp, '-a', join(src_path, 'whitelist.txt'), '.')
-            
+
             info('Copying python distribution')
             hostpython = sh.Command(self.ctx.hostpython)
             # AND: This *doesn't* need to be in arm env?
-            shprint(hostpython, '-OO', '-m', 'compileall', self.ctx.get_python_install_dir(),
-                    _tail=10, _filterout="^Listing", _critical=True)
+            try:
+                shprint(hostpython, '-OO', '-m', 'compileall', self.ctx.get_python_install_dir(),
+                        _tail=10, _filterout="^Listing")
+            except sh.ErrorReturnCode:
+                pass
             if not exists('python-install'):
                 shprint(sh.cp, '-a', self.ctx.get_python_install_dir(), './python-install')
 
@@ -58,7 +61,7 @@ class PygameBootstrap(Bootstrap):
             if not exists(join('private', 'lib')):
                 shprint(sh.cp, '-a', join('python-install', 'lib'), 'private')
             shprint(sh.mkdir, '-p', join('private', 'include', 'python2.7'))
-            
+
             # AND: Copylibs stuff should go here
             shprint(sh.mv, join('libs', arch.arch, 'libpymodules.so'), 'private/')
             shprint(sh.cp, join('python-install', 'include' , 'python2.7', 'pyconfig.h'), join('private', 'include', 'python2.7/'))


### PR DESCRIPTION
When i'm building a distribution with:

    p4a create -v --dist_name test --bootstrap pygame --requirements=kivy==1.9.1 --android_api=19 --force-build

I can't get to the end because it breaks to the python distribute part:

```
[INFO]:    Copying python distribution
[INFO]:    running python.host -OO -m compileall /home/tito/.local/share/python-for-android/build/python-installs/test
[INFO]:    STDOUT:
	Compiling /home/tito/.local/share/python-for-android/build/python-installs/test/lib/python2.7/json/tests/test_unicode.py ...
SyntaxError: ("(unicode error) \\N escapes not supported (can't load unicodedata module)", ('/home/tito/.local/share/python-for-android/build/python-installs/test/lib/python2.7/json/tests/test_unicode.py', 8, None, "u = u'\\N{GREEK SMALL LETTER ALPHA}\\N{GREEK CAPITAL LETTER OMEGA}'\n"))

Compiling /home/tito/.local/share/python-for-android/build/python-installs/test/lib/python2.7/lib2to3/tests/data/py3_test_grammar.py ...
SyntaxError: ('invalid syntax', ('/home/tito/.local/share/python-for-android/build/python-installs/test/lib/python2.7/lib2to3/tests/data/py3_test_grammar.py', 130, 13, '        x = ...\n'))
```

unicodedata module can't be loaded, so the \\N dont work. As for py3 compileall, it just can't work with python host compileall :)

I didn't search what changed about it, but making it non critical works.

(Should we do the same for others bootstraps ?)