### PR TITLE
Fixed python2 with pygame bootstrap

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/jni/application/Android.mk
+++ b/pythonforandroid/bootstraps/pygame/build/jni/application/Android.mk
@@ -18,7 +18,7 @@ LOCAL_CFLAGS := $(foreach D, $(APP_SUBDIRS), -I$(LOCAL_PATH)/$(D)) \
 				-I$(LOCAL_PATH)/../jpeg \
 				-I$(LOCAL_PATH)/../intl \
 				-I$(LOCAL_PATH)/.. \
-                -I$(LOCAL_PATH)/../../../../other_builds/python2/$(ARCH)/python2/python-install/include/python2.7
+                -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7
 				# -I$(LOCAL_PATH)/../../../../python-install/include/python2.7
 				# -I$(LOCAL_PATH)/../../../build/python-install/include/python2.7
 
@@ -40,7 +40,7 @@ LOCAL_LDLIBS := -lpython2.7 -lGLESv1_CM -ldl -llog -lz
 
 # AND: Another hardcoded path that should be templated
 # AND: NOT TEMPALTED! We can use $ARCH
-LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/python2/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
+LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
 
 LIBS_WITH_LONG_SYMBOLS := $(strip $(shell \
 	for f in $(LOCAL_PATH)/../../libs/$ARCH/*.so ; do \

--- a/pythonforandroid/recipes/sdl/__init__.py
+++ b/pythonforandroid/recipes/sdl/__init__.py
@@ -15,7 +15,7 @@ class LibSDLRecipe(BootstrapNDKRecipe):
             info('libsdl.so already exists, skipping sdl build.')
             return
         
-        env = arch.get_env()
+        env = self.get_recipe_env(arch)
 
         with current_directory(self.get_jni_dir()):
             shprint(sh.ndk_build, 'V=1', _env=env, _tail=20, _critical=True)
@@ -26,6 +26,14 @@ class LibSDLRecipe(BootstrapNDKRecipe):
         for content in contents:
             shprint(sh.cp, '-a', join(self.ctx.bootstrap.build_dir, 'libs', arch.arch, content),
                     self.ctx.libs_dir)
+
+    def get_recipe_env(self, arch=None):
+        env = super(LibSDLRecipe, self).get_recipe_env(arch)
+        py2 = self.get_recipe('python2', arch.ctx)
+        env['PYTHON2_NAME'] = py2.get_dir_name()
+        if 'python2' in self.ctx.recipe_build_order:
+            env['EXTRA_LDLIBS'] = ' -lpython2.7'
+        return env
 
 
 recipe = LibSDLRecipe()


### PR DESCRIPTION
The jni code wasn't checking the correct python2 build dir, so it
couldn't find Python.h when python2 was built with optional
dependencies.