### PR TITLE
Removed --download-cache pip argument

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -769,7 +769,7 @@ function run_pymodules_install() {
 	done
 
 	debug "Install pure-python modules via pip in venv"
-	try bash -c "source venv/bin/activate && env CC=/bin/false CXX=/bin/false PYTHONPATH= pip install --target '$SITEPACKAGES_PATH' --download-cache '$PACKAGES_PATH' -r requirements.txt"
+	try bash -c "source venv/bin/activate && env CC=/bin/false CXX=/bin/false PYTHONPATH= pip install --target '$SITEPACKAGES_PATH' -r requirements.txt"
 
 }
 


### PR DESCRIPTION
This is apparently the right fix for new pip versions, as applied in the new toolchain.