### PR TITLE
Remove print from cryptography recipe.

### DIFF
--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -33,7 +33,6 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
 			join(dirname(self.real_hostpython_location), 'Lib', 'site-packages'),
 			env['BUILDLIB_PATH'],
 		])
-		print env
 		return env
 
 	def build_arch(self, arch):


### PR DESCRIPTION
It cause an error when using python3.