### PR TITLE
Easy way to set the presplash background color

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
@@ -30,6 +30,7 @@ import android.widget.ImageView;
 import java.io.InputStream;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 
 import org.libsdl.app.SDLActivity;
 
@@ -356,6 +357,30 @@ public class PythonActivity extends SDLActivity {
 
         mImageView = new ImageView(this);
         mImageView.setImageBitmap(bitmap);
+
+        /*
+         * Edit this file: pythonforandroid/bootstraps/sdl2/build/templates/strings.tmpl.xml
+         * and set the background presplash color
+         * <?xml version="1.0" encoding="utf-8"?>
+         * <resources>
+         *     <string name="app_name">{{ args.name }}</string>
+         *     <string name="private_version">0.1</string>
+         *     <string name="presplash_bkgcolor">#FF00FFFF</string>
+         * </resources>
+         * https://developer.android.com/reference/android/graphics/Color.html
+         * Parse the color string, and return the corresponding color-int.
+         * If the string cannot be parsed, throws an IllegalArgumentException exception.
+         * Supported formats are: #RRGGBB #AARRGGBB or one of the following names:
+         * 'red', 'blue', 'green', 'black', 'white', 'gray', 'cyan', 'magenta', 'yellow',
+         * 'lightgray', 'darkgray', 'grey', 'lightgrey', 'darkgrey', 'aqua', 'fuchsia',
+         * 'lime', 'maroon', 'navy', 'olive', 'purple', 'silver', 'teal'.
+         */
+        String backgroundColor = resourceManager.getString("presplash_bkgcolor");
+        if (backgroundColor != null) {
+          try {
+            mImageView.setBackgroundColor(Color.parseColor(backgroundColor));
+          } catch (IllegalArgumentException e) {}
+        }   
         mImageView.setLayoutParams(new ViewGroup.LayoutParams(
         ViewGroup.LayoutParams.FILL_PARENT,
         ViewGroup.LayoutParams.FILL_PARENT));

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
@@ -359,14 +359,7 @@ public class PythonActivity extends SDLActivity {
         mImageView.setImageBitmap(bitmap);
 
         /*
-         * Edit this file: pythonforandroid/bootstraps/sdl2/build/templates/strings.tmpl.xml
-         * and set the background presplash color
-         * <?xml version="1.0" encoding="utf-8"?>
-         * <resources>
-         *     <string name="app_name">{{ args.name }}</string>
-         *     <string name="private_version">0.1</string>
-         *     <string name="presplash_bkgcolor">#FF00FFFF</string>
-         * </resources>
+	 * Set the presplash loading screen background color
          * https://developer.android.com/reference/android/graphics/Color.html
          * Parse the color string, and return the corresponding color-int.
          * If the string cannot be parsed, throws an IllegalArgumentException exception.
@@ -375,7 +368,7 @@ public class PythonActivity extends SDLActivity {
          * 'lightgray', 'darkgray', 'grey', 'lightgrey', 'darkgrey', 'aqua', 'fuchsia',
          * 'lime', 'maroon', 'navy', 'olive', 'purple', 'silver', 'teal'.
          */
-        String backgroundColor = resourceManager.getString("presplash_bkgcolor");
+        String backgroundColor = resourceManager.getString("presplash_color");
         if (backgroundColor != null) {
           try {
             mImageView.setBackgroundColor(Color.parseColor(backgroundColor));


### PR DESCRIPTION
Easy way to set the presplash background color of Loading Screen.

--presplash-color=#AARRGGBB, --presplash-color=#RRGGBB or --presplash-color=red

Default color: #FFFFFFFF (white)

More information:
https://developer.android.com/reference/android/graphics/Color.html
Parse the color string, and return the corresponding color-int. If the string cannot be parsed, throws an IllegalArgumentException exception. Supported formats are: #RRGGBB #AARRGGBB or one of the following names: 'red', 'blue', 'green', 'black', 'white', 'gray', 'cyan', 'magenta', 'yellow', 'lightgray', 'darkgray', 'grey', 'lightgrey', 'darkgrey', 'aqua', 'fuchsia', 'lime', 'maroon', 'navy', 'olive', 'purple', 'silver', 'teal'.
