### PR TITLE
add option to not include cflags in cc

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -30,7 +30,7 @@ class Arch(object):
                 d.format(arch=self))
             for d in self.ctx.include_dirs]
 
-    def get_env(self):
+    def get_env(self, with_flags_in_cc=True):
         env = {}
 
         env["CFLAGS"] = " ".join([
@@ -72,14 +72,22 @@ class Arch(object):
                     'installed. Exiting.')
             exit(1)
 
-        env['CC'] = '{ccache}{command_prefix}-gcc {cflags}'.format(
-            command_prefix=command_prefix,
-            ccache=ccache,
-            cflags=env['CFLAGS'])
-        env['CXX'] = '{ccache}{command_prefix}-g++ {cxxflags}'.format(
-            command_prefix=command_prefix,
-            ccache=ccache,
-            cxxflags=env['CXXFLAGS'])
+        if with_flags_in_cc:
+            env['CC'] = '{ccache}{command_prefix}-gcc {cflags}'.format(
+                command_prefix=command_prefix,
+                ccache=ccache,
+                cflags=env['CFLAGS'])
+            env['CXX'] = '{ccache}{command_prefix}-g++ {cxxflags}'.format(
+                command_prefix=command_prefix,
+                ccache=ccache,
+                cxxflags=env['CXXFLAGS'])
+        else:
+            env['CC'] = '{ccache}{command_prefix}-gcc'.format(
+                command_prefix=command_prefix,
+                ccache=ccache)
+            env['CXX'] = '{ccache}{command_prefix}-g++'.format(
+                command_prefix=command_prefix,
+                ccache=ccache)
 
         env['AR'] = '{}-ar'.format(command_prefix)
         env['RANLIB'] = '{}-ranlib'.format(command_prefix)
@@ -118,8 +126,8 @@ class ArchARM(Arch):
 class ArchARMv7_a(ArchARM):
     arch = 'armeabi-v7a'
 
-    def get_env(self):
-        env = super(ArchARMv7_a, self).get_env()
+    def get_env(self, with_flags_in_cc=True):
+        env = super(ArchARMv7_a, self).get_env(with_flags_in_cc)
         env['CFLAGS'] = (env['CFLAGS'] +
                          (' -march=armv7-a -mfloat-abi=softfp '
                           '-mfpu=vfp -mthumb'))
@@ -133,8 +141,8 @@ class Archx86(Arch):
     command_prefix = 'i686-linux-android'
     platform_dir = 'arch-x86'
 
-    def get_env(self):
-        env = super(Archx86, self).get_env()
+    def get_env(self, with_flags_in_cc=True):
+        env = super(Archx86, self).get_env(with_flags_in_cc)
         env['CFLAGS'] = (env['CFLAGS'] +
                          ' -march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32')
         env['CXXFLAGS'] = env['CFLAGS']
@@ -147,8 +155,8 @@ class Archx86_64(Arch):
     command_prefix = 'x86_64-linux-android'
     platform_dir = 'arch-x86'
 
-    def get_env(self):
-        env = super(Archx86_64, self).get_env()
+    def get_env(self, with_flags_in_cc=True):
+        env = super(Archx86_64, self).get_env(with_flags_in_cc)
         env['CFLAGS'] = (env['CFLAGS'] +
                          ' -march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel')
         env['CXXFLAGS'] = env['CFLAGS']

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -443,12 +443,12 @@ class Recipe(object):
             else:
                 info('{} is already unpacked, skipping'.format(self.name))
 
-    def get_recipe_env(self, arch=None):
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         """Return the env specialized for the recipe
         """
         if arch is None:
             arch = self.filtered_archs[0]
-        return arch.get_env()
+        return arch.get_env(with_flags_in_cc=with_flags_in_cc)
 
     def prebuild_arch(self, arch):
         '''Run any pre-build tasks for the Recipe. By default, this checks if
@@ -896,8 +896,8 @@ class CythonRecipe(PythonRecipe):
     #         for filename in fnmatch.filter(filenames, "*.pyx"):
     #             self.cythonize_file(join(root, filename))
 
-    def get_recipe_env(self, arch):
-        env = super(CythonRecipe, self).get_recipe_env(arch)
+    def get_recipe_env(self, arch, with_flags_in_cc=True):
+        env = super(CythonRecipe, self).get_recipe_env(arch, with_flags_in_cc)
         env['LDFLAGS'] = env['LDFLAGS'] + ' -L{} '.format(
             self.ctx.get_libs_dir(arch.arch) +
             ' -L{} '.format(self.ctx.libs_dir))


### PR DESCRIPTION
Allows a recipe to specify that CFLAGS should not be present in CC. Some packages will complain about this behavior (and they're technically right).