### PR TITLE
add aarch64/arm64-v8a arch

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -1,4 +1,4 @@
-from os.path import (join)
+from os.path import (join, dirname)
 from os import environ, uname
 import sys
 from distutils.spawn import find_executable
@@ -161,3 +161,22 @@ class Archx86_64(Arch):
                          ' -march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel')
         env['CXXFLAGS'] = env['CFLAGS']
         return env
+
+
+class ArchAarch_64(Arch):
+    arch = 'arm64-v8a'
+    toolchain_prefix = 'aarch64-linux-android'
+    command_prefix = 'aarch64-linux-android'
+    platform_dir = 'arch-arm64'
+
+    def get_env(self, with_flags_in_cc=True):
+        env = super(ArchAarch_64, self).get_env(with_flags_in_cc)
+        incpath = ' -I' + join(dirname(__file__), 'includes', 'arm64-v8a')
+        env['EXTRA_CFLAGS'] = incpath
+        env['CFLAGS'] += incpath
+        env['CXXFLAGS'] += incpath
+        if with_flags_in_cc:
+            env['CC'] += incpath
+            env['CXX'] += incpath
+        return env
+

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -1,4 +1,4 @@
-from os.path import (join, dirname, isdir, splitext, basename)
+from os.path import (join, dirname, isdir, splitext, basename, realpath)
 from os import listdir
 import sh
 import glob
@@ -253,3 +253,14 @@ class Bootstrap(object):
                 strip(filen, _env=env)
             except sh.ErrorReturnCode_1:
                 logger.debug('Failed to strip ' + filen)
+
+    def fry_eggs(self, sitepackages):
+        info('Frying eggs in {}'.format(sitepackages))
+        for d in listdir(sitepackages):
+            rd = join(sitepackages, d)
+            if isdir(rd) and d.endswith('.egg'):
+                info('  ' + d)
+                files = [join(rd, f) for f in listdir(rd) if f != 'EGG-INFO']
+                shprint(sh.mv, '-t', sitepackages, *files)
+                shprint(sh.rm, '-rf', d)
+

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -64,7 +64,9 @@ class SDL2Bootstrap(Bootstrap):
                 shprint(sh.rm, '-f', join('private', 'lib', 'libpython2.7.so'))
                 shprint(sh.rm, '-rf', join('private', 'lib', 'pkgconfig'))
 
-                with current_directory(join(self.dist_dir, 'private', 'lib', 'python2.7')):
+                libdir = join(self.dist_dir, 'private', 'lib', 'python2.7')
+                site_packages_dir = join(libdir, 'site-packages')
+                with current_directory(libdir):
                     # shprint(sh.xargs, 'rm', sh.grep('-E', '*\.(py|pyx|so\.o|so\.a|so\.libs)$', sh.find('.')))
                     removes = []
                     for dirname, something, filens in walk('.'):
@@ -107,6 +109,7 @@ class SDL2Bootstrap(Bootstrap):
 
 
         self.strip_libraries(arch)
+        self.fry_eggs(site_packages_dir)
         super(SDL2Bootstrap, self).run_distribute()
 
 bootstrap = SDL2Bootstrap()

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -12,7 +12,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include
 LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 	start.c
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7
+LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS)
 
 LOCAL_SHARED_LIBRARIES := SDL2 python_shared
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -14,7 +14,7 @@ from pythonforandroid.util import (ensure_dir, current_directory)
 from pythonforandroid.logger import (info, warning, error, info_notify,
                                      Err_Fore, Err_Style, info_main,
                                      shprint)
-from pythonforandroid.archs import ArchARM, ArchARMv7_a, Archx86, Archx86_64
+from pythonforandroid.archs import ArchARM, ArchARMv7_a, Archx86, Archx86_64, ArchAarch_64
 from pythonforandroid.recipe import Recipe
 
 DEFAULT_ANDROID_API = 15
@@ -432,7 +432,8 @@ class Context(object):
         self.archs = (
             ArchARM(self),
             ArchARMv7_a(self),
-            Archx86(self)
+            Archx86(self),
+            ArchAarch_64(self),
             )
 
         ensure_dir(join(self.build_dir, 'bootstrap_builds'))

--- a/pythonforandroid/recipes/cdecimal/__init__.py
+++ b/pythonforandroid/recipes/cdecimal/__init__.py
@@ -16,7 +16,11 @@ class CdecimalRecipe(CompiledComponentsPythonRecipe):
     def prebuild_arch(self, arch):
         super(CdecimalRecipe, self).prebuild_arch(arch)
         if not is_darwin():
-            self.setup_extra_args = ['--with-machine=ansi32']
+            if '64' in arch.arch:
+                machine = 'ansi64'
+            else:
+                machine = 'ansi32'
+            self.setup_extra_args = ['--with-machine=' + machine]
 
 
 recipe = CdecimalRecipe()

--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -36,5 +36,8 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
 		print env
 		return env
 
+	def build_arch(self, arch):
+		super(CryptographyRecipe, self).build_arch(arch)
+
 
 recipe = CryptographyRecipe()

--- a/pythonforandroid/recipes/sdl2_image/__init__.py
+++ b/pythonforandroid/recipes/sdl2_image/__init__.py
@@ -8,7 +8,9 @@ class LibSDL2Image(BootstrapNDKRecipe):
     dir_name = 'SDL2_image'
 
     patches = ['disable_webp.patch',
-               ('disable_jpg.patch', is_arch('x86'))]
+               ('disable_jpg.patch', is_arch('x86')),
+               'extra-cflags.patch',
+               ('disable-assembler.patch', is_arch('arm64-v8a'))]
 
 
 recipe = LibSDL2Image()

--- a/pythonforandroid/recipes/sdl2_image/disable-assembler.patch
+++ b/pythonforandroid/recipes/sdl2_image/disable-assembler.patch
@@ -1,0 +1,11 @@
+--- SDL2_image/Android.mk	2016-01-14 14:08:07.989191133 -0600
++++ b/Android.mk	2016-01-14 14:09:53.439136814 -0600
+@@ -77,7 +77,7 @@
+         $(JPG_LIBRARY_PATH)/jfdctfst.c \
+         $(JPG_LIBRARY_PATH)/jfdctint.c \
+         $(JPG_LIBRARY_PATH)/jidctflt.c \
+-        $(JPG_LIBRARY_PATH)/jidctfst.S \
++        $(JPG_LIBRARY_PATH)/jidctfst.c \
+         $(JPG_LIBRARY_PATH)/jidctint.c \
+         $(JPG_LIBRARY_PATH)/jquant1.c \
+         $(JPG_LIBRARY_PATH)/jquant2.c \

--- a/pythonforandroid/recipes/sdl2_image/extra-cflags.patch
+++ b/pythonforandroid/recipes/sdl2_image/extra-cflags.patch
@@ -1,0 +1,11 @@
+--- SDL2_image/Android.mk	2016-01-14 13:55:28.195171992 -0600
++++ b/Android.mk	2016-01-14 13:55:15.038929244 -0600
+@@ -23,7 +23,7 @@
+ LOCAL_C_INCLUDES := $(LOCAL_PATH)
+ LOCAL_CFLAGS := -DLOAD_BMP -DLOAD_GIF -DLOAD_LBM -DLOAD_PCX -DLOAD_PNM \
+                 -DLOAD_TGA -DLOAD_XCF -DLOAD_XPM -DLOAD_XV
+-LOCAL_CFLAGS += -O3 -fstrict-aliasing -fprefetch-loop-arrays
++LOCAL_CFLAGS += -O3 -fstrict-aliasing -fprefetch-loop-arrays $(EXTRA_CFLAGS)
+ 
+ LOCAL_SRC_FILES := $(notdir $(filter-out %/showimage.c, $(wildcard $(LOCAL_PATH)/*.c)))
+ 


### PR DESCRIPTION
Didn't work 100% for me, but it's a start. I had a weird issue with missing symbol `valloc` for libmysql.so, might just be a problem for that recipe though.

Also had to get rid of egg folders - for some reason bionic won't accept so paths longer than 128 characters in my arm64 builds, even though it never had an issue with the armeabi-v7a builds using the same paths.