### PR TITLE
Fixed missing else statement in for loop, allowing systems where cyth…

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -330,7 +330,8 @@ class Context(object):
             if cython:
                 self.cython = cython
                 break
-        self.cython = 'cython'
+        else:
+             self.cython = 'cython'
         if not self.cython:
             ok = False
             warning("Missing requirement: cython is not installed")


### PR DESCRIPTION
…on2 isn't symlinked to cython to build with the right cython binary

I have not tested this on systems other than mine (where cython isn't symlinked to cython2), therefore testing is advised.