### PR TITLE
[WIP] add experimental wheel support

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -8,6 +8,8 @@ from pythonforandroid.recipe import Recipe
 
 
 class Arch(object):
+    arch = None
+    '''The architecture name.'''
 
     toolchain_prefix = None
     '''The prefix for the toolchain dir in the NDK.'''
@@ -29,6 +31,10 @@ class Arch(object):
                 self.ctx.include_dir,
                 d.format(arch=self))
             for d in self.ctx.include_dirs]
+
+    @property
+    def android_python_abi(self):
+        return 'android{}_{}'.format(self.ctx.android_api, self.arch)
 
     def get_env(self, with_flags_in_cc=True):
         env = {}

--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -1,22 +1,23 @@
 
-from pythonforandroid.toolchain import CythonRecipe, shprint, current_directory, ArchARM
-from os.path import exists, join
-import sh
-import glob
+from pythonforandroid.toolchain import CythonRecipe
+from os.path import join
 
 
 class KivyRecipe(CythonRecipe):
-    # version = 'stable'
     version = 'master'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 
-    depends = [('sdl2', 'pygame'), 'pyjnius']
+    depends = [('sdl2', 'pygame'), 'pyjnius', 'setuptools', 'wheel']
 
-    # patches = ['setargv.patch']
+    call_hostpython_via_targetpython = False
+
+    use_pip = True
+    wheel_name = 'Kivy'
 
     def get_recipe_env(self, arch):
         env = super(KivyRecipe, self).get_recipe_env(arch)
+        env['KIVY_USE_SETUPTOOLS'] = '1'
         if 'sdl2' in self.ctx.recipe_build_order:
             env['USE_SDL2'] = '1'
             env['KIVY_SDL2_PATH'] = ':'.join([
@@ -26,5 +27,6 @@ class KivyRecipe(CythonRecipe):
                 join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
                 ])
         return env
+
 
 recipe = KivyRecipe()

--- a/pythonforandroid/recipes/sqlalchemy/__init__.py
+++ b/pythonforandroid/recipes/sqlalchemy/__init__.py
@@ -7,9 +7,13 @@ class SQLAlchemyRecipe(CompiledComponentsPythonRecipe):
     version = '1.0.9'
     url = 'https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-{version}.tar.gz'
     
-    depends = [('python2', 'python3'), 'setuptools']
+    depends = [('python2', 'python3'), 'setuptools', 'wheel']
     
     patches = ['zipsafe.patch']
+
+    call_hostpython_via_targetpython = False
+    use_pip = True
+    wheel_name = 'SQLAlchemy'
 
 
 recipe = SQLAlchemyRecipe()

--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -15,10 +15,13 @@ class TwistedRecipe(CythonRecipe):
     version = '15.4.0'
     url = 'https://pypi.python.org/packages/source/T/Twisted/Twisted-{version}.tar.bz2'
 
-    depends = ['setuptools', 'zope_interface']
+    depends = ['setuptools', 'zope_interface', 'wheel']
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = True
+
+    use_pip = True
+    wheel_name = 'Twisted'
 
     def prebuild_arch(self, arch):
         super(TwistedRecipe, self).prebuild_arch(arch)

--- a/pythonforandroid/recipes/wheel/__init__.py
+++ b/pythonforandroid/recipes/wheel/__init__.py
@@ -1,0 +1,16 @@
+
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class WheelRecipe(PythonRecipe):
+    version = '0.29.0'
+    url = 'https://pypi.python.org/packages/source/w/wheel/wheel-{version}.tar.gz'
+
+    depends = [('python2', 'python3crystax')]
+
+    call_hostpython_via_targetpython = False
+    install_in_targetpython = False
+    install_in_hostpython = True
+
+
+recipe = WheelRecipe()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -87,6 +87,7 @@ def require_prebuilt_dist(func):
                                       user_ndk_ver=self.ndk_version)
         dist = self._dist
         dist_args, args = parse_dist_args(args)
+        ctx.build_wheels = dist_args.build_wheels
         if dist.needs_build:
             info_notify('No dist exists that meets your requirements, '
                         'so one will be built.')
@@ -146,7 +147,7 @@ def build_dist_from_args(ctx, dist, args):
 
 def parse_dist_args(args_list):
     parser = argparse.ArgumentParser(
-            description='Create a newAndroid project')
+            description='Create a new Android project')
     parser.add_argument(
             '--bootstrap',
             help=('The name of the bootstrap type, \'pygame\' '
@@ -154,6 +155,12 @@ def parse_dist_args(args_list):
                   'bootstrap be chosen automatically from your '
                   'requirements.'),
             default=None)
+    parser.add_argument(
+            '--build-wheels',
+            help='Build wheels instead of downloading',
+            default=False,
+            dest='build_wheels',
+            action='store_true')
     args, unknown = parser.parse_known_args(args_list)
     return args, unknown
 


### PR DESCRIPTION
Recipes with `use_pip = True` will attempt to install via pip by default. Adding `--build-wheels` on the command line will cause p4a to build the wheels and then install rather than downloading via pip. Currently uses `http://localhost:8080/simple/` as the extra index url (for testing with pypi-server).

Wheel platform is set by Android API and ARM EABI - i.e. `android19-armeabi`.