### PR TITLE
add foreground option to segregated services

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -305,15 +305,25 @@ def make_package(args):
         service = True
 
     service_names = []
-    for entrypoint in args.services:
-        name, entrypoint = entrypoint.split(":", 1)
+    for sid, spec in enumerate(args.services):
+        spec = spec.split(':')
+        name = spec[0]
+        entrypoint = spec[1]
+        options = spec[2:]
+
+        foreground = False
+        if 'foreground' in options:
+            foreground = True
+
         service_names.append(name)
         render(
             'Service.tmpl.java',
             'src/{}/Service{}.java'.format(args.package.replace(".", "/"), name.capitalize()),
             name=name,
             entrypoint=entrypoint,
-            args=args
+            args=args,
+            foreground=foreground,
+            service_id=sid + 1,
         )
 
     render(
@@ -427,7 +437,8 @@ tools directory of the Android SDK.
     ap.add_argument('--with-billing', dest='billing_pubkey',
                     help='If set, the billing service will be added (not implemented)')
     ap.add_argument('--service', dest='services', action='append',
-                    help='Declare a new service entrypoint: NAME:PATH_TO_PY')
+                    help='Declare a new service entrypoint: '
+                         'NAME:PATH_TO_PY[:foreground]')
     ap.add_argument('--add-source', dest='extra_source_dirs', action='append',
                     help='Include additional source dirs in Java build')
 

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
@@ -64,22 +64,25 @@ public class PythonService extends Service implements Runnable {
         pythonThread = new Thread(this);
         pythonThread.start();
 
-        if (this.canDisplayNotification()) {
+        doStartForeground(extras);
+
+        return START_NOT_STICKY;
+    }
+
+    protected void doStartForeground(Bundle extras) {
+        if (canDisplayNotification()) {
             String serviceTitle = extras.getString("serviceTitle");
             String serviceDescription = extras.getString("serviceDescription");
 
             Context context = getApplicationContext();
             Notification notification = new Notification(context.getApplicationInfo().icon,
-            serviceTitle,
-            System.currentTimeMillis());
+                serviceTitle, System.currentTimeMillis());
             Intent contextIntent = new Intent(context, PythonActivity.class);
             PendingIntent pIntent = PendingIntent.getActivity(context, 0, contextIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT);
             notification.setLatestEventInfo(context, serviceTitle, serviceDescription, pIntent);
             startForeground(1, notification);
         }
-
-        return START_NOT_STICKY;
     }
 
     @Override
@@ -91,7 +94,7 @@ public class PythonService extends Service implements Runnable {
 
     @Override
     public void run(){
-		PythonUtil.loadLibraries(getFilesDir());
+        PythonUtil.loadLibraries(getFilesDir());
         this.mService = this;
         nativeStart(
             androidPrivate, androidArgument,

--- a/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
@@ -2,14 +2,24 @@ package {{ args.package }};
 
 import android.content.Intent;
 import android.content.Context;
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.os.Bundle;
 import org.kivy.android.PythonService;
 import org.kivy.android.PythonActivity;
 
 
 public class Service{{ name|capitalize }} extends PythonService {
     @Override
-    public boolean canDisplayNotification() {
-        return false;
+    protected void doStartForeground(Bundle extras) {
+        Context context = getApplicationContext();
+        Notification notification = new Notification(context.getApplicationInfo().icon,
+            "{{ args.name }}", System.currentTimeMillis());
+        Intent contextIntent = new Intent(context, PythonActivity.class);
+        PendingIntent pIntent = PendingIntent.getActivity(context, 0, contextIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT);
+        notification.setLatestEventInfo(context, "{{ args.name }}", "{{ name| capitalize }}", pIntent);
+        startForeground({{ service_id }}, notification);
     }
 
     static public void start(Context ctx, String pythonServiceArgument) {


### PR DESCRIPTION
Adds back the ability to run services in the foreground when using the new segregated service pattern. `--service` arguments can now include options, in the format `servicename:path/to/service.py:option1:option2:option3:...`. The only option which does anything is `foreground`, any other option will be silently ignored.