### PR TITLE
Coverage recipe

### DIFF
--- a/pythonforandroid/recipes/coverage/__init__.py
+++ b/pythonforandroid/recipes/coverage/__init__.py
@@ -1,0 +1,19 @@
+from pythonforandroid.toolchain import PythonRecipe
+
+
+class CoverageRecipe(PythonRecipe):
+
+    version = '4.1'
+
+    url = 'https://pypi.python.org/packages/2d/10/6136c8e10644c16906edf4d9f7c782c0f2e7ed47ff2f41f067384e432088/coverage-{version}.tar.gz'
+
+    depends = ['hostpython2', 'setuptools']
+
+    patches = ['fallback-utf8.patch']
+
+    site_packages_name = 'coverage'
+
+    call_hostpython_via_targetpython = False
+
+
+recipe = CoverageRecipe()

--- a/pythonforandroid/recipes/coverage/fallback-utf8.patch
+++ b/pythonforandroid/recipes/coverage/fallback-utf8.patch
@@ -1,0 +1,12 @@
+--- coverage-4.1/coverage/misc.py	2016-02-13 20:04:35.000000000 +0100
++++ patch/coverage/misc.py	2016-07-11 17:07:22.656603295 +0200
+@@ -166,7 +166,8 @@
+     encoding = (
+         getattr(outfile, "encoding", None) or
+         getattr(sys.__stdout__, "encoding", None) or
+-        locale.getpreferredencoding()
++        locale.getpreferredencoding() or
++        'utf-8'
+     )
+     return encoding
+ 


### PR DESCRIPTION
The included patch is why I made this recipe. It is a fallback to utf-8 encoding because the locale module is not working on Android at the moment.