### PR TITLE
add --storage-dir option

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -61,6 +61,7 @@ class Arch(object):
             ccache = self.ctx.ccache + ' '
             env['USE_CCACHE'] = '1'
             env['NDK_CCACHE'] = self.ctx.ccache
+            env.update({k: v for k, v in environ.items() if k.startswith('CCACHE_')})
 
         print('path is', environ['PATH'])
         cc = find_executable('{command_prefix}-gcc'.format(

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -97,6 +97,7 @@ class Context(object):
         self.build_dir = join(self.storage_dir, 'build')
         self.dist_dir = join(self.storage_dir, 'dists')
 
+    def ensure_dirs(self):
         ensure_dir(self.storage_dir)
         ensure_dir(self.build_dir)
         ensure_dir(self.dist_dir)
@@ -155,7 +156,7 @@ class Context(object):
     def ndk_dir(self, value):
         self._ndk_dir = value
 
-    def prepare_build_environment(self, storage_dir, user_sdk_dir, user_ndk_dir,
+    def prepare_build_environment(self, user_sdk_dir, user_ndk_dir,
                                   user_android_api, user_ndk_ver):
         '''Checks that build dependencies exist and sets internal variables
         for the Android SDK etc.
@@ -164,7 +165,7 @@ class Context(object):
 
         '''
 
-        self.setup_dirs(storage_dir)
+        self.ensure_dirs()
 
         if self._build_env_prepared:
             return

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -8,7 +8,6 @@ import glob
 import sys
 import re
 import sh
-from appdirs import user_data_dir
 
 from pythonforandroid.util import (ensure_dir, current_directory)
 from pythonforandroid.logger import (info, warning, error, info_notify,
@@ -88,19 +87,21 @@ class Context(object):
         dir = join(self.python_installs_dir, self.bootstrap.distribution.name)
         return dir
 
-    def setup_dirs(self):
+    def setup_dirs(self, storage_dir):
         '''Calculates all the storage and build dirs, and makes sure
         the directories exist where necessary.'''
-        self.root_dir = realpath(dirname(__file__))
-
-        # AND: TODO: Allow the user to set the build_dir
-        self.storage_dir = user_data_dir('python-for-android')
+        self.storage_dir = expanduser(storage_dir)
+        if ' ' in self.storage_dir:
+            raise ValueError('storage dir path cannot contain spaces, please '
+                             'specify a path with --storage-dir')
         self.build_dir = join(self.storage_dir, 'build')
         self.dist_dir = join(self.storage_dir, 'dists')
 
         ensure_dir(self.storage_dir)
         ensure_dir(self.build_dir)
         ensure_dir(self.dist_dir)
+        ensure_dir(join(self.build_dir, 'bootstrap_builds'))
+        ensure_dir(join(self.build_dir, 'other_builds'))
 
     @property
     def android_api(self):
@@ -154,7 +155,7 @@ class Context(object):
     def ndk_dir(self, value):
         self._ndk_dir = value
 
-    def prepare_build_environment(self, user_sdk_dir, user_ndk_dir,
+    def prepare_build_environment(self, storage_dir, user_sdk_dir, user_ndk_dir,
                                   user_android_api, user_ndk_ver):
         '''Checks that build dependencies exist and sets internal variables
         for the Android SDK etc.
@@ -162,6 +163,8 @@ class Context(object):
         ..warning:: This *must* be called before trying any build stuff
 
         '''
+
+        self.setup_dirs(storage_dir)
 
         if self._build_env_prepared:
             return
@@ -434,9 +437,6 @@ class Context(object):
         self.local_recipes = None
         self.copy_libs = False
 
-        # root of the toolchain
-        self.setup_dirs()
-
         # this list should contain all Archs, it is pruned later
         self.archs = (
             ArchARM(self),
@@ -445,9 +445,7 @@ class Context(object):
             ArchAarch_64(self),
             )
 
-        ensure_dir(join(self.build_dir, 'bootstrap_builds'))
-        ensure_dir(join(self.build_dir, 'other_builds'))
-        # other_builds: where everything else is built
+        self.root_dir = realpath(dirname(__file__))
 
         # remove the most obvious flags that can break the compilation
         self.env.pop("LDFLAGS", None)

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -565,9 +565,13 @@ class Recipe(with_metaclass(RecipeMeta)):
                 info('Deleting {}'.format(directory))
                 shutil.rmtree(directory)
 
-    def install_libs(self, arch, lib, *libs):
+    def install_libs(self, arch, *libs):
         libs_dir = self.ctx.get_libs_dir(arch.arch)
-        shprint(sh.cp, '-t', libs_dir, lib, *libs)
+        if not libs:
+            warning('install_libs called with no libraries to install!')
+            return
+        args = libs + (libs_dir,)
+        shprint(sh.cp, *args)
 
     def has_libs(self, arch, *libs):
         return all(map(lambda l: self.ctx.has_lib(arch.arch, l), libs))
@@ -577,8 +581,9 @@ class Recipe(with_metaclass(RecipeMeta)):
         recipe_dirs = []
         if ctx.local_recipes is not None:
             recipe_dirs.append(ctx.local_recipes)
-        recipe_dirs.extend([join(ctx.storage_dir, 'recipes'),
-                            join(ctx.root_dir, "recipes")])
+        if ctx.storage_dir:
+            recipe_dirs.append(join(ctx.storage_dir, 'recipes'))
+        recipe_dirs.append(join(ctx.root_dir, "recipes"))
         return recipe_dirs
 
     @classmethod

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -171,8 +171,6 @@ def split_argument_list(l):
 class ToolchainCL(object):
 
     def __init__(self):
-        self._ctx = None
-
         parser = argparse.ArgumentParser(
                 description="Tool for managing the Android / Python toolchain",
                 usage="""toolchain <command> [<args>]
@@ -296,6 +294,8 @@ build_dist
 
         if args.debug:
             logger.setLevel(logging.DEBUG)
+
+        self.ctx = Context()
         self.storage_dir = args.storage_dir
         self.ctx.setup_dirs(self.storage_dir)
         self.sdk_dir = args.sdk_dir
@@ -348,12 +348,6 @@ build_dist
         for line in lines:
             for arg in line:
                 sys.argv.append(arg)
-
-    @property
-    def ctx(self):
-        if self._ctx is None:
-            self._ctx = Context()
-        return self._ctx
 
     def recipes(self, args):
         parser = argparse.ArgumentParser(

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -93,8 +93,7 @@ def require_prebuilt_dist(func):
     def wrapper_func(self, args):
         ctx = self.ctx
         ctx.set_archs(self._archs)
-        ctx.prepare_build_environment(storage_dir=self.storage_dir,
-                                      user_sdk_dir=self.sdk_dir,
+        ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
                                       user_ndk_ver=self.ndk_version)
@@ -298,6 +297,7 @@ build_dist
         if args.debug:
             logger.setLevel(logging.DEBUG)
         self.storage_dir = args.storage_dir
+        self.ctx.setup_dirs(self.storage_dir)
         self.sdk_dir = args.sdk_dir
         self.ndk_dir = args.ndk_dir
         self.android_api = args.android_api
@@ -423,7 +423,7 @@ build_dist
         parser = argparse.ArgumentParser(
                 description="Delete any distributions that have been built.")
         args = parser.parse_args(args)
-        ctx = Context()
+        ctx = self.ctx
         if exists(ctx.dist_dir):
             shutil.rmtree(ctx.dist_dir)
 
@@ -438,7 +438,7 @@ build_dist
         parser = argparse.ArgumentParser(
                 description="Delete all build files (but not download caches)")
         args = parser.parse_args(args)
-        ctx = Context()
+        ctx = self.ctx
         # if exists(ctx.dist_dir):
         #     shutil.rmtree(ctx.dist_dir)
         if exists(ctx.build_dir):
@@ -476,7 +476,7 @@ build_dist
         parser = argparse.ArgumentParser(
                 description="Delete all download caches")
         args = parser.parse_args(args)
-        ctx = Context()
+        ctx = self.ctx
         if exists(ctx.packages_path):
             shutil.rmtree(ctx.packages_path)
 
@@ -641,7 +641,7 @@ build_dist
         python-for-android will internally use for package building, along
         with information about where the Android SDK and NDK will be called
         from.'''
-        ctx = Context()
+        ctx = self.ctx
         for attribute in ('root_dir', 'build_dir', 'dist_dir', 'libs_dir',
                           'ccache', 'cython', 'sdk_dir', 'ndk_dir',
                           'ndk_platform', 'ndk_ver', 'android_api'):
@@ -661,7 +661,7 @@ build_dist
     def distributions(self, args):
         '''Lists all distributions currently available (i.e. that have already
         been built).'''
-        ctx = Context()
+        ctx = self.ctx
         dists = Distribution.get_distributions(ctx)
 
         if dists:


### PR DESCRIPTION
Adds a `--storage-dir` option to specify the path to where p4a should store its files.

Also checks if the default storage dir includes a space, and if so changes it to `~/.python-for-android`. Fixes #622 