### PR TITLE
Added main.py existence check in both bootstraps

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/build.py
+++ b/pythonforandroid/bootstraps/pygame/build/build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-from os.path import dirname, join, isfile, realpath, relpath, split
+from os.path import dirname, join, isfile, realpath, relpath, split, exists
 from zipfile import ZipFile
 import sys
 sys.path.insert(0, 'buildlib/jinja2.egg')
@@ -258,6 +258,13 @@ def make_package(args):
     # Figure out if application has service part
     service = False
     directory = args.dir if public_version else args.private
+    if not (exists(join(realpath(directory), 'main.py')) or
+            exists(join(realpath(directory), 'main.pyo'))):
+        print('''BUILD FAILURE: No main.py(o) found in your app directory. This
+file must exist to act as the entry point for you app. If your app is
+started by a file with a different name, rename it to main.py or add a
+main.py that loads it.''')
+        exit(1)
     if directory:
         service_main = join(realpath(directory), 'service', 'main.py')
         if os.path.exists(service_main) or os.path.exists(service_main + 'o'):

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -218,6 +218,14 @@ def make_package(args):
     #     print('Your PATH must include android tools.')
     #     sys.exit(-1)
 
+    if not (exists(join(realpath(args.private), 'main.py')) or
+            exists(join(realpath(args.private), 'main.pyo'))):
+        print('''BUILD FAILURE: No main.py(o) found in your app directory. This
+file must exist to act as the entry point for you app. If your app is
+started by a file with a different name, rename it to main.py or add a
+main.py that loads it.''')
+        exit(1)
+
     # Delete the old assets.
     if exists('assets/public.mp3'):
         os.unlink('assets/public.mp3')


### PR DESCRIPTION
These cause the build to fail if main.py doesn't exist. I don't think there's any reason not to crash, as the app won't work without a main.py under any situation except the occasional debugging test that's easy to work around.

Resolves https://github.com/kivy/python-for-android/issues/656