### PR TITLE
Check if bdist_dir exists before removing

### DIFF
--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -87,7 +87,8 @@ class BdistAPK(Command):
                   'that.')
 
         bdist_dir = 'build/bdist.android-{}'.format(self.arch)
-        rmtree(bdist_dir)
+        if exists(bdist_dir):
+            rmtree(bdist_dir)
         makedirs(bdist_dir)
 
         globs = []


### PR DESCRIPTION
First call to `setup.py apk` fails since the build dir would not have been previously created:
```
error: [Errno 2] No such file or directory: 'build/bdist.android-armeabi'
```
