### PR TITLE
Sdl's recipe updated to use latest libjpeg-turbo and libfreetype (optional for Python 2.7.11)

### DIFF
--- a/pythonforandroid/recipes/sdl/__init__.py
+++ b/pythonforandroid/recipes/sdl/__init__.py
@@ -1,31 +1,64 @@
-from pythonforandroid.toolchain import BootstrapNDKRecipe, shprint, ArchARM, current_directory, info
+from pythonforandroid.toolchain import BootstrapNDKRecipe, shprint, current_directory, info, info_main, ensure_dir
 from os.path import exists, join
 import sh
+
 
 class LibSDLRecipe(BootstrapNDKRecipe):
     version = "1.2.14"
     url = None  
     name = 'sdl'
-    depends = ['python2', 'pygame_bootstrap_components']
+    dir_name = 'sdl'
+    depends = ['python2', 'pygame_bootstrap_components', 'jpeg', 'freetype']
     conflicts = ['sdl2']
+
+    def prebuild_arch(self, arch):
+        super(LibSDLRecipe, self).prebuild_arch(arch)
+
+        # Patch sdl_image and sdl_ttf to support new libraries
+        if exists(join(self.get_jni_dir(), 'sdl', '.patched')):
+            info_main('sdl already patched, skipping')
+            return
+        for patch_dir, patch in [('sdl_image', 'jpeg-prebuilt.patch'),
+                                 ('sdl_ttf', 'freetype-prebuilt.patch')]:
+            shprint(sh.patch, "-t", "-d", join(self.get_jni_dir(), patch_dir), "-p1",
+                        "-i", join(self.recipe_dir, patch), _tail=10)
+        shprint(sh.touch, join(self.get_jni_dir(), 'sdl', '.patched'))
+
+    def get_recipe_env(self, arch=None):
+        env = super(LibSDLRecipe, self).get_recipe_env(arch)
+
+        env['WITH_HARFBUZZ_SUPPORT'] = 'false'
+        if 'harfbuzz' in self.ctx.recipe_build_order:
+            env['WITH_HARFBUZZ_SUPPORT'] = 'true'
+
+        return env
 
     def build_arch(self, arch):
 
         if exists(join(self.ctx.libs_dir, 'libsdl.so')):
             info('libsdl.so already exists, skipping sdl build.')
             return
-        
-        env = arch.get_env()
+
+        # Patch Python Install Directory
+        python_build_name = self.get_recipe('python2', arch.arch).get_dir_name()
+        shprint(sh.sed, '-i', 's#other_builds/python2/#other_builds/{}/#'.format(python_build_name),
+                join(self.get_jni_dir(), 'application/Android.mk'))
+
+        env = self.get_recipe_env(arch)
 
         with current_directory(self.get_jni_dir()):
             shprint(sh.ndk_build, 'V=1', _env=env, _tail=20, _critical=True)
 
-        libs_dir = join(self.ctx.bootstrap.build_dir, 'libs', arch.arch)
         import os
+        libs_dir = join(self.ctx.bootstrap.build_dir, 'libs', arch.arch)
         contents = list(os.walk(libs_dir))[0][-1]
+
+        libs_target = join(self.ctx.build_dir, 'libs_collections',
+                        self.ctx.bootstrap.distribution.name, arch.arch)
+        ensure_dir(libs_target)
         for content in contents:
-            shprint(sh.cp, '-a', join(self.ctx.bootstrap.build_dir, 'libs', arch.arch, content),
-                    self.ctx.libs_dir)
+            shprint(sh.cp, '-a', join(self.ctx.bootstrap.build_dir, 'libs',
+                                      arch.arch, content), libs_target)
 
 
 recipe = LibSDLRecipe()

--- a/pythonforandroid/recipes/sdl/freetype-prebuilt.patch
+++ b/pythonforandroid/recipes/sdl/freetype-prebuilt.patch
@@ -1,0 +1,57 @@
+--- sdl_ttf/Android.mk.orig	2015-06-21 15:14:54.000000000 +0200
++++ sdl_ttf/Android.mk	2016-04-16 19:09:51.775647997 +0200
+@@ -2,9 +2,29 @@
+ 
+ include $(CLEAR_VARS)
+ 
+-LOCAL_MODULE := sdl_ttf
++SUPPORT_HARFBUZZ := $(WITH_HARFBUZZ_SUPPORT)
++HARFBUZZ_LIBRARY_PATH := $(LOCAL_PATH)/../../../../other_builds/harfbuzz/$(ARCH)/harfbuzz
+ 
+-LOCAL_CFLAGS := -I$(LOCAL_PATH) -I$(LOCAL_PATH)/../sdl/include -I$(LOCAL_PATH)/../freetype/include
++# HARFBUZZ
++ifeq ($(SUPPORT_HARFBUZZ),true)
++    FREETYPE_LIBRARY_PATH := $(LOCAL_PATH)/../../../../other_builds/freetype-harfbuzz/$(ARCH)/freetype
++
++    LOCAL_MODULE    := harfbuzz
++    LOCAL_SRC_FILES := $(HARFBUZZ_LIBRARY_PATH)/src/.libs/libharfbuzz.a
++    include $(PREBUILT_STATIC_LIBRARY)
++    include $(CLEAR_VARS)
++else
++    FREETYPE_LIBRARY_PATH := $(LOCAL_PATH)/../../../../other_builds/freetype/$(ARCH)/freetype
++endif
++
++# FREETYPE
++LOCAL_MODULE := freetype
++LOCAL_SRC_FILES := $(FREETYPE_LIBRARY_PATH)/objs/.libs/libfreetype.a
++include $(PREBUILT_STATIC_LIBRARY)
++include $(CLEAR_VARS)
++
++# SDL_TTF
++LOCAL_MODULE := sdl_ttf
+ 
+ LOCAL_CPP_EXTENSION := .cpp
+ 
+@@ -14,5 +34,22 @@
+ LOCAL_STATIC_LIBRARIES := freetype
+ LOCAL_LDLIBS := -lz
+ 
++LOCAL_CFLAGS := -I$(LOCAL_PATH) -I$(LOCAL_PATH)/../sdl/include -I$(FREETYPE_LIBRARY_PATH)/include
++LOCAL_CFLAGS += -DFT2_BUILD_LIBRARY
++LOCAL_C_INCLUDES += $(FREETYPE_LIBRARY_PATH)/include \
++    $(FREETYPE_LIBRARY_PATH)/include/config \
++    $(FREETYPE_LIBRARY_PATH)/include/internal \
++    $(FREETYPE_LIBRARY_PATH)/include/internal/services \
++    $(FREETYPE_LIBRARY_PATH)/src
++
++ifeq ($(SUPPORT_HARFBUZZ),true)
++    LOCAL_C_INCLUDES += $(HARFBUZZ_LIBRARY_PATH) \
++        $(HARFBUZZ_LIBRARY_PATH)/src \
++        $(FREETYPE_LIBRARY_PATH)/install/include
++    LOCAL_STATIC_LIBRARIES += harfbuzz
++endif
++
++LOCAL_EXPORT_C_INCLUDES += $(LOCAL_C_INCLUDES)
++
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/pythonforandroid/recipes/sdl/jpeg-prebuilt.patch
+++ b/pythonforandroid/recipes/sdl/jpeg-prebuilt.patch
@@ -1,0 +1,45 @@
+--- sdl_image/Android.mk.orig	2015-06-21 15:14:54.000000000 +0200
++++ sdl_image/Android.mk	2016-06-12 02:41:47.071707950 +0200
+@@ -2,10 +2,32 @@
+ 
+ include $(CLEAR_VARS)
+ 
++JPG_LIBRARY_PATH := $(LOCAL_PATH)/../../../../other_builds/jpeg/$(ARCH)/jpeg
++PNG_LIBRARY_PATH := $(LOCAL_PATH)/../png
++
++# JPEG
++LOCAL_MODULE    := jpeg
++LOCAL_SRC_FILES := $(JPG_LIBRARY_PATH)/obj/local/$(ARCH)/libjpeg.a
++include $(PREBUILT_STATIC_LIBRARY)
++include $(CLEAR_VARS)
++
++# SDL_IMAGE
+ LOCAL_MODULE := sdl_image
+ 
+-LOCAL_CFLAGS := -I$(LOCAL_PATH) -I$(LOCAL_PATH)/../jpeg -I$(LOCAL_PATH)/../png -I$(LOCAL_PATH)/../sdl/include \
+-				-DLOAD_PNG -DLOAD_JPG -DLOAD_GIF -DLOAD_BMP
++LOCAL_CFLAGS := -I$(LOCAL_PATH) -I$(LOCAL_PATH)/../sdl/include
++
++# JPEG/PNG FLAGS
++LOCAL_CFLAGS += -I$(JPG_LIBRARY_PATH) \
++    -I$(JPG_LIBRARY_PATH)/android \
++    -I$(JPG_LIBRARY_PATH)/simd \
++    -I$(JPG_LIBRARY_PATH) \
++    -I$(PNG_LIBRARY_PATH) \
++    -DLOAD_PNG -DLOAD_JPG -DLOAD_GIF -DLOAD_BMP -DAVOID_TABLES
++
++LOCAL_C_INCLUDES += $(JPG_LIBRARY_PATH) \
++    $(JPG_LIBRARY_PATH)/android \
++    $(JPG_LIBRARY_PATH)/simd \
++    $(PNG_LIBRARY_PATH)
+ 
+ LOCAL_CPP_EXTENSION := .cpp
+ 
+@@ -17,5 +39,7 @@
+ 
+ LOCAL_LDLIBS := -lz
+ 
++LOCAL_EXPORT_C_INCLUDES += $(LOCAL_C_INCLUDES)
++
+ include $(BUILD_SHARED_LIBRARY)
+ 


### PR DESCRIPTION
This PR has the words "optional for Python 2.7.11" to keep reference to the original PR #775 (Python 2.7.11). This depends on PR #784.

Here I force sdl to build against the p4a's libjpeg-turbo and p4a's libfreeetype instead of the ones distributed with the sdl package. Unfortunately I cannot manage to use the same formula with libpng's recipe.

