### PR TITLE
throw error early if running in venv

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -30,7 +30,7 @@ from pythonforandroid.recipe import (Recipe, PythonRecipe, CythonRecipe,
 from pythonforandroid.archs import (ArchARM, ArchARMv7_a, Archx86)
 from pythonforandroid.logger import (logger, info, warning, setup_color,
                                      Out_Style, Out_Fore, Err_Style, Err_Fore,
-                                     info_notify, info_main, shprint)
+                                     info_notify, info_main, shprint, error)
 from pythonforandroid.util import current_directory, ensure_dir
 from pythonforandroid.bootstrap import Bootstrap
 from pythonforandroid.distribution import Distribution, pretty_log_dists
@@ -117,6 +117,13 @@ def build_dist_from_args(ctx, dist, args):
         = get_recipe_order_and_bootstrap(ctx, dist.recipes, bs)
     ctx.recipe_build_order = build_order
     ctx.python_modules = python_modules
+
+    if python_modules and hasattr(sys, 'real_prefix'):
+        error('virtualenv is needed to install pure-Python modules, but')
+        error('virtualenv does not support nesting, and you are running')
+        error('python-for-android in one. Please run p4a outside of a')
+        error('virtualenv instead.')
+        exit(1)
 
     info('The selected bootstrap is {}'.format(bs.name))
     info_main('# Creating dist with {} bootstrap'.format(bs.name))


### PR DESCRIPTION
```
(venv) ryan@ryan-mk3:~/g/tmp$ p4a create --dist-name venvtest --requirements=kivy,alembic --debug --arch=armeabi-v7a
[INFO]:    This python-for-android revamp is an experimental alpha release!
[INFO]:    It should work (mostly), but you may experience missing features or bugs.
[INFO]:    Will compile for the following archs: armeabi-v7a
[INFO]:    Found Android API target in $ANDROIDAPI
[INFO]:    Available Android APIs are (8, 14, 19, 21, 22, 23)
[INFO]:    Requested API target 21 is available, continuing.
[INFO]:    Found NDK dir in $ANDROIDNDK
[INFO]:    Got NDK version from $ANDROIDNDKVER
[INFO]:    Using Crystax NDK 10.3.1
[INFO]:    Found virtualenv at /usr/bin/virtualenv
[INFO]:    Found the following toolchain versions: ['4.9', '5', 'clang3.6', 'clang3.7']
[INFO]:    Picking the latest gcc toolchain, here 5
[INFO]:    No existing dists meet the given requirements!
[INFO]:    No dist exists that meets your requirements, so one will be built.
[INFO]:    No recipe named alembic; will attempt to install with pip
[INFO]:    Loaded recipe kivy (depends on ['pyjnius', ('sdl2', 'pygame'), ('python2', 'python3crystax')])
[INFO]:    Loaded recipe pyjnius (depends on ['six', ('python2', 'python3crystax'), ('sdl2', 'sdl', 'webviewjni')])
[INFO]:    Loaded recipe six (depends on [('python2', 'python3crystax')])
[INFO]:    Found multiple valid recipe sets:
[INFO]:        ['pyjnius', 'python2', 'sdl2', 'six', u'kivy']
[INFO]:        ['six', 'pygame', u'kivy', 'sdl', 'pyjnius', 'python2']
[INFO]:        ['pyjnius', 'six', u'kivy', 'python3crystax', 'sdl2']
[INFO]:        ['six', 'python3crystax', 'pygame', u'kivy', 'sdl', 'pyjnius']
[INFO]:    Using the first of these: ['pyjnius', 'python2', 'sdl2', 'six', u'kivy']
[INFO]:    Trying to find a bootstrap that matches the given recipes.
[INFO]:    Found 1 acceptable bootstraps: ['sdl2']
[INFO]:    Using the first of these: sdl2
[INFO]:    sdl2 bootstrap appears compatible with the required recipes.
[INFO]:    Checking this...
[INFO]:    Loaded recipe sdl2 (depends on [('python2', 'python3crystax'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf'], conflicts ['sdl', 'pygame', 'pygame_bootstrap_components'])
[INFO]:    Loaded recipe sdl2_image (depends on [])
[INFO]:    Loaded recipe sdl2_mixer (depends on [])
[INFO]:    Loaded recipe sdl2_ttf (depends on [])
[INFO]:    Loaded recipe sdl2 (depends on [('python2', 'python3crystax'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf'], conflicts ['sdl', 'pygame', 'pygame_bootstrap_components'])
[INFO]:    Loaded recipe six (depends on [('python2', 'python3crystax')])
[INFO]:    Loaded recipe sdl2_ttf (depends on [])
[INFO]:    Loaded recipe sdl2_mixer (depends on [])
[INFO]:    Loaded recipe sdl2_image (depends on [])
[INFO]:    Loaded recipe pyjnius (depends on ['six', ('python2', 'python3crystax'), ('sdl2', 'sdl', 'webviewjni')])
[INFO]:    Loaded recipe kivy (depends on ['pyjnius', ('sdl2', 'pygame'), ('python2', 'python3crystax')])
[INFO]:    No recipe named alembic; will attempt to install with pip
[INFO]:    Loaded recipe python2 (depends on ['hostpython2'], conflicts ['python3crystax', 'python3'])
[INFO]:    Loaded recipe hostpython2 (depends on [], conflicts ['hostpython3'])
[INFO]:    Found a single valid recipe set (this is good)
[ERROR]:   virtualenv is needed to install pure-Python modules, but
[ERROR]:   virtualenv does not support nesting, and you are running
[ERROR]:   python-for-android in one. Please run p4a outside of a
[ERROR]:   virtualenv instead.
```