### PR TITLE
Bump colorama requirement to 0.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='python-for-android',
       author_email='kivy-dev@googlegroups.com',
       url='https://github.com/kivy/python-for-android', 
       license='MIT', 
-      install_requires=['appdirs', 'colorama>0.3', 'sh>=1.10', 'jinja2', 'argparse',
+      install_requires=['appdirs', 'colorama>=0.3.3', 'sh>=1.10', 'jinja2', 'argparse',
                         'six'],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
The EX color variants weren't added until 0.3.3. I found out because
Fedora 23 packages colorama 0.3.2, which satisfies the requirement, but
causes the error: `AttributeError: 'AnsiCodes' object has no attribute
'LIGHTBLUE_EX'`...