### PR TITLE
Enable snappy recipe for py-leveldb

### DIFF
--- a/pythonforandroid/recipes/pyleveldb/__init__.py
+++ b/pythonforandroid/recipes/pyleveldb/__init__.py
@@ -5,7 +5,7 @@ import sh
 class PyLevelDBRecipe(CompiledComponentsPythonRecipe):
     version = '0.193'
     url = 'https://pypi.python.org/packages/source/l/leveldb/leveldb-{version}.tar.gz'
-    depends = ['leveldb', 'hostpython2', 'python2', 'setuptools']
+    depends = ['snappy', 'leveldb', 'hostpython2', 'python2', 'setuptools']
     patches = ['bindings-only.patch']
     call_hostpython_via_targetpython = False # Due to setuptools
     site_packages_name = 'leveldb'


### PR DESCRIPTION
Without this the source files of snappy are not replaced but only removed.