### PR TITLE
Added symlink_java_src dev option

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -89,10 +89,11 @@ class Bootstrap(object):
         self.build_dir = self.get_build_dir()
         shprint(sh.cp, '-r',
                 join(self.bootstrap_dir, 'build'),
-                # join(self.ctx.root_dir,
-                #      'bootstrap_templates',
-                #      self.name),
                 self.build_dir)
+        if self.ctx.symlink_java_src:
+            info('Symlinking java src instead of copying')
+            shprint(sh.rm, '-r', join(self.build_dir, 'src'))
+            shprint(sh.ln, '-s', join(self.bootstrap_dir, 'build', 'src'), self.build_dir)
         with current_directory(self.build_dir):
             with open('project.properties', 'w') as fileh:
                 fileh.write('target=android-{}'.format(self.ctx.android_api))

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -1,5 +1,5 @@
 from os.path import (join, dirname, isdir, splitext, basename, realpath)
-from os import listdir
+from os import listdir, mkdir
 import sh
 import glob
 import json
@@ -93,7 +93,10 @@ class Bootstrap(object):
         if self.ctx.symlink_java_src:
             info('Symlinking java src instead of copying')
             shprint(sh.rm, '-r', join(self.build_dir, 'src'))
-            shprint(sh.ln, '-s', join(self.bootstrap_dir, 'build', 'src'), self.build_dir)
+            shprint(sh.mkdir, join(self.build_dir, 'src'))
+            for dirn in listdir(join(self.bootstrap_dir, 'build', 'src')):
+                shprint(sh.ln, '-s', join(self.bootstrap_dir, 'build', 'src', dirn),
+                        join(self.build_dir, 'src'))
         with current_directory(self.build_dir):
             with open('project.properties', 'w') as fileh:
                 fileh.write('target=android-{}'.format(self.ctx.android_api))

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -33,7 +33,6 @@ class Context(object):
     libs_dir = None  # where Android libs are cached after build but
                      # before being placed in dists
     aars_dir = None
-    javaclass_dir = None
 
     ccache = None  # whether to use ccache
     cython = None  # the cython interpreter name
@@ -45,6 +44,8 @@ class Context(object):
     bootstrap_build_dir = None
 
     recipe_build_order = None  # Will hold the list of all built recipes
+
+    symlink_java_src = False # If True, will symlink instead of copying during build
 
     @property
     def packages_path(self):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -256,6 +256,14 @@ class ToolchainCL(object):
             '--ndk-version', '--ndk_version', dest='ndk_version', default='',
             help=('The version of the Android NDK. This is optional, '
                   'we try to work it out automatically from the ndk_dir.'))
+        generic_parser.add_argument(
+            '--symlink-java-src', '--symlink_java_src',
+            action='store_true',
+            dest='symlink_java_src',
+            default=False,
+            help=('If True, symlinks the java src folder during build and dist '
+                  'creation. This is useful for development only, it could also '
+                  'cause weird problems.'))
 
         default_storage_dir = user_data_dir('python-for-android')
         if ' ' in default_storage_dir:
@@ -454,6 +462,7 @@ class ToolchainCL(object):
         self.ndk_dir = args.ndk_dir
         self.android_api = args.android_api
         self.ndk_version = args.ndk_version
+        self.ctx.symlink_java_src = args.symlink_java_src
 
         self._archs = split_argument_list(args.arch)
 

--- a/test_builds/tests/test_apk.py
+++ b/test_builds/tests/test_apk.py
@@ -1,5 +1,6 @@
 
 from pythonforandroid.toolchain import main
+from pythonforandroid.recipe import Recipe
 
 from os import path
 import sys
@@ -51,11 +52,14 @@ argument_combinations = [{'app_dir': path.join(testapps_dir, 'testapp'),
 @pytest.mark.parametrize('args', argument_combinations)
 def test_build_sdl2(args):
 
+    Recipe.recipes = {}
+
     set_argv(('apk --requirements={requirements} --private '
               '{app_dir} --package=net.p4a.{packagename} --name={packagename} '
               '--version=0.1 --bootstrap={bootstrap} --android_api=19 '
               '--ndk_dir={ndk_dir} --ndk_version={ndk_version} --debug '
               '--permission VIBRATE '
+              '--symlink-java-src '
               '--orientation portrait --dist_name=test-{packagename}').format(
                   **args).split(' '))
 


### PR DESCRIPTION
Not for merging yet.

This makes development that modifies the java source easier, by symlinking instead of copying during the build process, so that you can modify the source and deploy without any dist rebuild.