### PR TITLE
sdl2/bootstrap: Restore GenericBroadcastReceiver/GenericBroadcastRece…

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/GenericBroadcastReceiver.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/GenericBroadcastReceiver.java
@@ -1,0 +1,19 @@
+package org.kivy.android;
+
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.Context;
+
+public class GenericBroadcastReceiver extends BroadcastReceiver {
+
+    GenericBroadcastReceiverCallback listener;
+
+    public GenericBroadcastReceiver(GenericBroadcastReceiverCallback listener) {
+        super();
+        this.listener = listener;
+    }
+
+    public void onReceive(Context context, Intent intent) {
+        this.listener.onReceive(context, intent);
+    }
+}

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/GenericBroadcastReceiverCallback.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/GenericBroadcastReceiverCallback.java
@@ -1,0 +1,8 @@
+package org.kivy.android;
+
+import android.content.Intent;
+import android.content.Context;
+
+public interface GenericBroadcastReceiverCallback {
+    void onReceive(Context context, Intent intent);
+};


### PR DESCRIPTION
Restore GenericBroadcastReceiver/GenericBroadcastReceiverCallback

Fix support of android broadcast call.
The android.broadcast is requiring it.

Because it's android only, there is a few interest to make it available in Plyer.