### PR TITLE
Added commands to import binary dists, and fetch from a basic online repo

### DIFF
--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -1,9 +1,13 @@
-from os.path import exists, join
+from os.path import (exists, join, realpath, isdir, isfile,
+                     basename, splitext)
+import shutil
+import os
 import glob
 import json
+import sh
 
-from pythonforandroid.logger import (info, info_notify, warning,
-                                     Err_Style, Err_Fore)
+from pythonforandroid.logger import (info, info_notify, warning, error,
+                                     Err_Style, Err_Fore, shprint)
 from pythonforandroid.util import current_directory
 
 
@@ -228,3 +232,87 @@ def pretty_log_dists(dists, log_func=info):
 
     for line in infos:
         log_func('\t' + line)
+
+
+def import_binary_dist(path, ctx):
+        print('build dir is', ctx.build_dir)
+        print('dist dir is', ctx.dist_dir)
+
+        path = realpath(path)
+
+        filename, extension = splitext(basename(path))
+
+        temp_dir = join(ctx.dist_dir, basename(filename))
+
+        if not exists(path):
+            error('No file or folder with the given name exists')
+            exit(1)
+
+        if exists(temp_dir):
+            error('Cannot extract dist, a dist with the default temporary '
+                  'name already exists')
+            info('To fix this, rename the dist file or delete the existing '
+                 'dist')
+            exit(1)
+
+        print('path is', path)
+        if isdir(path):
+            info('Dist path is a directory, copying')
+            shutil.copytree(path, temp_dir)
+        elif isfile(path):
+            info("Extracting {} into {}".format(path, temp_dir))
+
+            if path.endswith(".tgz") or path.endswith(".tar.gz"):
+                shprint(sh.tar, "-C", temp_dir, "-xvzf", path)
+
+            elif path.endswith(".tbz2") or path.endswith(".tar.bz2"):
+                shprint(sh.tar, "-C", temp_dir, "-xvjf", path)
+
+            elif path.endswith(".zip"):
+                import zipfile
+                zf = zipfile.ZipFile(path)
+                zf.extractall(path=temp_dir)
+                zf.close()
+
+        else:
+            error(
+                "Error: cannot extract, unrecognized filetype for {}"
+                .format(path))
+            exit(1)
+
+        # Allow zipped dir or zipped contents
+        files = os.listdir(temp_dir)
+        print('files are', files)
+        if len(files) == 1:
+            os.rename(temp_dir, temp_dir + '__old')
+            os.rename(join(temp_dir + '__old', files[0]), temp_dir)
+            shutil.rmtree(temp_dir + '__old')
+
+        if not exists(join(temp_dir, 'dist_info.json')):
+            error('Dist does not include a dist_info.json, cannot install')
+            shutil.rmtree(temp_dir)
+            exit(1)
+
+        with open(join(temp_dir, 'dist_info.json'), 'r') as fileh:
+            data = json.load(fileh)
+
+        if 'dist_name' not in data:
+            error('Dist does not have dist_name declared in its dist_info.json')
+            shutil.rmtree(temp_dir)
+            exit(1)
+
+        dist_name = data['dist_name']
+        info('Imported dist has name {}'.format(dist_name))
+
+        dist_dir = join(ctx.dist_dir, dist_name)
+        if dist_dir != temp_dir:
+            if exists(dist_dir):
+                error('A dist with this name already exists, exiting.')
+                shutil.rmtree(temp_dir)
+                exit(1)
+
+            os.rename(temp_dir, dist_dir)
+            
+        info('Dist was imported successfully')
+        info('Run `p4a dists` to see information about the new dist.')
+    

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -236,9 +236,6 @@ def pretty_log_dists(dists, log_func=info):
 
 
 def import_binary_dist(path, ctx):
-        print('build dir is', ctx.build_dir)
-        print('dist dir is', ctx.dist_dir)
-
         path = realpath(path)
 
         filename, extension = splitext(basename(path))
@@ -256,7 +253,6 @@ def import_binary_dist(path, ctx):
                  'dist')
             exit(1)
 
-        print('path is', path)
         if isdir(path):
             info('Dist path is a directory, copying')
             shutil.copytree(path, temp_dir)
@@ -283,7 +279,6 @@ def import_binary_dist(path, ctx):
 
         # Allow zipped dir or zipped contents
         files = os.listdir(temp_dir)
-        print('files are', files)
         if len(files) == 1:
             os.rename(temp_dir, temp_dir + '__old')
             os.rename(join(temp_dir + '__old', files[0]), temp_dir)
@@ -325,8 +320,6 @@ def fetch_online_dists(ctx):
     if exists(join(ctx.storage_dir, 'binary_dists')):
         shutil.rmtree(join(ctx.storage_dir, 'binary_dists'))
     os.makedirs(join(ctx.storage_dir, 'binary_dists'))
-
-    print('build dir is', ctx.storage_dir)
 
     dists_info_filen = join(ctx.storage_dir, 'binary_dists', 'dists.json')
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -774,6 +774,9 @@ build_dist
 
         import_binary_dist(path, ctx)
 
+    def fetch_binary_dists(self, args):
+        from pythonforandroid.distribution import fetch_online_dists
+        fetch_online_dists(self.ctx)
 
 def main():
     ToolchainCL()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -816,10 +816,18 @@ def import_binary_dist(path, ctx):
                 zf.close()
 
         else:
-            warning(
+            error(
                 "Error: cannot extract, unrecognized filetype for {}"
                 .format(path))
-            raise Exception()
+            exit(1)
+
+        # Allow zipped dir or zipped contents
+        files = os.listdir(temp_dir)
+        print('files are', files)
+        if len(files) == 1:
+            os.rename(temp_dir, temp_dir + '__old')
+            os.rename(join(temp_dir + '__old', files[0]), temp_dir)
+            shutil.rmtree(temp_dir + '__old')
 
         if not exists(join(temp_dir, 'dist_info.json')):
             error('Dist does not include a dist_info.json, cannot install')
@@ -838,12 +846,13 @@ def import_binary_dist(path, ctx):
         info('Imported dist has name {}'.format(dist_name))
 
         dist_dir = join(ctx.dist_dir, dist_name)
-        if exists(dist_dir):
-            error('A dist with this name already exists, exiting.')
-            shutil.rmtree(temp_dir)
-            exit(1)
+        if dist_dir != temp_dir:
+            if exists(dist_dir):
+                error('A dist with this name already exists, exiting.')
+                shutil.rmtree(temp_dir)
+                exit(1)
 
-        os.rename(temp_dir, dist_dir)
+            os.rename(temp_dir, dist_dir)
             
         info('Dist was installed successfully')
         info('Run `p4a dists` to see information about the new dist.')


### PR DESCRIPTION
I don't really know if this is a good idea, but it seems like it could be. I've tried to keep this POC simple. Basically, you run `p4a fetch_binary_dists` to download some prebuilt dists from a github repo containing a basic index. p4a then downloads each one of these if there isn't already one with that name. After this, the dists behave exactly as normal and can be used to make APKs without any compiling.

Here's some sample output of running the commands:

    asandy@homemade:~/devel/p4a-binary-distribution$ p4a dists
    [INFO]:    This python-for-android revamp is an experimental alpha release!
    [INFO]:    It should work (mostly), but you may experience missing features or bugs.
    There are no dists currently built.
    asandy@homemade:~/devel/p4a-binary-distribution$ p4a fetch_binary_dists
    [INFO]:    This python-for-android revamp is an experimental alpha release!
    [INFO]:    It should work (mostly), but you may experience missing features or bugs.
    [INFO]:    Retrieved binary dists index
    [INFO]:    Found dists for download:
    [INFO]:        - py2_sdl2_binary_test
    [INFO]:    py2_sdl2_binary_test dist not yet present, downloading
    [INFO]:    Extracting /home/asandy/.local/share/python-for-android/binary_dists/py2_sdl2_binary_test.zip into /home/asandy/.local/share/python-for-android/dists/py2_sdl2_binary_test
    [INFO]:    Imported dist has name py2_sdl2_binary_test
    [INFO]:    Dist was imported successfully
    [INFO]:    Run `p4a dists` to see information about the new dist.
    asandy@homemade:~/devel/p4a-binary-distribution$ p4a dists
    [INFO]:    This python-for-android revamp is an experimental alpha release!
    [INFO]:    It should work (mostly), but you may experience missing features or bugs.
    /usr/lib/python3.5/re.py:203: FutureWarning: split() requires a non-empty pattern match.
      return _compile(pattern, flags).split(string, maxsplit)
    Distributions currently installed are:
        py2_sdl2_binary_test: includes recipes (hostpython2, sdl2_image, sdl2_mixer, sdl2_ttf, python2, sdl2, six, pyjnius, kivy), built for archs (armeabi)
