### PR TITLE
add sticky services, auto-restart services, fix foreground option

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -311,9 +311,8 @@ def make_package(args):
         entrypoint = spec[1]
         options = spec[2:]
 
-        foreground = False
-        if 'foreground' in options:
-            foreground = True
+        foreground = 'foreground' in options
+        sticky = 'sticky' in options
 
         service_names.append(name)
         render(
@@ -323,6 +322,7 @@ def make_package(args):
             entrypoint=entrypoint,
             args=args,
             foreground=foreground,
+            sticky=sticky,
             service_id=sid + 1,
         )
 

--- a/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
@@ -10,6 +10,20 @@ import org.kivy.android.PythonActivity;
 
 
 public class Service{{ name|capitalize }} extends PythonService {
+    {% if sticky %}
+    @Override
+    public int startType() {
+        return START_STICKY;
+    }
+    {% endif %}
+
+    {% if not foreground %}
+    @Override
+    public boolean canDisplayNotification() {
+        return false;
+    }
+    {% endif %}
+
     @Override
     protected void doStartForeground(Bundle extras) {
         Context context = getApplicationContext();


### PR DESCRIPTION
Allows services to be started sticky (`sticky` option with `--service`, i.e. `--service=name:file.py:sticky`).

Adds option to restart services when they exit by calling `<ServiceObject>.setAutoRestartService(true)`. When the Python interpreter exits, it will be restarted automatically. This is done programmatically, rather than via a build option, so that a service can actually shut down if necessary (by setting auto-restart to false).

Fixes issue with the foreground option which caused it to be applied to all services, regardless of whether the option was actually specified.