### PR TITLE
Pygame's recipe updated to use latest libjpeg-turbo and libfreetype (optional for Python 2.7.11)

### DIFF
--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -1,12 +1,11 @@
 
-from pythonforandroid.recipe import Recipe
-from pythonforandroid.util import current_directory, ensure_dir
-from pythonforandroid.logger import debug, shprint, info
-from os.path import exists, join
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from pythonforandroid.util import ensure_dir
+from pythonforandroid.logger import debug, shprint
+from os.path import join
 import sh
-import glob
 
-class PygameRecipe(Recipe):
+class PygameRecipe(CompiledComponentsPythonRecipe):
     name = 'pygame'
     version = '1.9.1'
     url = 'http://pygame.org/ftp/pygame-{version}release.tar.gz'
@@ -17,15 +16,64 @@ class PygameRecipe(Recipe):
     patches = ['patches/fix-surface-access.patch',
                'patches/fix-array-surface.patch',
                'patches/fix-sdl-spam-log.patch']
+    call_hostpython_via_targetpython = False
 
     def get_recipe_env(self, arch=None):
         env = super(PygameRecipe, self).get_recipe_env(arch)
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
-            self.ctx.get_libs_dir(arch.arch))
+
+        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+        env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python2.7'
+        # SET LINKER TO USE THE CORRECT GCC
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
+        env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/lib' + \
+                          ' -lpython2.7'
+
+        env['LDFLAGS'] += ' -L{}'.format(self.ctx.get_libs_dir(arch.arch))
         env['LDSHARED'] = join(self.ctx.root_dir, 'tools', 'liblink')
         env['LIBLINK'] = 'NOTNONE'
         env['NDKPLATFORM'] = self.ctx.ndk_platform
 
+        # PNG FLAGS
+        png = self.get_recipe('png', self.ctx)
+        png_lib_dir = png.get_lib_dir(arch)
+        png_inc_dir = png.get_include_dir(arch)
+        env['CFLAGS'] += ' -I{}'.format(png_inc_dir)
+        env['LDFLAGS'] += ' -L{} -lpng'.format(png_lib_dir)
+
+        # JPEG TURBO FLAGS
+        jpeg = self.get_recipe('jpeg', self.ctx)
+        jpeg_lib_dir = jpeg.get_lib_dir(arch)
+        jpeg_jni_dir = jpeg.get_jni_dir(arch)
+        env['CFLAGS'] += ' -I{} -I{} -I{}'.format(
+            jpeg_jni_dir, join(jpeg_jni_dir, 'android'),
+            join(jpeg_jni_dir, 'simd'))
+        env['LDFLAGS'] += ' -L{} -ljpeg'.format(jpeg_lib_dir)
+
+        # FREETYPE FLAGS
+        free = self.get_recipe('freetype', self.ctx)
+        free_lib_dir = free.get_lib_dir(arch)
+        free_inc_dir = join(free.get_build_dir(arch.arch), 'include')
+        env['CFLAGS'] += ' -I{} -L{}'.format(free_inc_dir, free_lib_dir)
+        if 'harfbuzz' in self.ctx.recipe_build_order:
+            free_install = join(free.get_build_dir(arch.arch), 'install')
+            harf = self.get_recipe('harfbuzz', self.ctx)
+            harf_lib_dir = harf.get_lib_dir(arch)
+            harf_inc_dir = harf.get_build_dir(arch.arch)
+            env['CFLAGS'] += ' -I{} -I{} -I{} -L{}'.format(
+                harf_inc_dir, join(harf_inc_dir, 'src'),
+                join(free_install, 'include'), harf_lib_dir)
+            env['LDFLAGS'] += ' -L{} -lharfbuzz'.format(harf_lib_dir)
+
+        env['CFLAGS'] += ' -I{jni_path}/sdl/include -I{jni_path}/sdl_mixer'.format(
+            jni_path=join(self.ctx.bootstrap.build_dir, 'jni'))
+        env['CFLAGS'] += ' -I{jni_path}/sdl_ttf -I{jni_path}/sdl_image'.format(
+            jni_path=join(self.ctx.bootstrap.build_dir, 'jni'))
+        debug('pygame cflags', env['CFLAGS'])
+
+        env['LDFLAGS'] += ' -L{src_path}/obj/local/{arch} -lm -lz'.format(
+            src_path=self.ctx.bootstrap.build_dir, arch=env['ARCH'])
+
+        env['LDSHARED'] = join(self.ctx.root_dir, 'tools', 'liblink')
         # Every recipe uses its own liblink path, object files are collected and biglinked later
         liblink_path = join(self.get_build_container_dir(arch.arch), 'objects_{}'.format(self.name))
         env['LIBLINK_PATH'] = liblink_path
@@ -37,42 +85,6 @@ class PygameRecipe(Recipe):
             return
         shprint(sh.cp, join(self.get_recipe_dir(), 'Setup'),
                 join(self.get_build_dir(arch.arch), 'Setup'))
-        
-    def build_arch(self, arch):
-        # AND: I'm going to ignore any extra pythonrecipe or cythonrecipe behaviour for now
-        
-        env = self.get_recipe_env(arch)
-        
-        env['CFLAGS'] = env['CFLAGS'] + ' -I{jni_path}/png -I{jni_path}/jpeg'.format(
-            jni_path=join(self.ctx.bootstrap.build_dir, 'jni'))
-        env['CFLAGS'] = env['CFLAGS'] + ' -I{jni_path}/sdl/include -I{jni_path}/sdl_mixer'.format(
-            jni_path=join(self.ctx.bootstrap.build_dir, 'jni'))
-        env['CFLAGS'] = env['CFLAGS'] + ' -I{jni_path}/sdl_ttf -I{jni_path}/sdl_image'.format(
-            jni_path=join(self.ctx.bootstrap.build_dir, 'jni'))
-        debug('pygame cflags', env['CFLAGS'])
-
-        
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{libs_path} -L{src_path}/obj/local/{arch} -lm -lz'.format(
-            libs_path=self.ctx.libs_dir, src_path=self.ctx.bootstrap.build_dir, arch=env['ARCH'])
-
-        env['LDSHARED'] = join(self.ctx.root_dir, 'tools', 'liblink')
-
-        with current_directory(self.get_build_dir(arch.arch)):
-            info('hostpython is ' + self.ctx.hostpython)
-            hostpython = sh.Command(self.ctx.hostpython)
-            shprint(hostpython, 'setup.py', 'install', '-O2', _env=env,
-                    _tail=10, _critical=True)
-
-            info('strip is ' + env['STRIP'])
-            build_lib = glob.glob('./build/lib*')
-            assert len(build_lib) == 1
-            print('stripping pygame')
-            shprint(sh.find, build_lib[0], '-name', '*.o', '-exec',
-                    env['STRIP'], '{}', ';')
-
-        python_install_path = join(self.ctx.build_dir, 'python-install')
-        # AND: Should do some deleting here!
-        print('Should remove pygame tests etc. here, but skipping for now')
 
 
 recipe = PygameRecipe()

--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -21,12 +21,8 @@ class PygameRecipe(CompiledComponentsPythonRecipe):
     def get_recipe_env(self, arch=None):
         env = super(PygameRecipe, self).get_recipe_env(arch)
 
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
-        env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python2.7'
         # SET LINKER TO USE THE CORRECT GCC
         env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
-        env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/lib' + \
-                          ' -lpython2.7'
 
         env['LDFLAGS'] += ' -L{}'.format(self.ctx.get_libs_dir(arch.arch))
         env['LDSHARED'] = join(self.ctx.root_dir, 'tools', 'liblink')

--- a/pythonforandroid/recipes/pygame_bootstrap_components/__init__.py
+++ b/pythonforandroid/recipes/pygame_bootstrap_components/__init__.py
@@ -1,5 +1,6 @@
-from pythonforandroid.toolchain import BootstrapNDKRecipe, current_directory, shprint, info
-from os.path import exists, join
+from pythonforandroid.toolchain import BootstrapNDKRecipe, current_directory
+from pythonforandroid.logger import shprint, info
+from os.path import exists, join, basename
 import sh
 import glob
 
@@ -19,9 +20,10 @@ class PygameJNIComponentsRecipe(BootstrapNDKRecipe):
                 return
             for dirn in glob.glob(join(self.get_build_dir(arch),
                                        'pygame_bootstrap_jni', '*')):
-                shprint(sh.mv, dirn, './')
+                if basename(dirn) not in ['freetype', 'jpeg', 'sqlite3']:
+                    shprint(sh.mv, dirn, './')
         info('Unpacking was successful, deleting original container dir')
         shprint(sh.rm, '-rf', self.get_build_dir(arch))
-        
+
 
 recipe = PygameJNIComponentsRecipe()


### PR DESCRIPTION
This PR has the words "optional for Python 2.7.11" to keep reference to the original PR #775 (Python 2.7.11). This depends on PRs: #784,  #785 and #793.

Here I force pygame to build against the p4a's libjpeg-turbo and p4a's libfreeetype instead of the ones distributed with the pygame_bootstrap_components. This way we avoid building all the stuff against different versions of libraries and the ones from the p4a are more updated. Unfortunately I cannot manage to use the same formula with libpng's recipe.

Merge note: Be careful with this because the `pygame_bootstrap_components/__init__.py` file also has been modified in the Python 2.7.11 (PR #775) and it is possible that a merge conflict happens, if this is finally merged.

