### PR TITLE
use wget to download recipe url;

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -110,19 +110,9 @@ class Recipe(object):
 
         parsed_url = urlparse(url)
         if parsed_url.scheme in ('http', 'https'):
-            def report_hook(index, blksize, size):
-                if size <= 0:
-                    progression = '{0} bytes'.format(index * blksize)
-                else:
-                    progression = '{0:.2f}%'.format(
-                        index * blksize * 100. / float(size))
-                stdout.write('- Download {}\r'.format(progression))
-                stdout.flush()
-
             if exists(target):
                 unlink(target)
-
-            urlretrieve(url, target, report_hook)
+            urlretrieve(url, target)
             return target
         elif parsed_url.scheme in ('git', 'git+ssh', 'git+http', 'git+https'):
             if isdir(target):

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -6,10 +6,7 @@ import json
 import shutil
 import sys
 from tempfile import mkdtemp
-try:
-    from urllib.request import FancyURLopener
-except ImportError:
-    from urllib import FancyURLopener
+import wget
 
 from pythonforandroid.logger import (logger, Err_Fore)
 
@@ -21,12 +18,7 @@ else:
     unistr = unicode
 
 
-class ChromeDownloader(FancyURLopener):
-    version = (
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
-        '(KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36')
-
-urlretrieve = ChromeDownloader().retrieve
+urlretrieve = wget.download
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
use wget to download recipe url;
fixes #573

py-wget handles the HTTP 302 of sourceforge nicely.

also wget has a nice progress bar similar to the custom one in recipe.py I therefore removed that hook.