### PR TITLE
add openssl support

### DIFF
--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -1,0 +1,30 @@
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+
+
+class CffiRecipe(CompiledComponentsPythonRecipe):
+	name = 'cffi'
+	version = '1.4.2'
+	url = 'https://pypi.python.org/packages/source/c/cffi/cffi-{version}.tar.gz'
+
+	depends = [('python2', 'python3'), 'setuptools', 'pycparser', 'libffi']
+
+	patches = ['disable-pkg-config.patch']
+
+	# call_hostpython_via_targetpython = False
+	install_in_hostpython = True
+
+	def get_recipe_env(self, arch=None):
+		env = super(CffiRecipe, self).get_recipe_env(arch)
+		libffi = self.get_recipe('libffi', self.ctx)
+		includes = libffi.get_include_dirs(arch)
+		env['CFLAGS'] = ' -I'.join([env.get('CFLAGS', '')] + includes)
+		env['LDFLAGS'] = (env.get('CFLAGS', '') + ' -L' +
+		                  self.ctx.get_libs_dir(arch.arch))
+		env['PYTHONPATH'] = ':'.join([
+			self.ctx.get_site_packages_dir(),
+			env['BUILDLIB_PATH'],
+		])
+		return env
+
+
+recipe = CffiRecipe()

--- a/pythonforandroid/recipes/cffi/disable-pkg-config.patch
+++ b/pythonforandroid/recipes/cffi/disable-pkg-config.patch
@@ -1,0 +1,29 @@
+diff -Naur cffi-1.4.2/setup.py b/setup.py
+--- cffi-1.4.2/setup.py	2015-12-21 12:09:47.000000000 -0600
++++ b/setup.py	2015-12-23 10:20:40.590622524 -0600
+@@ -5,8 +5,7 @@
+ 
+ sources = ['c/_cffi_backend.c']
+ libraries = ['ffi']
+-include_dirs = ['/usr/include/ffi',
+-                '/usr/include/libffi']    # may be changed by pkg-config
++include_dirs = []
+ define_macros = []
+ library_dirs = []
+ extra_compile_args = []
+@@ -67,14 +66,7 @@
+         sys.stderr.write("The above error message can be safely ignored\n")
+ 
+ def use_pkg_config():
+-    if sys.platform == 'darwin' and os.path.exists('/usr/local/bin/brew'):
+-        use_homebrew_for_libffi()
+-
+-    _ask_pkg_config(include_dirs,       '--cflags-only-I', '-I', sysroot=True)
+-    _ask_pkg_config(extra_compile_args, '--cflags-only-other')
+-    _ask_pkg_config(library_dirs,       '--libs-only-L', '-L', sysroot=True)
+-    _ask_pkg_config(extra_link_args,    '--libs-only-other')
+-    _ask_pkg_config(libraries,          '--libs-only-l', '-l')
++    pass
+ 
+ def use_homebrew_for_libffi():
+     # We can build by setting:

--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -1,0 +1,40 @@
+from os.path import dirname, join
+
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+
+
+class CryptographyRecipe(CompiledComponentsPythonRecipe):
+	name = 'cryptography'
+	version = '1.1.2'
+	url = 'https://pypi.python.org/packages/source/c/cryptography/cryptography-{version}.tar.gz'
+
+	depends = [('python2', 'python3'), 'cffi', 'enum34', 'openssl', 'ipaddress', 'idna']
+
+	patches = ['fix-cffi-path.patch',
+	           'link-static.patch']
+
+	# call_hostpython_via_targetpython = False
+
+	def get_recipe_env(self, arch=None):
+		env = super(CryptographyRecipe, self).get_recipe_env(arch)
+	# 	# libffi = self.get_recipe('libffi', self.ctx)
+	# 	# includes = libffi.get_include_dirs(arch)
+	# 	# env['CFLAGS'] = ' -I'.join([env.get('CFLAGS', '')] + includes)
+	# 	# env['LDFLAGS'] = (env.get('CFLAGS', '') + ' -L' +
+	# 	#                   self.ctx.get_libs_dir(arch.arch))
+		openssl = self.get_recipe('openssl', self.ctx)
+		openssl_dir = openssl.get_build_dir(arch.arch)
+		env['CFLAGS'] = env.get('CFLAGS', '') + ' -I' + join(openssl_dir, 'include')
+		# env['LDFLAGS'] = env.get('LDFLAGS', '') + ' -L' + openssl.get_build_dir(arch.arch)
+		env['LIBSSL'] = join(openssl_dir, 'libssl.a')
+		env['LIBCRYPTO'] = join(openssl_dir, 'libcrypto.a')
+		env['PYTHONPATH'] = ':'.join([
+			join(dirname(self.real_hostpython_location), 'Lib'),
+			join(dirname(self.real_hostpython_location), 'Lib', 'site-packages'),
+			env['BUILDLIB_PATH'],
+		])
+		print env
+		return env
+
+
+recipe = CryptographyRecipe()

--- a/pythonforandroid/recipes/cryptography/fix-cffi-path.patch
+++ b/pythonforandroid/recipes/cryptography/fix-cffi-path.patch
@@ -1,0 +1,14 @@
+diff -Naur cryptography/setup.py b/setup.py
+--- cryptography/setup.py	2015-12-10 13:53:28.000000000 -0600
++++ b/setup.py	2015-12-23 12:12:22.830287138 -0600
+@@ -18,6 +18,10 @@
+ from setuptools.command.install import install
+ from setuptools.command.test import test
+ 
++import sys
++for d in sys.path[:]:
++    if 'python-installs' in d:
++        sys.path.remove(d)
+ 
+ base_dir = os.path.dirname(__file__)
+ src_dir = os.path.join(base_dir, "src")

--- a/pythonforandroid/recipes/cryptography/link-static.patch
+++ b/pythonforandroid/recipes/cryptography/link-static.patch
@@ -1,0 +1,64 @@
+--- cryptography/src/_cffi_src/build_openssl.py	2015-12-10 13:53:28.000000000 -0600
++++ b/src/_cffi_src/build_openssl.py	2016-01-06 14:58:59.735728893 -0600
+@@ -10,50 +10,6 @@
+ from _cffi_src.utils import build_ffi_for_binding, extra_link_args
+ 
+ 
+-def _get_openssl_libraries(platform):
+-    # OpenSSL goes by a different library name on different operating systems.
+-    if platform == "darwin":
+-        return _osx_libraries(
+-            os.environ.get("CRYPTOGRAPHY_OSX_NO_LINK_FLAGS")
+-        )
+-    elif platform == "win32":
+-        return ["libeay32", "ssleay32", "advapi32",
+-                "crypt32", "gdi32", "user32", "ws2_32"]
+-    else:
+-        # In some circumstances, the order in which these libs are
+-        # specified on the linker command-line is significant;
+-        # libssl must come before libcrypto
+-        # (http://marc.info/?l=openssl-users&m=135361825921871)
+-        return ["ssl", "crypto"]
+-
+-
+-def _osx_libraries(build_static):
+-    # For building statically we don't want to pass the -lssl or -lcrypto flags
+-    if build_static == "1":
+-        return []
+-    else:
+-        return ["ssl", "crypto"]
+-
+-
+-_OSX_PRE_INCLUDE = """
+-#ifdef __APPLE__
+-#include <AvailabilityMacros.h>
+-#define __ORIG_DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER \
+-    DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+-#undef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+-#define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+-#endif
+-"""
+-
+-_OSX_POST_INCLUDE = """
+-#ifdef __APPLE__
+-#undef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+-#define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER \
+-    __ORIG_DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+-#endif
+-"""
+-
+-
+ ffi = build_ffi_for_binding(
+     module_name="_openssl",
+     module_prefix="_cffi_src.openssl.",
+@@ -89,8 +45,6 @@
+         "x509_vfy",
+         "pkcs7",
+     ],
+-    pre_include=_OSX_PRE_INCLUDE,
+-    post_include=_OSX_POST_INCLUDE,
+-    libraries=_get_openssl_libraries(sys.platform),
+-    extra_link_args=extra_link_args(sys.platform),
++    libraries=[],
++    extra_link_args=[os.environ['LIBSSL'], os.environ['LIBCRYPTO']],
+ )

--- a/pythonforandroid/recipes/idna/__init__.py
+++ b/pythonforandroid/recipes/idna/__init__.py
@@ -1,0 +1,14 @@
+from pythonforandroid.recipe import PythonRecipe
+
+
+class IdnaRecipe(PythonRecipe):
+	name = 'idna'
+	version = '2.0'
+	url = 'https://pypi.python.org/packages/source/i/idna/idna-{version}.tar.gz'
+
+	depends = [('python2', 'python3'), 'setuptools']
+
+	call_hostpython_via_targetpython = False
+
+
+recipe = IdnaRecipe()

--- a/pythonforandroid/recipes/ipaddress/__init__.py
+++ b/pythonforandroid/recipes/ipaddress/__init__.py
@@ -1,0 +1,12 @@
+from pythonforandroid.recipe import PythonRecipe
+
+
+class IpaddressRecipe(PythonRecipe):
+	name = 'ipaddress'
+	version = '1.0.15'
+	url = 'https://pypi.python.org/packages/source/i/ipaddress/ipaddress-{version}.tar.gz'
+
+	depends = ['python2']
+
+
+recipe = IpaddressRecipe()

--- a/pythonforandroid/recipes/libffi/Application.mk
+++ b/pythonforandroid/recipes/libffi/Application.mk
@@ -1,0 +1,3 @@
+APP_OPTIM := release
+APP_ABI := all # or armeabi
+APP_MODULES := libffi

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -1,0 +1,69 @@
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.logger import shprint
+from pythonforandroid.util import current_directory
+from os.path import exists, join
+import sh
+import glob
+
+
+class LibffiRecipe(Recipe):
+	name = 'libffi'
+	version = 'v3.2.1'
+	url = 'https://github.com/atgreen/libffi/archive/{version}.zip'
+
+	patches = ['remove-version-info.patch']
+
+	host = 'arm-unknown-linux-androideabi'
+
+	def should_build(self, arch):
+		# return not bool(glob.glob(join(self.ctx.get_libs_dir(arch.arch),
+		#                                'libffi.so*')))
+		return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
+		# return not exists(join(self.ctx.get_python_install_dir(), 'lib',
+		#                        'libffi.so'))
+
+	def build_arch(self, arch):
+		env = self.get_recipe_env(arch)
+		with current_directory(self.get_build_dir(arch.arch)):
+			if not exists('configure'):
+				shprint(sh.Command('./autogen.sh'), _env=env)
+			shprint(sh.Command('./configure'), '--host=arm-linux-androideabi',
+			        '--prefix=' + self.ctx.get_python_install_dir(),
+			        '--enable-shared', _env=env)
+			shprint(sh.make, '-j5', 'libffi.la', _env=env)
+
+			host = None
+			with open('Makefile') as f:
+				for line in f:
+					if line.startswith('host = '):
+						host = line.strip()[7:]
+						break
+
+			if not host or not exists(host):
+				raise RuntimeError('failed to find build output! ({})'
+				                   .format(host))
+
+			self.host = host
+
+			# dlname = None
+			# with open(join(host, 'libffi.la')) as f:
+			# 	for line in f:
+			# 		if line.startswith('dlname='):
+			# 			dlname = line.strip()[8:-1]
+			# 			break
+			# 
+			# if not dlname or not exists(join(host, '.libs', dlname)):
+			# 	raise RuntimeError('failed to locate shared object! ({})'
+			# 	                   .format(dlname))
+
+			# shprint(sh.sed, '-i', 's/^dlname=.*$/dlname=\'libffi.so\'/', join(host, 'libffi.la'))
+
+			shprint(sh.cp, '-t', self.ctx.get_libs_dir(arch.arch),
+			        join(host, '.libs', 'libffi.so')) #,
+			        # join(host, 'libffi.la'))
+
+	def get_include_dirs(self, arch):
+		return [join(self.get_build_dir(arch.arch), self.host, 'include')]
+
+
+recipe = LibffiRecipe()

--- a/pythonforandroid/recipes/libffi/disable-mips-check.patch
+++ b/pythonforandroid/recipes/libffi/disable-mips-check.patch
@@ -1,0 +1,35 @@
+diff -Naur libffi/Android.mk b/Android.mk
+--- libffi/Android.mk	2015-12-22 17:00:48.025478556 -0600
++++ b/Android.mk	2015-12-22 17:02:23.999249390 -0600
+@@ -23,23 +23,20 @@
+ # Build rules for the target.
+ #
+ 
+-# We only build ffi for mips.
+-ifeq ($(TARGET_ARCH),mips)
+ 
+-   include $(CLEAR_VARS)
++include $(CLEAR_VARS)
+ 
+-   ffi_arch := $(TARGET_ARCH)
+-   ffi_os := $(TARGET_OS)
++ffi_arch := $(TARGET_ARCH)
++ffi_os := $(TARGET_OS)
+ 
+-   # This include just keeps the nesting a bit saner.
+-   include $(LOCAL_PATH)/Libffi.mk
++# This include just keeps the nesting a bit saner.
++include $(LOCAL_PATH)/Libffi.mk
+ 
+-   LOCAL_MODULE_TAGS := optional
+-   LOCAL_MODULE := libffi
++LOCAL_MODULE_TAGS := optional
++LOCAL_MODULE := libffi
+ 
+-   include $(BUILD_SHARED_LIBRARY)
++include $(BUILD_SHARED_LIBRARY)
+ 
+-endif
+ 
+ # Also include the rules for the test suite.
+ include external/libffi/testsuite/Android.mk

--- a/pythonforandroid/recipes/libffi/remove-version-info.patch
+++ b/pythonforandroid/recipes/libffi/remove-version-info.patch
@@ -1,0 +1,12 @@
+diff -Naur libffi/Makefile.am b/Makefile.am
+--- libffi/Makefile.am	2014-11-12 06:00:59.000000000 -0600
++++ b/Makefile.am	2015-12-23 15:57:10.363148806 -0600
+@@ -249,7 +249,7 @@
+ AM_CFLAGS += -DFFI_DEBUG
+ endif
+ 
+-libffi_la_LDFLAGS = -no-undefined -version-info `grep -v '^\#' $(srcdir)/libtool-version` $(LTLDFLAGS) $(AM_LTLDFLAGS)
++libffi_la_LDFLAGS = -no-undefined -avoid-version $(LTLDFLAGS) $(AM_LTLDFLAGS)
+ 
+ AM_CPPFLAGS = -I. -I$(top_srcdir)/include -Iinclude -I$(top_srcdir)/src
+ AM_CCASFLAGS = $(AM_CPPFLAGS)

--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -1,6 +1,6 @@
+from functools import partial
 
 from pythonforandroid.toolchain import Recipe, shprint, current_directory
-from os.path import exists, join
 import sh
 
 
@@ -9,7 +9,22 @@ class OpenSSLRecipe(Recipe):
     url = 'https://www.openssl.org/source/openssl-{version}.tar.gz'
 
     def should_build(self, arch):
-        return not exists(join(self.get_build_dir(arch.arch), 'libssl.a'))
+        return not self.has_libs(arch, 'libssl.so', 'libcrypto.so')
+
+    def check_symbol(self, env, sofile, symbol):
+        nm = env.get('NM', 'nm')
+        syms = sh.sh('-c', "{} -gp {} | cut -d' ' -f3".format(
+                nm, sofile), _env=env).splitlines()
+        if symbol in syms:
+            return True
+        print('{} missing symbol {}; rebuilding'.format(sofile, symbol))
+        return False
+
+    def get_recipe_env(self, arch=None):
+        env = super(OpenSSLRecipe, self).get_recipe_env(arch)
+        env['CFLAGS'] += ' ' + env['LDFLAGS']
+        env['CC'] += ' ' + env['LDFLAGS']
+        return env
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
@@ -17,7 +32,17 @@ class OpenSSLRecipe(Recipe):
             # sh fails with code 255 trying to execute ./Configure
             # so instead we manually run perl passing in Configure
             perl = sh.Command('perl')
-            shprint(perl, 'Configure', 'no-dso', 'no-krb5', 'linux-armv4', _env=env)
-            shprint(sh.make, 'build_libs', _env=env)
+            shprint(perl, 'Configure', 'shared', 'no-dso', 'no-krb5', 'linux-armv4', _env=env)
+            self.apply_patch('disable-sover.patch', arch.arch)
+
+            check_crypto = partial(self.check_symbol, env, 'libcrypto.so')
+            # check_ssl = partial(self.check_symbol, env, 'libssl.so')
+            while True:
+                shprint(sh.make, 'build_libs', _env=env)
+                if all(map(check_crypto, ('SSLeay', 'MD5_Transform', 'MD4_Init'))):
+                    break
+                shprint(sh.make, 'clean', _env=env)
+
+            self.install_libs(arch, 'libssl.so', 'libcrypto.so')
 
 recipe = OpenSSLRecipe()

--- a/pythonforandroid/recipes/openssl/disable-sover.patch
+++ b/pythonforandroid/recipes/openssl/disable-sover.patch
@@ -1,0 +1,20 @@
+--- openssl/Makefile	2015-12-28 16:48:49.159522273 -0600
++++ b/Makefile	2015-12-29 10:31:54.358438402 -0600
+@@ -343,7 +343,7 @@
+ link-shared:
+ 	@ set -e; for i in $(SHLIBDIRS); do \
+ 		$(MAKE) -f $(HERE)/Makefile.shared -e $(BUILDENV) \
+-			LIBNAME=$$i LIBVERSION=$(SHLIB_MAJOR).$(SHLIB_MINOR) \
++			LIBNAME=$$i LIBVERSION= \
+ 			LIBCOMPATVERSIONS=";$(SHLIB_VERSION_HISTORY)" \
+ 			symlink.$(SHLIB_TARGET); \
+ 		libs="$$libs -l$$i"; \
+@@ -357,7 +357,7 @@
+ 			libs="$(LIBKRB5) $$libs"; \
+ 		fi; \
+ 		$(CLEARENV) && $(MAKE) -f Makefile.shared -e $(BUILDENV) \
+-			LIBNAME=$$i LIBVERSION=$(SHLIB_MAJOR).$(SHLIB_MINOR) \
++			LIBNAME=$$i LIBVERSION= \
+ 			LIBCOMPATVERSIONS=";$(SHLIB_VERSION_HISTORY)" \
+ 			LIBDEPS="$$libs $(EX_LIBS)" \
+ 			link_a.$(SHLIB_TARGET); \

--- a/pythonforandroid/recipes/pycparser/__init__.py
+++ b/pythonforandroid/recipes/pycparser/__init__.py
@@ -1,0 +1,16 @@
+from pythonforandroid.recipe import PythonRecipe
+
+
+class PycparserRecipe(PythonRecipe):
+	name = 'pycparser'
+	version = '2.14'
+	url = 'https://pypi.python.org/packages/source/p/pycparser/pycparser-{version}.tar.gz'
+
+	depends = [('python2', 'python3'), 'setuptools']
+
+	call_hostpython_via_targetpython = False
+
+	install_in_hostpython = True
+
+
+recipe = PycparserRecipe()

--- a/pythonforandroid/recipes/pyopenssl/__init__.py
+++ b/pythonforandroid/recipes/pyopenssl/__init__.py
@@ -1,38 +1,14 @@
 
-from pythonforandroid.toolchain import (
-    CompiledComponentsPythonRecipe,
-    Recipe,
-    current_directory,
-    info,
-    shprint,
-)
-from os.path import exists, join
-import sh
-import glob
+from pythonforandroid.toolchain import PythonRecipe
 
 
-class PyOpenSSLRecipe(CompiledComponentsPythonRecipe):
-    version = '0.13'
+class PyOpenSSLRecipe(PythonRecipe):
+    version = '0.14'
     url = 'https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-{version}.tar.gz'
-    depends = ['openssl', 'python2']
+    depends = ['openssl', 'python2', 'setuptools']
+    site_packages_name = 'OpenSSL'
 
-    def prebuild_arch(self, arch):
-        super(PyOpenSSLRecipe, self).prebuild_arch(arch)
-        build_dir = self.get_build_dir(arch.arch)
-        if exists(join(build_dir, '.patched')):
-            print('pyOpenSSL already patched, skipping')
-            return
-        self.apply_patch('fix-dlfcn.patch', arch.arch)
-        shprint(sh.touch, join(build_dir, '.patched'))
+    call_hostpython_via_targetpython = False
 
-    def get_recipe_env(self, arch):
-        env = super(PyOpenSSLRecipe, self).get_recipe_env(arch)
-        openssl_build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
-        env['CC'] = '%s -I%s' % (env['CC'], join(openssl_build_dir, 'include'))
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
-            self.ctx.get_libs_dir(arch.arch) +
-            '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
-            openssl_build_dir)
-        return env
 
 recipe = PyOpenSSLRecipe()

--- a/pythonforandroid/recipes/python2/Setup.local-ssl
+++ b/pythonforandroid/recipes/python2/Setup.local-ssl
@@ -1,0 +1,4 @@
+SSL=
+_ssl _ssl.c \
+  -DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
+  -L$(SSL) -lssl -lcrypto

--- a/pythonforandroid/recipes/python2/patches/disable-openpty.patch
+++ b/pythonforandroid/recipes/python2/patches/disable-openpty.patch
@@ -1,0 +1,59 @@
+--- python2/Modules/posixmodule.c	2016-01-05 15:54:39.504651722 -0600
++++ b/Modules/posixmodule.c	2016-01-05 16:01:48.072559330 -0600
+@@ -3743,54 +3743,8 @@
+ static PyObject *
+ posix_openpty(PyObject *self, PyObject *noargs)
+ {
+-    int master_fd, slave_fd;
+-#ifndef HAVE_OPENPTY
+-    char * slave_name;
+-#endif
+-#if defined(HAVE_DEV_PTMX) && !defined(HAVE_OPENPTY) && !defined(HAVE__GETPTY)
+-    PyOS_sighandler_t sig_saved;
+-#ifdef sun
+-    extern char *ptsname(int fildes);
+-#endif
+-#endif
+-
+-#ifdef HAVE_OPENPTY
+-    if (openpty(&master_fd, &slave_fd, NULL, NULL, NULL) != 0)
+-        return posix_error();
+-#elif defined(HAVE__GETPTY)
+-    slave_name = _getpty(&master_fd, O_RDWR, 0666, 0);
+-    if (slave_name == NULL)
+-        return posix_error();
+-
+-    slave_fd = open(slave_name, O_RDWR);
+-    if (slave_fd < 0)
+-        return posix_error();
+-#else
+-    master_fd = open(DEV_PTY_FILE, O_RDWR | O_NOCTTY); /* open master */
+-    if (master_fd < 0)
+-        return posix_error();
+-    sig_saved = PyOS_setsig(SIGCHLD, SIG_DFL);
+-    /* change permission of slave */
+-    if (grantpt(master_fd) < 0) {
+-        PyOS_setsig(SIGCHLD, sig_saved);
+-        return posix_error();
+-    }
+-    /* unlock slave */
+-    if (unlockpt(master_fd) < 0) {
+-        PyOS_setsig(SIGCHLD, sig_saved);
+-        return posix_error();
+-    }
+-    PyOS_setsig(SIGCHLD, sig_saved);
+-    slave_name = ptsname(master_fd); /* get name of slave */
+-    if (slave_name == NULL)
+-        return posix_error();
+-    slave_fd = open(slave_name, O_RDWR | O_NOCTTY); /* open slave */
+-    if (slave_fd < 0)
+-        return posix_error();
+-#endif /* HAVE_OPENPTY */
+-
+-    return Py_BuildValue("(ii)", master_fd, slave_fd);
+-
++    PyErr_SetString(PyExc_NotImplementedError, "openpty not implemented for this build");
++    return NULL;
+ }
+ #endif /* defined(HAVE_OPENPTY) || defined(HAVE__GETPTY) || defined(HAVE_DEV_PTMX) */
+ 

--- a/pythonforandroid/recipes/python2/patches/enable-ssl.patch
+++ b/pythonforandroid/recipes/python2/patches/enable-ssl.patch
@@ -1,0 +1,17 @@
+--- python2/Modules/Setup.dist	2011-06-11 10:46:26.000000000 -0500
++++ b/Modules/Setup.dist	2015-12-28 16:18:13.329648940 -0600
+@@ -211,10 +211,10 @@
+ 
+ # Socket module helper for SSL support; you must comment out the other
+ # socket line above, and possibly edit the SSL variable:
+-#SSL=/usr/local/ssl
+-#_ssl _ssl.c \
+-#	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
+-#	-L$(SSL)/lib -lssl -lcrypto
++SSL=/p4a/path/to/openssl
++_ssl _ssl.c \
++	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
++	-L$(SSL) -lssl -lcrypto
+ 
+ # The crypt module is now disabled by default because it breaks builds
+ # on many systems (where -lcrypt is needed), e.g. Linux (I believe).


### PR DESCRIPTION
Compiles python2 with openssl support, and includes related recipes: cffi, cryptography, idna, ipaddress, libffi, pycparser