### PR TITLE
Make unistr available in logger

### DIFF
--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -15,6 +15,11 @@ if not six.PY3:
     stdout = codecs.getwriter('utf8')(stdout)
     stderr = codecs.getwriter('utf8')(stderr)
 
+if six.PY2:
+    unistr = unicode
+else:
+    unistr = str
+
 # monkey patch to show full output
 sh.ErrorReturnCode.truncate_cap = 999999
 
@@ -216,4 +221,3 @@ def shprint(command, *args, **kwargs):
             raise
 
     return output
-


### PR DESCRIPTION
Or else the simple example given in the quickstart guide would fail with the log
```
$ python-for-android create --dist_name=testproject --bootstrap=pygame \
    --requirements=sdl,python2
... lots of correct output ...
[INFO]:    -> running make -j5
           working: Objects/descrobject.c:359:5: warning: missing initializer for field ‘set’ of ‘PyGetSetDef {aka struct PyGetSetDef}’ [-Wmissing-field-initializers]                                                                                                        Traceback (most recent call last):
  File "/home/me/.virtualenvs/sandbox/bin/python-for-android", line 9, in <module>
    load_entry_point('python-for-android', 'console_scripts', 'python-for-android')()
  File "/home/me/test/python-for-android/pythonforandroid/toolchain.py", line 708, in main
    ToolchainCL()
  File "/home/me/test/python-for-android/pythonforandroid/toolchain.py", line 323, in __init__
    getattr(self, args.command)(unknown)
  File "/home/me/test/python-for-android/pythonforandroid/toolchain.py", line 105, in wrapper_func
    build_dist_from_args(ctx, dist, dist_args)
  File "/home/me/test/python-for-android/pythonforandroid/toolchain.py", line 142, in build_dist_from_args
    build_recipes(build_order, python_modules, ctx)
  File "/home/me/test/python-for-android/pythonforandroid/build.py", line 560, in build_recipes
    recipe.build_arch(arch)
  File "/home/me/test/python-for-android/pythonforandroid/recipes/hostpython2/__init__.py", line 42, in build_arch
    shprint(sh.make, '-j5')
  File "/home/me/test/python-for-android/pythonforandroid/logger.py", line 169, in shprint
    shorten_string(msg, msg_width), width=msg_width))
  File "/home/me/test/python-for-android/pythonforandroid/logger.py", line 101, in shorten_string
    if not isinstance(string, unistr):
NameError: global name 'unistr' is not defined
Exception in thread Thread-193 (most likely raised during interpreter shutdown):Exception in thread Thread-194 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
```