### PR TITLE
Openssl for Python 2.7.11 (mandatory dependency of Python 2.7.11)

### DIFF
--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -1,15 +1,32 @@
 from functools import partial
-
-from pythonforandroid.toolchain import Recipe, shprint, current_directory
+from pythonforandroid.toolchain import Recipe, current_directory
+from pythonforandroid.logger import shprint
+from os.path import join, exists
 import sh
-
 
 class OpenSSLRecipe(Recipe):
     version = '1.0.2g'
     url = 'https://www.openssl.org/source/openssl-{version}.tar.gz'
+    force_shared = False
+
+    @property
+    def build_static(self):
+        if self.force_shared:
+            return False
+        return True if 'python2' in self.ctx.recipe_build_order else False
+
+    @property
+    def libssl(self):
+        return 'libssl.a' if self.build_static else 'libssl.so'
+
+    @property
+    def libcrypto(self):
+        return 'libcrypto.a' if self.build_static else 'libcrypto.so'
 
     def should_build(self, arch):
-        return not self.has_libs(arch, 'libssl.so', 'libcrypto.so')
+        if exists(join(self.get_build_dir(arch.arch), self.libssl)):
+            return False
+        return True
 
     def check_symbol(self, env, sofile, symbol):
         nm = env.get('NM', 'nm')
@@ -43,17 +60,33 @@ class OpenSSLRecipe(Recipe):
             # so instead we manually run perl passing in Configure
             perl = sh.Command('perl')
             buildarch = self.select_build_arch(arch)
-            shprint(perl, 'Configure', 'shared', 'no-dso', 'no-krb5', buildarch, _env=env)
+
+            # NOTE: Disabled the build of shared libraries to prevent anything to be
+            # linked against them by mistake. It's better to build the openssl libs as
+            # static because this way we avoid conflicts with the openssl libs
+            # distributed with android system. You can force the build of shared libs
+            # setting the variable 'force_shared' to True, but probably,
+            # your app will not be able to use the compiled openssl libraries because
+            # when the app loads them, first will use the system ones,instead of the compiled
+            if self.build_static:
+                shprint(perl, 'Configure', 'no-dso', 'no-krb5', buildarch, _env=env)
+            else:
+                shprint(perl, 'Configure', 'shared', 'no-dso', 'no-krb5', buildarch, _env=env)
+
             self.apply_patch('disable-sover.patch', arch.arch)
 
-            check_crypto = partial(self.check_symbol, env, 'libcrypto.so')
-            # check_ssl = partial(self.check_symbol, env, 'libssl.so')
+            check_crypto = partial(self.check_symbol, env, self.libcrypto)
+            # check_ssl = partial(self.check_symbol, env, self.libssl)
             while True:
                 shprint(sh.make, 'build_libs', _env=env)
                 if all(map(check_crypto, ('SSLeay', 'MD5_Transform', 'MD4_Init'))):
                     break
                 shprint(sh.make, 'clean', _env=env)
 
-            self.install_libs(arch, 'libssl.so', 'libcrypto.so')
+            if exists('libssl.so') and not self.build_static:
+                self.install_libs(arch, 'libssl.so', 'libcrypto.so')
+            else:
+                shprint(sh.cp, 'libssl.a', self.ctx.libs_dir)
+                shprint(sh.cp, 'libcrypto.a', self.ctx.libs_dir)
 
 recipe = OpenSSLRecipe()


### PR DESCRIPTION
This recipe is needed by PR #775 (Python 2.7.11).

This libraries are problematic because android already distributes an older version and we compile all the stuff against the latest version. This causes some troubles when we try to load the openssl libs from the app, because the android system loads first his own libs... and it is almost sure that the app will fail at some point when trying to call some function that not exist anymore, or maybe, is a newer function that not exist in the old libs.

Is for this that I decide to compile this libs as static instead of shared (I know that it increase a little bit the final size of the app but this way we make sure that all the calls to openssl libs will work as expected). Cause building as static libs maybe is not necessary for some recipes or bootstraps, I doubt so, if we need to add this libs into the final app,  I decide to add the ability to build as static or shared (if the new python2 recipe is used it will be build as static, unless the user uses the variable "force_shared" set to True, otherwise it will be build as shared as always has been).

**Merge Note**: This could break the old python2 recipe...so, only should be merged if the Python 2.7.11 PR is accepted