### PR TITLE
Allow installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ package_data = {'': ['*.tmpl',
 
 data_files = []
 
+
+if os.name == 'nt':
+    install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2',
+                        'six']
+else:
+    install_reqs = ['appdirs', 'colorama>=0.3.3', 'sh>=1.10', 'jinja2',
+                        'six']
+
 # By specifying every file manually, package_data will be able to
 # include them in binary distributions. Note that we have to add
 # everything as a 'pythonforandroid' rule, using '' apparently doesn't
@@ -50,8 +58,7 @@ setup(name='python-for-android',
       author_email='kivy-dev@googlegroups.com',
       url='https://github.com/kivy/python-for-android', 
       license='MIT', 
-      install_requires=['appdirs', 'colorama>=0.3.3', 'sh>=1.10', 'jinja2',
-                        'six'],
+      install_requires=install_reqs,
       entry_points={
           'console_scripts': [
               'python-for-android = pythonforandroid.toolchain:main',


### PR DESCRIPTION
**Note**: this does _not_ allow one to use the full Python for Android toolchain. It simply removes the requirement for the sh module on Windows so that it is pip installable.

This addresses #819. I am not sure if a warning about the limited abilities is required, but this does allow one to pip install or use setup.py install. When I run p4a (for the curious), I get:

```
C:\Users\ethanhs>p4a
ERROR: The sh Python module could not be found, please install version 1.10 or higher
python-for-android is exiting due to the errors above.
```

Something that I could modify for this PR is to change [`check_python_dependencies`](https://github.com/kivy/python-for-android/blob/master/pythonforandroid/toolchain.py#L12) to not error on Windows, and instead add a message to wait for binary redistributable recipes.
