### PR TITLE
add basic env-based overrides for recipe version and url

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -585,7 +585,12 @@ def run_pymodules_install(ctx, modules):
         info('Creating a requirements.txt file for the Python modules')
         with open('requirements.txt', 'w') as fileh:
             for module in modules:
-                fileh.write('{}\n'.format(module))
+                key = 'VERSION_' + module
+                if key in environ:
+                    line = '{}=={}\n'.format(module, environ[key])
+                else:
+                    line = '{}\n'.format(module)
+                fileh.write(line)
 
         info('Installing Python modules with pip')
         info('If this fails with a message about /bin/false, this '

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -2,7 +2,7 @@ from os.path import join, dirname, isdir, exists, isfile, split, realpath
 import importlib
 import zipfile
 import glob
-from six import PY2
+from six import PY2, with_metaclass
 
 import sh
 import shutil
@@ -37,8 +37,19 @@ else:
             return SourceFileLoader(module, filename).load_module()
 
 
-class Recipe(object):
-    url = None
+class RecipeMeta(type):
+    def __new__(cls, name, bases, dct):
+        if name != 'Recipe':
+            if 'url' in dct:
+                dct['_url'] = dct.pop('url')
+            if 'version' in dct:
+                dct['_version'] = dct.pop('version')
+
+        return super(RecipeMeta, cls).__new__(cls, name, bases, dct)
+
+
+class Recipe(with_metaclass(RecipeMeta)):
+    _url = None
     '''The address from which the recipe may be downloaded. This is not
     essential, it may be omitted if the source is available some other
     way, such as via the :class:`IncludedFilesBehaviour` mixin.
@@ -52,7 +63,7 @@ class Recipe(object):
               if you want.
     '''
 
-    version = None
+    _version = None
     '''A string giving the version of the software the recipe describes,
     e.g. ``2.0.3`` or ``master``.'''
 
@@ -87,6 +98,16 @@ class Recipe(object):
     at build time, you must create a recipe.'''
 
     archs = ['armeabi']  # Not currently implemented properly
+
+    @property
+    def version(self):
+        key = 'VERSION_' + self.name
+        return environ.get(key, self._version)
+
+    @property
+    def url(self):
+        key = 'URL_' + self.name
+        return environ.get(key, self._url)
 
     @property
     def versioned_url(self):


### PR DESCRIPTION
Allows versions and URLs for recipes to be specified via the environment variables `VERSION_recipename` and `URL_recipename`. Should be trivial to add requirements-style support (i.e. `recipename==1.2.3` in requirements).