### PR TITLE
Port storm and psycopg2 recipes from the old toolchain to the revamp.

### DIFF
--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -1,0 +1,25 @@
+from pythonforandroid.toolchain import Recipe, current_directory, shprint
+import sh
+import os.path
+
+
+class LibpqRecipe(Recipe):
+    version = '9.5.3'
+    url = 'http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2'
+    depends = [('python2', 'python3')]
+
+    def should_build(self, arch):
+        return not os.path.isfile('{}/libpq.a'.format(self.ctx.get_libs_dir(arch.arch)))
+
+    def build_arch(self, arch):
+        env = self.get_recipe_env(arch)
+
+        with current_directory(self.get_build_dir(arch.arch)):
+            configure = sh.Command('./configure')
+            shprint(configure, '--without-readline', '--host=arm-linux',
+                    _env=env)
+            shprint(sh.make, 'submake-libpq', _env=env)
+            shprint(sh.cp, '-a', 'src/interfaces/libpq/libpq.a',
+                    self.ctx.get_libs_dir(arch.arch))
+
+recipe = LibpqRecipe()

--- a/pythonforandroid/recipes/psycopg2/__init__.py
+++ b/pythonforandroid/recipes/psycopg2/__init__.py
@@ -1,0 +1,41 @@
+from pythonforandroid.toolchain import PythonRecipe, current_directory, shprint
+import sh
+
+
+class Psycopg2Recipe(PythonRecipe):
+    version = 'latest'
+    url = 'http://initd.org/psycopg/tarballs/psycopg2-{version}.tar.gz'
+    depends = [('python2', 'python3'), 'libpq']
+    site_packages_name = 'psycopg2'
+
+    def prebuild_arch(self, arch):
+        libdir = self.ctx.get_libs_dir(arch.arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            # pg_config_helper will return the system installed libpq, but we
+            # need the one we just cross-compiled
+            shprint(sh.sed, '-i',
+                    "s|pg_config_helper.query(.libdir.)|'{}'|".format(libdir),
+                    'setup.py')
+
+    def get_recipe_env(self, arch):
+        env = super(Psycopg2Recipe, self).get_recipe_env(arch)
+        env['LDFLAGS'] = "{} -L{}".format(env['LDFLAGS'], self.ctx.get_libs_dir(arch.arch))
+        env['EXTRA_CFLAGS'] = "--host linux-armv"
+        return env
+
+    def install_python_package(self, arch, name=None, env=None, is_dir=True):
+        '''Automate the installation of a Python package (or a cython
+        package where the cython components are pre-built).'''
+        if env is None:
+            env = self.get_recipe_env(arch)
+
+        with current_directory(self.get_build_dir(arch.arch)):
+            hostpython = sh.Command(self.ctx.hostpython)
+
+            shprint(hostpython, 'setup.py', 'build_ext', '--static-libpq',
+                    _env=env)
+            shprint(hostpython, 'setup.py', 'install', '-O2',
+                    '--root={}'.format(self.ctx.get_python_install_dir()),
+                    '--install-lib=lib/python2.7/site-packages', _env=env)
+
+recipe = Psycopg2Recipe()

--- a/pythonforandroid/recipes/storm/__init__.py
+++ b/pythonforandroid/recipes/storm/__init__.py
@@ -1,0 +1,22 @@
+from pythonforandroid.toolchain import PythonRecipe, current_directory, shprint
+import sh
+
+
+class StormRecipe(PythonRecipe):
+    version = '0.20'
+    url = 'https://launchpad.net/storm/trunk/{version}/+download/storm-{version}.tar.bz2'
+    depends = [('python2', 'python3')]
+    site_packages_name = 'storm'
+    call_hostpython_via_targetpython = False
+
+    def prebuild_arch(self, arch):
+        with current_directory(self.get_build_dir(arch.arch)):
+            # Cross compiling for 32 bits in 64 bit ubuntu before precise is
+            # failing. See
+            # https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/873007
+            shprint(sh.sed, '-i',
+                    "s|BUILD_CEXTENSIONS = True|BUILD_CEXTENSIONS = False|",
+                    'setup.py')
+
+
+recipe = StormRecipe()


### PR DESCRIPTION
Port psycopg2 (such as it's dependency 'libpq') and storm recipes from the old toolchain to the revamp.