### PR TITLE
sdl2/bootstrap: add --add-jar and --intent-filters support

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -52,7 +52,10 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            {%- if args.intent_filters -%}
+            {{- args.intent_filters -}}
+            {%- endif -%}
         </activity>
     </application>
 
-</manifest> 
+</manifest>


### PR DESCRIPTION
Same behavior as the old toolchain, it allows to add other jar and other intent when building an application