### PR TITLE
introduce versioning for openssl

### DIFF
--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -10,7 +10,8 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
 
     def get_recipe_env(self, arch):
         env = super(CryptographyRecipe, self).get_recipe_env(arch)
-        openssl_dir = self.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
+        r = self.get_recipe('openssl', self.ctx)
+        openssl_dir = r.get_build_dir(arch.arch)
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
         env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python2.7' + \
                          ' -I' + join(openssl_dir, 'include')
@@ -19,7 +20,8 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
         env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/lib' + \
                           ' -L' + openssl_dir + \
                           ' -lpython2.7' + \
-                          ' -lssl -lcrypto'
+                          ' -lssl' + r.version + \
+                          ' -lcrypto' + r.version
         return env
 
 recipe = CryptographyRecipe()

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -65,7 +65,9 @@ class LibtorrentRecipe(Recipe):
         # Copy environment from boost recipe
         env.update(self.get_recipe('boost', self.ctx).get_recipe_env(arch))
         if 'openssl' in recipe.ctx.recipe_build_order:
-            env['OPENSSL_BUILD_PATH'] = self.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
+            r = self.get_recipe('openssl', self.ctx)
+            env['OPENSSL_BUILD_PATH'] = r.get_build_dir(arch.arch)
+            env['OPENSSL_VERSION'] = r.version
         return env
 
 recipe = LibtorrentRecipe()

--- a/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
+++ b/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
@@ -20,6 +20,6 @@
 +<linkflags>-L$(OPENSSL_BUILD_PATH)
  <linkflags>-lgnustl_shared
  <linkflags>-lpython2.7
-+<linkflags>-lcrypto
-+<linkflags>-lssl
++<linkflags>-lcrypto$(OPENSSL_VERSION)
++<linkflags>-lssl$(OPENSSL_VERSION)
  ;

--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -9,7 +9,8 @@ class OpenSSLRecipe(Recipe):
     url = 'https://www.openssl.org/source/openssl-{version}.tar.gz'
 
     def should_build(self, arch):
-        return not self.has_libs(arch, 'libssl.so', 'libcrypto.so')
+        return not self.has_libs(arch, 'libssl' + self.version + '.so',
+                                 'libcrypto' + self.version + '.so')
 
     def check_symbol(self, env, sofile, symbol):
         nm = env.get('NM', 'nm')
@@ -22,6 +23,7 @@ class OpenSSLRecipe(Recipe):
 
     def get_recipe_env(self, arch=None):
         env = super(OpenSSLRecipe, self).get_recipe_env(arch)
+        env['OPENSSL_VERSION'] = self.version
         env['CFLAGS'] += ' ' + env['LDFLAGS']
         env['CC'] += ' ' + env['LDFLAGS']
         return env
@@ -45,15 +47,17 @@ class OpenSSLRecipe(Recipe):
             buildarch = self.select_build_arch(arch)
             shprint(perl, 'Configure', 'shared', 'no-dso', 'no-krb5', buildarch, _env=env)
             self.apply_patch('disable-sover.patch', arch.arch)
+            self.apply_patch('rename-shared-lib.patch', arch.arch)
 
-            check_crypto = partial(self.check_symbol, env, 'libcrypto.so')
-            # check_ssl = partial(self.check_symbol, env, 'libssl.so')
+            # check_ssl = partial(self.check_symbol, env, 'libssl' + self.version + '.so')
+            check_crypto = partial(self.check_symbol, env, 'libcrypto' + self.version + '.so')
             while True:
                 shprint(sh.make, 'build_libs', _env=env)
                 if all(map(check_crypto, ('SSLeay', 'MD5_Transform', 'MD4_Init'))):
                     break
                 shprint(sh.make, 'clean', _env=env)
 
-            self.install_libs(arch, 'libssl.so', 'libcrypto.so')
+            self.install_libs(arch, 'libssl' + self.version + '.so',
+                              'libcrypto' + self.version + '.so')
 
 recipe = OpenSSLRecipe()

--- a/pythonforandroid/recipes/openssl/rename-shared-lib.patch
+++ b/pythonforandroid/recipes/openssl/rename-shared-lib.patch
@@ -1,0 +1,16 @@
+--- openssl/Makefile.shared	2016-05-03 15:44:42.000000000 +0200
++++ patch/Makefile.shared	2016-07-14 00:08:37.268792948 +0200
+@@ -147,11 +147,11 @@
+ DETECT_GNU_LD=($(CC) -Wl,-V /dev/null 2>&1 | grep '^GNU ld' )>/dev/null
+ 
+ DO_GNU_SO=$(CALC_VERSIONS); \
+-	SHLIB=lib$(LIBNAME).so; \
++	SHLIB=lib$(LIBNAME)$(OPENSSL_VERSION).so; \
+ 	SHLIB_SUFFIX=; \
+ 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
+ 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
+-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
++	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB"
+ 
+ DO_GNU_APP=LDFLAGS="$(CFLAGS) -Wl,-rpath,$(LIBRPATH)"
+ 

--- a/pythonforandroid/recipes/python2/Setup.local-ssl
+++ b/pythonforandroid/recipes/python2/Setup.local-ssl
@@ -1,4 +1,4 @@
 SSL=
 _ssl _ssl.c \
   -DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
-  -L$(SSL) -lssl -lcrypto
+  -L$(SSL) -lssl$(OPENSSL_VERSION) -lcrypto$(OPENSSL_VERSION)

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -93,10 +93,12 @@ class Python2Recipe(TargetPythonRecipe):
             # TODO need to add a should_build that checks if optional
             # dependencies have changed (possibly in a generic way)
             if 'openssl' in self.ctx.recipe_build_order:
-                openssl_build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
+                r = Recipe.get_recipe('openssl', self.ctx)
+                openssl_build_dir = r.get_build_dir(arch.arch)
                 setuplocal = join('Modules', 'Setup.local')
                 shprint(sh.cp, join(self.get_recipe_dir(), 'Setup.local-ssl'), setuplocal)
                 shprint(sh.sed, '-i', 's#^SSL=.*#SSL={}#'.format(openssl_build_dir), setuplocal)
+                env['OPENSSL_VERSION'] = r.version
 
             if 'sqlite3' in self.ctx.recipe_build_order:
                 # Include sqlite3 in python2 build


### PR DESCRIPTION
On Android versions lower than 6.0 the openssl library of the system is being loaded instead of the one provided with the app.
Adding the version to the name of the shared library file avoids the problem of the linker at runtime giving the wrong version of the library and provides a clear indication of what version you are using (good ensuring you use the latest version for security).