### PR TITLE
Improve service_only bootstrap

### DIFF
--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -1,10 +1,12 @@
-from pythonforandroid.toolchain import Bootstrap, shprint, current_directory, info, warning, ArchARM, info_main
-from os.path import join, exists, curdir, abspath
-from os import walk
 import glob
+from os import walk
+from os.path import join, exists, curdir, abspath
 import sh
+from pythonforandroid.toolchain import Bootstrap, shprint, current_directory, info, warning, ArchARM, info_main
+
 
 class ServiceOnlyBootstrap(Bootstrap):
+
     name = 'service_only'
 
     recipe_depends = ['genericndkbuild', ('python2', 'python3crystax')]
@@ -62,7 +64,7 @@ class ServiceOnlyBootstrap(Bootstrap):
                 # AND: Copylibs stuff should go here
                 if exists(join('libs', arch.arch, 'libpymodules.so')):
                     shprint(sh.mv, join('libs', arch.arch, 'libpymodules.so'), 'private/')
-                shprint(sh.cp, join('python-install', 'include' , 'python2.7', 'pyconfig.h'), join('private', 'include', 'python2.7/'))
+                shprint(sh.cp, join('python-install', 'include', 'python2.7', 'pyconfig.h'), join('private', 'include', 'python2.7/'))
 
                 info('Removing some unwanted files')
                 shprint(sh.rm, '-f', join('private', 'lib', 'libpython2.7.so'))
@@ -117,5 +119,6 @@ class ServiceOnlyBootstrap(Bootstrap):
         self.strip_libraries(arch)
         self.fry_eggs(site_packages_dir)
         super(ServiceOnlyBootstrap, self).run_distribute()
+
 
 bootstrap = ServiceOnlyBootstrap()

--- a/pythonforandroid/bootstraps/service_only/build/jni/src/start.c
+++ b/pythonforandroid/bootstraps/service_only/build/jni/src/start.c
@@ -279,7 +279,7 @@ int main(int argc, char *argv[]) {
 }
 
 JNIEXPORT void JNICALL Java_org_kivy_android_PythonService_nativeStart(
-    JNIEnv *env, jobject thiz, jstring j_android_private,
+    JNIEnv *env, jobject j_this, jstring j_android_private,
     jstring j_android_argument, jstring j_service_entrypoint,
     jstring j_python_name, jstring j_python_home, jstring j_python_path,
     jstring j_arg) {
@@ -296,7 +296,8 @@ JNIEXPORT void JNICALL Java_org_kivy_android_PythonService_nativeStart(
       (*env)->GetStringUTFChars(env, j_python_home, &iscopy);
   const char *python_path =
       (*env)->GetStringUTFChars(env, j_python_path, &iscopy);
-  const char *arg = (*env)->GetStringUTFChars(env, j_arg, &iscopy);
+  const char *arg =
+      (*env)->GetStringUTFChars(env, j_arg, &iscopy);
 
   setenv("ANDROID_PRIVATE", android_private, 1);
   setenv("ANDROID_ARGUMENT", android_argument, 1);

--- a/pythonforandroid/bootstraps/service_only/build/src/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/org/kivy/android/PythonService.java
@@ -1,18 +1,16 @@
 package org.kivy.android;
 
-import android.app.Activity;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
-import android.os.IBinder;
 import android.os.Process;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
-public class PythonService extends Service implements Runnable {
+public abstract class PythonService extends Service implements Runnable {
     private static String TAG = PythonService.class.getSimpleName();
 
     /**
@@ -41,14 +39,6 @@ public class PythonService extends Service implements Runnable {
 
     public boolean getAutoRestart() {
         return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public IBinder onBind(Intent intent) {
-        return null;
     }
 
     /**
@@ -109,7 +99,7 @@ public class PythonService extends Service implements Runnable {
 
         int NOTIFICATION_ID = 1;
 
-        Intent targetIntent = new Intent(this, Activity.class);
+        Intent targetIntent = new Intent(this, MainActivity.class);
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0, targetIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         builder.setContentIntent(contentIntent);
 

--- a/pythonforandroid/bootstraps/service_only/build/src/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/org/kivy/android/PythonService.java
@@ -31,11 +31,16 @@ public class PythonService extends Service implements Runnable {
     private String serviceEntrypoint;
     private String pythonServiceArgument;
 
-    protected boolean autoRestartService = false;
-    protected boolean startForeground = true;
-
-    public int startType() {
+    public int getStartType() {
         return START_NOT_STICKY;
+    }
+
+    public boolean getStartForeground() {
+        return false;
+    }
+
+    public boolean getAutoRestart() {
+        return false;
     }
 
     /**
@@ -81,11 +86,11 @@ public class PythonService extends Service implements Runnable {
         pythonThread = new Thread(this);
         pythonThread.start();
 
-        if (startForeground) {
+        if (getStartForeground()) {
             doStartForeground(extras);
         }
 
-        return startType();
+        return getStartType();
     }
 
     protected void doStartForeground(Bundle extras) {
@@ -118,7 +123,7 @@ public class PythonService extends Service implements Runnable {
     public void onDestroy() {
         super.onDestroy();
         pythonThread = null;
-        if (autoRestartService && startIntent != null) {
+        if (getAutoRestart() && startIntent != null) {
             Log.v(TAG, "Service restart requested");
             startService(startIntent);
         }
@@ -131,8 +136,8 @@ public class PythonService extends Service implements Runnable {
     @Override
     public void run() {
         PythonUtil.loadLibraries(getFilesDir());
-        nativeStart(androidPrivate, androidArgument, serviceEntrypoint,
-                pythonName, pythonHome, pythonPath, pythonServiceArgument);
+        nativeStart(androidPrivate, androidArgument, serviceEntrypoint, pythonName, pythonHome,
+                pythonPath, pythonServiceArgument);
         stopSelf();
     }
 
@@ -145,8 +150,8 @@ public class PythonService extends Service implements Runnable {
      * @param pythonPath            Python path
      * @param pythonServiceArgument Argument to pass to Python code
      */
-    public static native void nativeStart(String androidPrivate,
-                                          String androidArgument, String serviceEntrypoint,
-                                          String pythonName, String pythonHome, String pythonPath,
+    public static native void nativeStart(String androidPrivate, String androidArgument,
+                                          String serviceEntrypoint, String pythonName,
+                                          String pythonHome, String pythonPath,
                                           String pythonServiceArgument);
 }

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -51,6 +51,14 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+    }
+    
+    /**
      * Class used for the client Binder. Because we know this service always
      * runs in the same process as its clients, we don't need to deal with IPC.
      */
@@ -59,13 +67,5 @@ public class Service{{ name|capitalize }} extends PythonService {
             // Return this instance of Service{{ name|capitalize }} so clients can call public methods
             return Service{{ name|capitalize }}.this;
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public IBinder onBind(Intent intent) {
-        return mBinder;
     }
 }

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -20,13 +20,13 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
     {% endif %}
 
-    {% if not foreground %}
+    {% if foreground %}
     /**
      * {@inheritDoc}
      */
     @Override
     public boolean getStartForeground() {
-        return false;
+        return true;
     }
     {% endif %}
 

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -4,14 +4,18 @@ import android.content.Intent;
 import android.content.Context;
 import org.kivy.android.PythonService;
 
-
 public class Service{{ name|capitalize }} extends PythonService {
+	/**
+	 * Binder given to clients
+	 */
+    private final IBinder mBinder = new LocalBinder();
+
     {% if sticky %}
     /**
      * {@inheritDoc}
      */
     @Override
-    public int startType() {
+    public int getStartType() {
         return START_STICKY;
     }
     {% endif %}
@@ -21,7 +25,7 @@ public class Service{{ name|capitalize }} extends PythonService {
      * {@inheritDoc}
      */
     @Override
-    public boolean canDisplayNotification() {
+    public boolean getStartForeground() {
         return false;
     }
     {% endif %}
@@ -46,4 +50,22 @@ public class Service{{ name|capitalize }} extends PythonService {
         ctx.stopService(intent);
     }
 
+    /**
+     * Class used for the client Binder. Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with IPC.
+     */
+    public class Service{{ name|capitalize }}Binder extends Binder {
+    	Service{{ name|capitalize }} getService() {
+            // Return this instance of Service{{ name|capitalize }} so clients can call public methods
+            return Service{{ name|capitalize }}.this;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+    }
 }

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -8,7 +8,7 @@ public class Service{{ name|capitalize }} extends PythonService {
 	/**
 	 * Binder given to clients
 	 */
-    private final IBinder mBinder = new LocalBinder();
+    private final IBinder mBinder = new Service{{ name|capitalize }}Binder();
 
     {% if sticky %}
     /**

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ recursively_include(package_data, 'pythonforandroid/recipes',
                      '*.mk', '*.jam', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps',
                     ['*.properties', '*.xml', '*.java', '*.tmpl', '*.txt', '*.png',
-                     '*.mk', '*.c', '*.h', '*.py', '*.sh', '*.jpg', '*.aidl', ])
+                     '*.mk', '*.c', '*.h', '*.py', '*.sh', '*.jpg', '*.aidl',
+                     '*.gradle', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps',
                     ['sdl-config', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps/webview',


### PR DESCRIPTION
 * Add option to have a different icon for the python service.
 * Bugfix bootstrap Gradle build script
 * Binder interface

Because it will be shown in the notification bar in black and white you likely want to use a different icon than the colored app one, since Android forces that one to black and white otherwise (ugly).