### PR TITLE
stop service on interpreter exit

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
@@ -101,6 +101,7 @@ public class PythonService extends Service implements Runnable {
             serviceEntrypoint, pythonName,
             pythonHome, pythonPath,
             pythonServiceArgument);
+        stopSelf();
     }
 
     // Native part


### PR DESCRIPTION
Stop the service process to free its memory when the Python interpreter has exited.