### PR TITLE
Added toolchain_version initialisation

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -352,6 +352,7 @@ class Context(object):
         arch = self.archs[0]
         platform_dir = arch.platform_dir
         toolchain_prefix = arch.toolchain_prefix
+        toolchain_version = None
         self.ndk_platform = join(
             self.ndk_dir,
             'platforms',


### PR DESCRIPTION
If the toolchain version isn't found, p4a currently crashes because it's
not defined rather than when this is checked for (and a more helpful
error returned).