### PR TITLE
enable recipe package top-level directory names to be the same as the…

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1,4 +1,4 @@
-from os.path import join, dirname, isdir, exists, isfile, split, realpath
+from os.path import join, dirname, isdir, exists, isfile, split, realpath, basename
 import importlib
 import zipfile
 import glob
@@ -433,7 +433,7 @@ class Recipe(with_metaclass(RecipeMeta)):
                         import zipfile
                         fileh = zipfile.ZipFile(extraction_filename, 'r')
                         root_directory = fileh.filelist[0].filename.split('/')[0]
-                        if root_directory != directory_name:
+                        if root_directory != basename(directory_name):
                             shprint(sh.mv, root_directory, directory_name)
                     elif (extraction_filename.endswith('.tar.gz') or
                           extraction_filename.endswith('.tgz') or


### PR DESCRIPTION
… package name

For my own custom package `package-name`, I created a package zip file with a top-level directory `package-name`. I got an error in `File "pythonforandroid/recipe.py", line 437, in unpack` because a move of the same directory from a relative to an absolute path is attempted. Taking `basename()` first checks if the directory name is already the same as it should be.