### PR TITLE
fixed recipe zope_interface

### DIFF
--- a/pythonforandroid/recipes/zope_interface/__init__.py
+++ b/pythonforandroid/recipes/zope_interface/__init__.py
@@ -1,9 +1,9 @@
-from pythonforandroid.toolchain import PythonRecipe, shprint, current_directory
-from os.path import join
+from pythonforandroid.toolchain import PythonRecipe, current_directory
 import sh
 
 
 class ZopeInterfaceRecipe(PythonRecipe):
+    call_hostpython_via_targetpython = False
     name = 'zope_interface'
     version = '4.1.3'
     url = 'https://pypi.python.org/packages/source/z/zope.interface/zope.interface-{version}.tar.gz'


### PR DESCRIPTION
zope_interface was not installing "common" hierarchy because it
couldn't find setuptools and was using distutils instead.

This commit fix this by using hostpython own build dir, and also
removed unused imports (shprint and join).
