### PR TITLE
add libtribler recipe

### DIFF
--- a/pythonforandroid/recipes/libtribler/__init__.py
+++ b/pythonforandroid/recipes/libtribler/__init__.py
@@ -1,0 +1,18 @@
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class LibTriblerRecipe(PythonRecipe):
+
+    version = 'devel'
+
+    url = 'git+https://github.com/Tribler/tribler.git'
+
+    depends = ['android', 'apsw', 'cherrypy', 'cryptography', 'decorator',
+               'feedparser', 'ffmpeg', 'libnacl', 'libsodium', 'libtorrent',
+               'm2crypto', 'netifaces', 'openssl', 'pyasn1', 'pil', 'pyleveldb',
+               'python2', 'requests', 'twisted']
+
+    site_packages_name = 'Tribler'
+
+
+recipe = LibTriblerRecipe()

--- a/pythonforandroid/recipes/libtribler/__init__.py
+++ b/pythonforandroid/recipes/libtribler/__init__.py
@@ -13,8 +13,8 @@ class LibTriblerRecipe(PythonRecipe):
 
     depends = ['apsw', 'cherrypy', 'cryptography', 'decorator', 'feedparser',
                'ffmpeg', 'libnacl', 'libsodium', 'libtorrent', 'm2crypto',
-               'netifaces', 'openssl', 'pyasn1', 'pil', 'pyleveldb', 'python2',
-               'requests', 'twisted']
+               'netifaces', 'openssl', 'pyasn1', 'pil', 'pycrypto', 'pyleveldb',
+               'python2', 'requests', 'twisted']
 
     site_packages_name = 'Tribler'
 

--- a/pythonforandroid/recipes/libtribler/__init__.py
+++ b/pythonforandroid/recipes/libtribler/__init__.py
@@ -1,6 +1,10 @@
 from pythonforandroid.toolchain import PythonRecipe
 
+"""
+Privacy with BitTorrent and resilient to shut down
 
+http://www.tribler.org
+"""
 class LibTriblerRecipe(PythonRecipe):
 
     version = 'devel'

--- a/pythonforandroid/recipes/libtribler/__init__.py
+++ b/pythonforandroid/recipes/libtribler/__init__.py
@@ -11,10 +11,10 @@ class LibTriblerRecipe(PythonRecipe):
 
     url = 'git+https://github.com/Tribler/tribler.git'
 
-    depends = ['android', 'apsw', 'cherrypy', 'cryptography', 'decorator',
-               'feedparser', 'ffmpeg', 'libnacl', 'libsodium', 'libtorrent',
-               'm2crypto', 'netifaces', 'openssl', 'pyasn1', 'pil', 'pyleveldb',
-               'python2', 'requests', 'twisted']
+    depends = ['apsw', 'cherrypy', 'cryptography', 'decorator', 'feedparser',
+               'ffmpeg', 'libnacl', 'libsodium', 'libtorrent', 'm2crypto',
+               'netifaces', 'openssl', 'pyasn1', 'pil', 'pyleveldb', 'python2',
+               'requests', 'twisted']
 
     site_packages_name = 'Tribler'
 


### PR DESCRIPTION
Privacy with BitTorrent and resilient to shut down http://www.tribler.org

Recipe uses the latest development version from git.
Supersedes PR #405 