### PR TITLE
fixes for #890 (deadlock on pause/resume with pyjnius/pygame)

### DIFF
--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -196,14 +196,17 @@ if mActivity:
             self.height = mActivity.getWindowManager().getDefaultDisplay().getHeight() - (rctx.bottom - rctx.top)
             # print('final height: {0}'.format(self.height))
 
-    ll = LayoutListener()
     IF BOOTSTRAP == 'sdl2':
+        ll = LayoutListener()
         python_act.getLayout().getViewTreeObserver().addOnGlobalLayoutListener(ll)
-    ELSE:
-        python_act.mView.getViewTreeObserver().addOnGlobalLayoutListener(ll)
 
-    def get_keyboard_height():
-        return ll.height
+        def get_keyboard_height():
+            return ll.height
+            
+    ELSE:
+        def get_keyboard_height():
+            return python_act.getLayoutListenerHeight()
+        
 else:
     def get_keyboard_height():
         return 0


### PR DESCRIPTION
Moved java LayoutListener logic out of 'android' package into pygame bootstrap

This avoids deadlock due to LayoutListener locking python thread with pyjnius when app onPause/onResume occurs