### PR TITLE
Fix build errors in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,7 +82,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['ext/*', ]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,6 +35,7 @@ Contents
    apis
    troubleshooting
    contribute
+   related
    old_toolchain/index.rst
 
 

--- a/doc/source/old_toolchain/faq.rst
+++ b/doc/source/old_toolchain/faq.rst
@@ -5,7 +5,7 @@ arm-linux-androideabi-gcc: Internal error: Killed (program cc1)
 ---------------------------------------------------------------
 
 This could happen if you are not using a validated SDK/NDK with Python for
-Android. Go to :doc:`prerequisites.rst` to see which one are working.
+Android. Go to :doc:`prerequisites` to see which one are working.
 
 _sqlite3.so not found
 ---------------------

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -110,7 +110,7 @@ This will first build a distribution that contains `python2` and `kivy`, and usi
 You can also use ``--bootstrap=pygame``, but this bootstrap is deprecated for use with Kivy and SDL2 is preferred.
 
 Build a WebView application
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To build your application, you need to have a name, version, a package
 identifier, and explicitly use the webview bootstrap, as
@@ -158,14 +158,14 @@ If something goes wrong and you don't know how to fix it, add the
 group <https://groups.google.com/forum/#!forum/kivy-users>`__ or irc
 channel #kivy at irc.freenode.net .
 
-See :ref:`Troubleshooting <troubleshooting>` for more information.
+See :doc:`troubleshooting` for more information.
 
 
 Advanced usage
 --------------
 
 Recipe management
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 You can see the list of the available recipes with::
 
@@ -187,7 +187,7 @@ it (edit the ``__init__.py``)::
     
 
 Distribution management
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Every time you start a new project, python-for-android will internally
 create a new distribution (an Android build project including Python
@@ -215,7 +215,7 @@ Configuration file
 python-for-android checks in the current directory for a configuration
 file named ``.p4a``. If found, it adds all the lines as options to the
 command line. For example, you can add the options you would always
-include such as:
+include such as::
 
     --dist_name my_example
     --android_api 19

--- a/doc/source/related.rst
+++ b/doc/source/related.rst
@@ -1,4 +1,5 @@
 Related projects
 ================
 
-python-for-android was originally created to package Kivy applications.
+python-for-android was originally created to package `Kivy <https://kivy.org>`
+applications.

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -1,3 +1,4 @@
+.. _troubleshooting:
 
 Troubleshooting
 ===============


### PR DESCRIPTION
~31 errors purged to 2:
```
p4a\doc\source\commands.rst:17: WARNING: autodoc: failed to import class u'ToolchainCL' from module u'toolchain'; the module executes module level statement and it might call sys.exit().
p4a\doc\source\recipes.rst:488: WARNING: autodoc: failed to import class u'Recipe' from module u'toolchain'; the module executes module level statement and it might call sys.exit().
```
 Most of the errors came with `ext/sphinx_rtd_theme` because it used non-existing `math` extension. Then some broken links, underlines, missing `_static` etc.

I took out `ext/*` part of the docs out because it's just an example from sphinx and shouldn't be available in the final documentation. It isn't included in pdf or in the website, but if you build a local docs, then it'll be there.