### PR TITLE
SDL2: implement support for loadingscreen

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/libsdl/app/SDLActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/libsdl/app/SDLActivity.java
@@ -54,7 +54,7 @@ public class SDLActivity extends Activity {
 
     // This is what SDL runs in. It invokes SDL_main(), eventually
     protected static Thread mSDLThread;
-    
+
     // Audio
     protected static AudioTrack mAudioTrack;
 
@@ -83,7 +83,7 @@ public class SDLActivity extends Activity {
           System.loadLibrary(lib);
        }
     }
-    
+
     /**
      * This method is called by SDL before starting the native application thread.
      * It can be overridden to provide the arguments after the application name.
@@ -93,7 +93,7 @@ public class SDLActivity extends Activity {
     protected String[] getArguments() {
         return new String[0];
     }
-    
+
     public static void initialize() {
         // The static nature of the singleton and Android quirkyness force us to initialize everything here
         // Otherwise, when exiting the app and returning to it, these variables *keep* their pre exit values
@@ -114,11 +114,11 @@ public class SDLActivity extends Activity {
     // Setup
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.v("SDL", "Device: " + android.os.Build.DEVICE);                     
+        Log.v("SDL", "Device: " + android.os.Build.DEVICE);
         Log.v("SDL", "Model: " + android.os.Build.MODEL);
         Log.v("SDL", "onCreate():" + mSingleton);
         super.onCreate(savedInstanceState);
-        
+
         SDLActivity.initialize();
         // So we can call stuff from static callbacks
         mSingleton = this;
@@ -161,7 +161,7 @@ public class SDLActivity extends Activity {
 
         // Set up the surface
         mSurface = new SDLSurface(getApplication());
-        
+
         if(Build.VERSION.SDK_INT >= 12) {
             mJoystickHandler = new SDLJoystickHandler_API12();
         }
@@ -254,7 +254,7 @@ public class SDLActivity extends Activity {
 
             //Log.v("SDL", "Finished waiting for SDL thread");
         }
-            
+
         super.onDestroy();
         // Reset everything in case the user re opens the app
         SDLActivity.initialize();
@@ -303,7 +303,7 @@ public class SDLActivity extends Activity {
             mSurface.handleResume();
         }
     }
-        
+
     /* The native thread has finished */
     public static void handleNativeExit() {
         SDLActivity.mSDLThread = null;
@@ -410,14 +410,14 @@ public class SDLActivity extends Activity {
     public static native void onNativeKeyboardFocusLost();
     public static native void onNativeMouse(int button, int action, float x, float y);
     public static native void onNativeTouch(int touchDevId, int pointerFingerId,
-                                            int action, float x, 
+                                            int action, float x,
                                             float y, float p);
     public static native void onNativeAccel(float x, float y, float z);
     public static native void onNativeSurfaceChanged();
     public static native void onNativeSurfaceDestroyed();
     public static native void nativeFlipBuffers();
-    public static native int nativeAddJoystick(int device_id, String name, 
-                                               int is_accelerometer, int nbuttons, 
+    public static native int nativeAddJoystick(int device_id, String name,
+                                               int is_accelerometer, int nbuttons,
                                                int naxes, int nhats, int nballs);
     public static native int nativeRemoveJoystick(int device_id);
     public static native String nativeGetHint(String name);
@@ -542,33 +542,33 @@ public class SDLActivity extends Activity {
         int channelConfig = isStereo ? AudioFormat.CHANNEL_CONFIGURATION_STEREO : AudioFormat.CHANNEL_CONFIGURATION_MONO;
         int audioFormat = is16Bit ? AudioFormat.ENCODING_PCM_16BIT : AudioFormat.ENCODING_PCM_8BIT;
         int frameSize = (isStereo ? 2 : 1) * (is16Bit ? 2 : 1);
-        
+
         Log.v("SDL", "SDL audio: wanted " + (isStereo ? "stereo" : "mono") + " " + (is16Bit ? "16-bit" : "8-bit") + " " + (sampleRate / 1000f) + "kHz, " + desiredFrames + " frames buffer");
-        
+
         // Let the user pick a larger buffer if they really want -- but ye
         // gods they probably shouldn't, the minimums are horrifyingly high
         // latency already
         desiredFrames = Math.max(desiredFrames, (AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat) + frameSize - 1) / frameSize);
-        
+
         if (mAudioTrack == null) {
             mAudioTrack = new AudioTrack(AudioManager.STREAM_MUSIC, sampleRate,
                     channelConfig, audioFormat, desiredFrames * frameSize, AudioTrack.MODE_STREAM);
-            
+
             // Instantiating AudioTrack can "succeed" without an exception and the track may still be invalid
             // Ref: https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/media/java/android/media/AudioTrack.java
             // Ref: http://developer.android.com/reference/android/media/AudioTrack.html#getState()
-            
+
             if (mAudioTrack.getState() != AudioTrack.STATE_INITIALIZED) {
                 Log.e("SDL", "Failed during initialization of Audio Track");
                 mAudioTrack = null;
                 return -1;
             }
-            
+
             mAudioTrack.play();
         }
-       
+
         Log.v("SDL", "SDL audio: got " + ((mAudioTrack.getChannelCount() >= 2) ? "stereo" : "mono") + " " + ((mAudioTrack.getAudioFormat() == AudioFormat.ENCODING_PCM_16BIT) ? "16-bit" : "8-bit") + " " + (mAudioTrack.getSampleRate() / 1000f) + "kHz, " + desiredFrames + " frames buffer");
-        
+
         return 0;
     }
 
@@ -654,8 +654,15 @@ public class SDLActivity extends Activity {
     public static void pollInputDevices() {
         if (SDLActivity.mSDLThread != null) {
             mJoystickHandler.pollInputDevices();
+			SDLActivity.mSingleton.keepActive();
         }
     }
+
+	/**
+	 * Trick needed for loading screen
+	 */
+	public void keepActive() {
+	}
 
     // APK extension files support
 
@@ -928,11 +935,11 @@ class SDLMain implements Runnable {
 
 /**
     SDLSurface. This is what we draw on, so we need to know when it's created
-    in order to do anything useful. 
+    in order to do anything useful.
 
     Because of this, that's where we set up the SDL thread
 */
-class SDLSurface extends SurfaceView implements SurfaceHolder.Callback, 
+class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     View.OnKeyListener, View.OnTouchListener, SensorEventListener  {
 
     // Sensors
@@ -942,20 +949,20 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     // Keep track of the surface size to normalize touch events
     protected static float mWidth, mHeight;
 
-    // Startup    
+    // Startup
     public SDLSurface(Context context) {
         super(context);
-        getHolder().addCallback(this); 
-    
+        getHolder().addCallback(this);
+
         setFocusable(true);
         setFocusableInTouchMode(true);
         requestFocus();
-        setOnKeyListener(this); 
-        setOnTouchListener(this);   
+        setOnKeyListener(this);
+        setOnTouchListener(this);
 
         mDisplay = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         mSensorManager = (SensorManager)context.getSystemService(Context.SENSOR_SERVICE);
-        
+
         if(Build.VERSION.SDK_INT >= 12) {
             setOnGenericMotionListener(new SDLGenericMotionListener_API12());
         }
@@ -964,7 +971,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
         mWidth = 1.0f;
         mHeight = 1.0f;
     }
-     
+
     public void handleResume() {
         setFocusable(true);
         setFocusableInTouchMode(true);
@@ -973,7 +980,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
         setOnTouchListener(this);
         enableSensor(Sensor.TYPE_ACCELEROMETER, true);
     }
-    
+
     public Surface getNativeSurface() {
         return getHolder().getSurface();
     }
@@ -1063,7 +1070,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
             final Thread sdlThread = new Thread(new SDLMain(), "SDLThread");
             enableSensor(Sensor.TYPE_ACCELEROMETER, true);
             sdlThread.start();
-            
+
             // Set up a listener thread to catch when the native thread ends
             SDLActivity.mSDLThread = new Thread(new Runnable(){
                 @Override
@@ -1072,7 +1079,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                         sdlThread.join();
                     }
                     catch(Exception e){}
-                    finally{ 
+                    finally{
                         // Native thread has finished
                         if (! SDLActivity.mExitCalledFromJava) {
                             SDLActivity.handleNativeExit();
@@ -1108,7 +1115,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                 }
             }
         }
-        
+
         if( (event.getSource() & InputDevice.SOURCE_KEYBOARD) != 0) {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
                 //Log.v("SDL", "key down: " + keyCode);
@@ -1121,7 +1128,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                 return true;
             }
         }
-        
+
         return false;
     }
 
@@ -1160,7 +1167,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                         SDLActivity.onNativeTouch(touchDevId, pointerFingerId, action, x, y, p);
                     }
                     break;
-                
+
                 case MotionEvent.ACTION_UP:
                 case MotionEvent.ACTION_DOWN:
                     // Primary pointer up/down, the index is always zero
@@ -1171,14 +1178,14 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                     if (i == -1) {
                         i = event.getActionIndex();
                     }
-                    
+
                     pointerFingerId = event.getPointerId(i);
                     x = event.getX(i) / mWidth;
                     y = event.getY(i) / mHeight;
                     p = event.getPressure(i);
                     SDLActivity.onNativeTouch(touchDevId, pointerFingerId, action, x, y, p);
                     break;
-                
+
                 case MotionEvent.ACTION_CANCEL:
                     for (i = 0; i < pointerCount; i++) {
                         pointerFingerId = event.getPointerId(i);
@@ -1195,21 +1202,21 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
         }
 
         return true;
-   } 
+   }
 
     // Sensor events
     public void enableSensor(int sensortype, boolean enabled) {
         // TODO: This uses getDefaultSensor - what if we have >1 accels?
         if (enabled) {
-            mSensorManager.registerListener(this, 
-                            mSensorManager.getDefaultSensor(sensortype), 
+            mSensorManager.registerListener(this,
+                            mSensorManager.getDefaultSensor(sensortype),
                             SensorManager.SENSOR_DELAY_GAME, null);
         } else {
-            mSensorManager.unregisterListener(this, 
+            mSensorManager.unregisterListener(this,
                             mSensorManager.getDefaultSensor(sensortype));
         }
     }
-    
+
     @Override
     public void onAccuracyChanged(Sensor sensor, int accuracy) {
         // TODO
@@ -1241,7 +1248,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                                       y / SensorManager.GRAVITY_EARTH,
                                       event.values[2] / SensorManager.GRAVITY_EARTH - 1);
         }
-    }    
+    }
 }
 
 /* This is a fake invisible editor view that receives the input and defines the
@@ -1283,7 +1290,7 @@ class DummyEdit extends View implements View.OnKeyListener {
 
         return false;
     }
-        
+
     //
     @Override
     public boolean onKeyPreIme (int keyCode, KeyEvent event) {
@@ -1362,7 +1369,7 @@ class SDLInputConnection extends BaseInputConnection {
     public native void nativeSetComposingText(String text, int newCursorPosition);
 
     @Override
-    public boolean deleteSurroundingText(int beforeLength, int afterLength) {       
+    public boolean deleteSurroundingText(int beforeLength, int afterLength) {
         // Workaround to capture backspace key. Ref: http://stackoverflow.com/questions/14560344/android-backspace-in-webview-baseinputconnection
         if (beforeLength == 1 && afterLength == 0) {
             // backspace
@@ -1376,7 +1383,7 @@ class SDLInputConnection extends BaseInputConnection {
 
 /* A null joystick handler for API level < 12 devices (the accelerometer is handled separately) */
 class SDLJoystickHandler {
-    
+
     /**
      * Handles given MotionEvent.
      * @param event the event to be handled.
@@ -1408,11 +1415,11 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
             return arg0.getAxis() - arg1.getAxis();
         }
     }
-    
+
     private ArrayList<SDLJoystick> mJoysticks;
-    
+
     public SDLJoystickHandler_API12() {
-       
+
         mJoysticks = new ArrayList<SDLJoystick>();
     }
 
@@ -1423,7 +1430,7 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
         // For example, in the case of the XBox 360 wireless dongle,
         // so the first controller seen by SDL matches what the receiver
         // considers to be the first controller
-        
+
         for(int i=deviceIds.length-1; i>-1; i--) {
             SDLJoystick joystick = getJoystick(deviceIds[i]);
             if (joystick == null) {
@@ -1434,7 +1441,7 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
                     joystick.name = joystickDevice.getName();
                     joystick.axes = new ArrayList<InputDevice.MotionRange>();
                     joystick.hats = new ArrayList<InputDevice.MotionRange>();
-                    
+
                     List<InputDevice.MotionRange> ranges = joystickDevice.getMotionRanges();
                     Collections.sort(ranges, new RangeComparator());
                     for (InputDevice.MotionRange range : ranges ) {
@@ -1448,14 +1455,14 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
                             }
                         }
                     }
-                    
+
                     mJoysticks.add(joystick);
-                    SDLActivity.nativeAddJoystick(joystick.device_id, joystick.name, 0, -1, 
+                    SDLActivity.nativeAddJoystick(joystick.device_id, joystick.name, 0, -1,
                                                   joystick.axes.size(), joystick.hats.size()/2, 0);
                 }
             }
         }
-        
+
         /* Check removed devices */
         ArrayList<Integer> removedDevices = new ArrayList<Integer>();
         for(int i=0; i < mJoysticks.size(); i++) {
@@ -1468,7 +1475,7 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
                 removedDevices.add(Integer.valueOf(device_id));
             }
         }
-            
+
         for(int i=0; i < removedDevices.size(); i++) {
             int device_id = removedDevices.get(i).intValue();
             SDLActivity.nativeRemoveJoystick(device_id);
@@ -1478,9 +1485,9 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
                     break;
                 }
             }
-        }        
+        }
     }
-    
+
     protected SDLJoystick getJoystick(int device_id) {
         for(int i=0; i < mJoysticks.size(); i++) {
             if (mJoysticks.get(i).device_id == device_id) {
@@ -1488,9 +1495,9 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
             }
         }
         return null;
-    }   
-    
-    @Override        
+    }
+
+    @Override
     public boolean handleMotionEvent(MotionEvent event) {
         if ( (event.getSource() & InputDevice.SOURCE_JOYSTICK) != 0) {
             int actionPointerIndex = event.getActionIndex();
@@ -1504,7 +1511,7 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
                             /* Normalize the value to -1...1 */
                             float value = ( event.getAxisValue( range.getAxis(), actionPointerIndex) - range.getMin() ) / range.getRange() * 2.0f - 1.0f;
                             SDLActivity.onNativeJoy(joystick.device_id, i, value );
-                        }          
+                        }
                         for (int i = 0; i < joystick.hats.size(); i+=2) {
                             int hatX = Math.round(event.getAxisValue( joystick.hats.get(i).getAxis(), actionPointerIndex ) );
                             int hatY = Math.round(event.getAxisValue( joystick.hats.get(i+1).getAxis(), actionPointerIndex ) );
@@ -1517,7 +1524,7 @@ class SDLJoystickHandler_API12 extends SDLJoystickHandler {
             }
         }
         return true;
-    }            
+    }
 }
 
 class SDLGenericMotionListener_API12 implements View.OnGenericMotionListener {


### PR DESCRIPTION
As explained on #465, the previous approach (pure GL, or using window background) doesn't fully work.
This approach have a tiny delay until PythonActivity.onCreate is called.
It first display an ImageView fitted on the screen.
Once SDL is loaded (and that SDL put its own layout), we put again our ImageView.

The tricky part is when to remove.
On the previous python-for-android+kivy, kivy was explicitely saying that he's ready to receive event. And that's where we knew the loading screen could be removed.
Here, there is no absolute way to do it, as SDL itself on the java part doesn't provide any callback... except pollInputDevices()

This method is called each X seconds, to check if any joystick has been plugged or not.
The PR add a keepActive() method that is overrided in PythonActivity to remove the screen.
It wait for the second call of it before removing the loading screen:
1. the first call is done right after the creation of the SDL window in C code. (In kivy, it's just the start, after that we load the app, widgets etc... it can take a long time)
2. the second call is done (at least on kivy) after the first frame rendered.

The loading screen might be displayed more than needed (pure SDL2 game // very fast loading). In any case,
we can always force to remove the loading screen with:

    PythonActivity.mActivity.removeLoadingScreen()

If anybody have another good approach, feel free :)

Closes #465