### PR TITLE
Allow list of permissions for bdist

### DIFF
--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -42,7 +42,11 @@ class BdistAPK(Command):
             if source == 'command line':
                 continue
             if not argv_contains('--' + option):
-                if value in (None, 'None'):
+                # allow 'permissions': ['permission', 'permission] in apk
+                if option == 'permissions':
+                    for perm in value:
+                        sys.argv.append('--permission={}'.format(perm))
+                elif value in (None, 'None'):
                     sys.argv.append('--{}'.format(option))
                 else:
                     sys.argv.append('--{}={}'.format(option, value))


### PR DESCRIPTION
Allows writing of a list of permissions, because the dictionary isn't capable of holding multiple values to a single key other way to me. (multiple `permission` will be rewritten).

```
'permissions': ['ACCESS_COARSE_LOCATION', 'ACCESS_FINE_LOCATION',
                'BLUETOOTH', 'BODY_SENSORS', 'CAMERA', 'INTERNET',
                'NFC', 'READ_EXTERNAL_STORAGE', 'RECORD_AUDIO',
                'USE_FINGERPRINT', 'VIBRATE', 'WAKE_LOCK',
                'WRITE_EXTERNAL_STORAGE']
```