### PR TITLE
Fixes cyclic dependency between freetype and harfbuzz (optional for Python 2.7.11)

### DIFF
--- a/pythonforandroid/recipes/freetype/__init__.py
+++ b/pythonforandroid/recipes/freetype/__init__.py
@@ -1,39 +1,78 @@
 
-from pythonforandroid.toolchain import Recipe, shprint, current_directory, ArchARM
+from pythonforandroid.toolchain import Recipe
+from pythonforandroid.logger import shprint, info
+from pythonforandroid.util import current_directory, ensure_dir
 from os.path import exists, join, realpath
-from os import uname
-import glob
 import sh
 
+# NOTE: The libraries, freetype and harfbuzz, are special because they has cyclic dependencies:
+# freetype can be build with harfbuzz support and harfbuzz can be build with freetype support.
+# So, to correctly build both libraries, first we must build freetype without harfbuzz,
+# then we build harfbuzz with freetype support and then we build again the freetype
+# library with harfbuzz support. See reference at:
+# https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/
 class FreetypeRecipe(Recipe):
-
     version = '2.5.5'
     url = 'http://download.savannah.gnu.org/releases/freetype/freetype-{version}.tar.gz'
-
-    depends = ['harfbuzz']
+    opt_depends = ['harfbuzz']
 
     def should_build(self, arch):
-        if exists(join(self.get_build_dir(arch.arch), 'objs', '.libs', 'libfreetype.so')):
+        if exists(join(self.get_build_dir(arch.arch), 'objs', '.libs', 'libfreetype.a')):
             return False
         return True
 
-    def build_arch(self, arch):
+    def get_jni_dir(self, arch):
+        return join(self.ctx.bootstrap.build_dir, 'jni')
+
+    def get_lib_dir(self, arch):
+        return join(self.get_build_dir(arch.arch), 'objs', '.libs')
+
+    def build_arch(self, arch, with_harfbuzz=False):
         env = self.get_recipe_env(arch)
+        use_harfbuzz = False
+        prefix_path = realpath('.')
+        if 'harfbuzz' in self.ctx.recipe_build_order:
+            use_harfbuzz = True
+            if not with_harfbuzz:
+                info('\t - This is the first Build of freetype (without harfbuzz)')
+                prefix_path = join(self.get_build_dir(arch.arch), 'install')
 
-        harfbuzz_recipe = Recipe.get_recipe('harfbuzz', self.ctx)
-        env['LDFLAGS'] = ' '.join(
-            [env['LDFLAGS'],
-             '-L{}'.format(join(harfbuzz_recipe.get_build_dir(arch.arch), 'src', '.libs'))])
+        if with_harfbuzz:
+            # Is the second build, now we link with harfbuzz
+            info('\t - This is the second Build of freetype: enabling harfbuzz support ...')
+            harfbuzz_build = Recipe.get_recipe('harfbuzz', self.ctx).get_build_dir(arch.arch)
+            freetype_install = join(self.get_build_dir(arch.arch), 'install')
+            env['CFLAGS'] = ' '.join(
+                [env['CFLAGS'], '-I{harfbuzz}'.format(harfbuzz=harfbuzz_build),
+                 '-I{harfbuzz}/src'.format(harfbuzz=harfbuzz_build),
+                 '-I{freetype}/include/freetype2'.format(freetype=freetype_install),
+                 '-L{freetype}/lib -lfreetype'.format(freetype=freetype_install)])
+            env['LDFLAGS'] = ' '.join(['-L{freetype}/lib -lfreetype'.format(freetype=freetype_install)])
 
+            env['HARFBUZZ_CFLAGS'] = '-I{harfbuzz} -I{harfbuzz}/src'.format(harfbuzz=harfbuzz_build)
+            env['HARFBUZZ_LIBS'] = '-L{freetype}/lib -lfreetype ' \
+                                   '-L{harfbuzz}/src/.libs -lharfbuzz'.format(
+                freetype=freetype_install, harfbuzz=harfbuzz_build)
+
+        # Build freetype library
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
             shprint(configure, '--host=arm-linux-androideabi',
-                    '--prefix={}'.format(realpath('.')),
-                    '--without-zlib', '--with-png=no', '--enable-shared',
-                    _env=env)
+                    '--prefix={}'.format(prefix_path),
+                    '--without-zlib', '--with-png=no',
+                    '--disable-shared', _env=env)
             shprint(sh.make, '-j5', _env=env)
 
-            shprint(sh.cp, 'objs/.libs/libfreetype.so', self.ctx.libs_dir)
+            if not with_harfbuzz and use_harfbuzz:
+                # Is first build, install the compiled lib, and clean build env
+                shprint(sh.make, 'install', _env=env)
+                shprint(sh.make, 'distclean', _env=env)
+            else:
+                # This is the second build (or the first if harfbuzz not enabled),
+                # now we copy definitive libs to libs collection. Be sure to link
+                # your recipes to the definitive library, located at: objs/.libs
+                ensure_dir(join(self.ctx.libs_dir, arch.arch))
+                shprint(sh.cp, 'objs/.libs/libfreetype.a', self.ctx.libs_dir)
 
 
 recipe = FreetypeRecipe()

--- a/pythonforandroid/recipes/harfbuzz/__init__.py
+++ b/pythonforandroid/recipes/harfbuzz/__init__.py
@@ -1,33 +1,63 @@
 
-from pythonforandroid.toolchain import Recipe, shprint, current_directory, ArchARM
-from os.path import exists, join, realpath
-from os import uname
-import glob
+from pythonforandroid.toolchain import Recipe, shprint
+from pythonforandroid.util import current_directory
+from os.path import exists, join
 import sh
 
-
+# NOTE: The libraries, freetype and harfbuzz, are special because they has cyclic dependencies:
+# freetype can be build with harfbuzz support and harfbuzz can be build with freetype support.
+# So, to correctly build both libraries, first we must build freetype without harfbuzz,
+# then we build harfbuzz with freetype support and then we build again the freetype
+# library with harfbuzz support. See reference at:
+# https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/
 class HarfbuzzRecipe(Recipe):
     version = '0.9.40'
     url = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-{version}.tar.bz2'
 
     def should_build(self, arch):
-        if exists(join(self.get_build_dir(arch.arch), 'src', '.libs', 'libharfbuzz.so')):
+        if exists(join(self.get_build_dir(arch.arch),
+                       'src', '.libs', 'libharfbuzz.a')):
             return False
         return True
+
+    def get_jni_dir(self, arch):
+        return join(self.ctx.bootstrap.build_dir, 'jni')
+
+    def get_lib_dir(self, arch):
+        if 'pygame' in self.ctx.recipe_build_order:
+            return join(self.get_jni_dir(arch), 'harfbuzz', arch.arch)
+        return join(self.get_build_dir(arch.arch), 'src', '.libs')
 
     def build_arch(self, arch):
 
         env = self.get_recipe_env(arch)
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
-            self.ctx.get_libs_dir(arch.arch) +
-            '-L{}'.format(self.ctx.libs_dir))
+        env['LDFLAGS'] += ' -L{} -L{}'.format(self.ctx.get_libs_dir(arch.arch), self.ctx.libs_dir)
+
+        with_freetype = 'no'
+        # FREETYPE FLAGS
+        if 'freetype' in self.ctx.recipe_build_order:
+            with_freetype = 'yes'
+            freetype = self.get_recipe('freetype', self.ctx)
+            freetype_install = join(freetype.get_build_dir(arch.arch), 'install')
+            env['CFLAGS'] = ' '.join([env['CFLAGS'], '-I{}/include/freetype2'.format(freetype_install),
+                                      '-L{}/lib'.format(freetype_install), '-lfreetype'])
+        # HARFBUZZ FLAGS
+        env['CFLAGS'] = ' '.join([env['CFLAGS'], '-I{}'.format(self.get_build_dir(arch.arch)),
+             '-I{}/src'.format(self.get_build_dir(arch.arch))])
+        env['LDFLAGS'] += ' -L{}/src/.libs'.format(self.get_build_dir(arch.arch))
+
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
             shprint(configure, '--without-icu', '--host=arm-linux=androideabi',
                     '--prefix={}'.format(join(self.ctx.build_dir, 'python-install')),
-                    '--without-freetype', '--without-glib', _env=env)
+                    '--with-freetype={}'.format(with_freetype), '--without-glib',
+                    '--disable-shared', _env=env)
             shprint(sh.make, '-j5', _env=env)
 
-            shprint(sh.cp, '-L', join('src', '.libs', 'libharfbuzz.so'), self.ctx.libs_dir)
+            shprint(sh.cp, '-L', join('src', '.libs', 'libharfbuzz.a'), self.ctx.libs_dir)
+
+        if 'freetype' in self.ctx.recipe_build_order:
+            # Rebuild freetype with harfbuzz support
+            freetype.build_arch(arch, with_harfbuzz=True)
 
 recipe = HarfbuzzRecipe()


### PR DESCRIPTION
The changes made in this PR should fix the issues with cyclic dependencies between freetype and harfbuzz. This PR has the words "optional for Python 2.7.11" to keep reference to the original PR #775 (Python 2.7.11), but actually it should work as an independent PR so... I think it could be merged safely without merging all the other stuff related with the "Python 2.7.11" update