### PR TITLE
Enable SDL2 MP3 support for Android

### DIFF
--- a/pythonforandroid/recipes/sdl2_mixer/__init__.py
+++ b/pythonforandroid/recipes/sdl2_mixer/__init__.py
@@ -38,8 +38,6 @@ class LibSDL2Mixer(BootstrapNDKRecipe):
         Copies the smpeg2 external library to the jni/ folder.
         This is required by the linker.
         """
-        jni_dir = self.get_jni_dir()
-        build_dir = self.get_build_dir(arch)
         self._copy_smpeg2_to_jni()
         super(LibSDL2Mixer, self).prebuild_arch(arch)
 

--- a/pythonforandroid/recipes/sdl2_mixer/__init__.py
+++ b/pythonforandroid/recipes/sdl2_mixer/__init__.py
@@ -1,3 +1,8 @@
+from os.path import join
+
+import sh
+
+from pythonforandroid.logger import shprint
 from pythonforandroid.toolchain import BootstrapNDKRecipe
 
 
@@ -6,6 +11,36 @@ class LibSDL2Mixer(BootstrapNDKRecipe):
     url = 'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-{version}.tar.gz'
     dir_name = 'SDL2_mixer'
 
-    patches = ['toggle_modplug_mikmod_smpeg_ogg.patch']
+    patches = ['toggle_modplug_mikmod_ogg.patch']
+
+    def _external_dir(self):
+        """
+        Returns the external/ dir path.
+        """
+        return join(self.get_build_dir(None), 'external')
+
+    def _smpeg2_external_dir(self):
+        """
+        Returns the smpeg2 external dir path.
+        """
+        return join(self._external_dir(), 'smpeg2-2.0.0')
+
+    def _copy_smpeg2_to_jni(self):
+        """
+        Copies the smpeg2 external to the jni/ folder.
+        """
+        smpeg2_external_dir = self._smpeg2_external_dir()
+        jni_dir = self.get_jni_dir()
+        shprint(sh.cp, '-r', smpeg2_external_dir, jni_dir)
+
+    def prebuild_arch(self, arch):
+        """
+        Copies the smpeg2 external library to the jni/ folder.
+        This is required by the linker.
+        """
+        jni_dir = self.get_jni_dir()
+        build_dir = self.get_build_dir(arch)
+        self._copy_smpeg2_to_jni()
+        super(LibSDL2Mixer, self).prebuild_arch(arch)
 
 recipe = LibSDL2Mixer()

--- a/pythonforandroid/recipes/sdl2_mixer/toggle_modplug_mikmod_ogg.patch
+++ b/pythonforandroid/recipes/sdl2_mixer/toggle_modplug_mikmod_ogg.patch
@@ -1,6 +1,6 @@
---- orig/Android.mk	2016-01-03 07:15:57.000000000 +0100
-+++ patch/Android.mk	2016-04-15 21:28:55.169697882 +0200
-@@ -6,22 +6,22 @@
+--- orig/Android.mk	2016-09-22 13:19:04.562867449 +0200
++++ patch/Android.mk	2016-09-22 13:20:04.403821137 +0200
+@@ -6,12 +6,12 @@
  
  # Enable this if you want to support loading MOD music via modplug
  # The library path should be a relative path to this directory.
@@ -15,10 +15,7 @@
  MIKMOD_LIBRARY_PATH := external/libmikmod-3.1.12
  
  # Enable this if you want to support loading MP3 music via SMPEG
- # The library path should be a relative path to this directory.
--SUPPORT_MP3_SMPEG ?= true
-+SUPPORT_MP3_SMPEG := false
- SMPEG_LIBRARY_PATH := external/smpeg2-2.0.0
+@@ -21,7 +21,7 @@
  
  # Enable this if you want to support loading OGG Vorbis music via Tremor
  # The library path should be a relative path to this directory.


### PR DESCRIPTION
We had to copy the external/smpeg2-2.0.0/ folder
to the jni/ folder to fix linker errors.
See https://groups.google.com/forum/#!topic/kivy-users/N4isIjQ1Ja8
