### PR TITLE
sdl2 bootstrap: implement --add-source argument

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/ant.properties
+++ b/pythonforandroid/bootstraps/sdl2/build/ant.properties
@@ -15,3 +15,4 @@
 #  'key.alias' for the name of the key to use.
 # The password will be asked during the build when you use the 'release' target.
 
+source.absolute.dir = tmp-src

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -286,6 +286,19 @@ def make_package(args):
         with open(args.intent_filters) as fd:
             args.intent_filters = fd.read()
 
+    if args.extra_source_dirs:
+        esd = []
+        for spec in args.extra_source_dirs:
+            if ':' in spec:
+                specdir, specincludes = spec.split(':')
+            else:
+                specdir = spec
+                specincludes = '**'
+            esd.append((realpath(specdir), specincludes))
+        args.extra_source_dirs = esd
+    else:
+        args.extra_source_dirs = []
+
     service = False
     service_main = join(realpath(args.private), 'service', 'main.py')
     if exists(service_main) or exists(service_main + 'o'):
@@ -320,6 +333,11 @@ def make_package(args):
     render(
         'strings.tmpl.xml',
         'res/values/strings.xml',
+        args=args)
+
+    render(
+        'custom_rules.tmpl.xml',
+        'custom_rules.xml',
         args=args)
 
     with open(join(dirname(__file__), 'res',
@@ -410,6 +428,8 @@ tools directory of the Android SDK.
                     help='If set, the billing service will be added (not implemented)')
     ap.add_argument('--service', dest='services', action='append',
                     help='Declare a new service entrypoint: NAME:PATH_TO_PY')
+    ap.add_argument('--add-source', dest='extra_source_dirs', action='append',
+                    help='Include additional source dirs in Java build')
 
     if args is None:
         args = sys.argv[1:]

--- a/pythonforandroid/bootstraps/sdl2/build/templates/custom_rules.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/custom_rules.tmpl.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="CustomRules">
+    <target name="-pre-build">
+        <copy todir="tmp-src">
+            <fileset dir="src" includes="**" />
+            {% for dir, includes in args.extra_source_dirs %}
+            <fileset dir="{{ dir }}" includes="{{ includes }}" />
+            {% endfor %}
+        </copy>
+    </target>
+    <target name="-post-build">
+        <delete dir="tmp-src" />
+    </target>
+</project>

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -539,9 +539,15 @@ build_dist
         # unsatisfactory and should probably be changed somehow, but
         # we can't leave it until later as the build.py scripts assume
         # they are in the current directory.
+        fix_args = ('--dir', '--private', '--add-jar', '--add-source')
         for i, arg in enumerate(args[:-1]):
-            if arg in ('--dir', '--private'):
-                args[i+1] = realpath(expanduser(args[i+1]))
+            argx = arg.split('=')
+            if argx[0] in fix_args:
+                if len(argx) > 1:
+                    args[i] = '='.join((argx[0],
+                                        realpath(expanduser(argx[1]))))
+                else:
+                    args[i+1] = realpath(expanduser(args[i+1]))
 
         build = imp.load_source('build', join(dist.dist_dir, 'build.py'))
         with current_directory(dist.dist_dir):


### PR DESCRIPTION
Allows for additional source directories which need to be compiled with the bootstrap sources. This is useful when the additional sources reference classes in the bootstrap source, or when you want to create a custom Activity class (by subclassing PythonActivity and setting the custom Activity as the entrypoint).