### PR TITLE
Fixed app path for SDL2 services

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
@@ -302,6 +302,7 @@ JNIEXPORT void JNICALL Java_org_kivy_android_PythonService_nativeStart(
 
   setenv("ANDROID_PRIVATE", android_private, 1);
   setenv("ANDROID_ARGUMENT", android_argument, 1);
+  setenv("ANDROID_APP_PATH", android_argument, 1);
   setenv("ANDROID_ENTRYPOINT", service_entrypoint, 1);
   setenv("PYTHONOPTIMIZE", "2", 1);
   setenv("PYTHON_NAME", python_name, 1);

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonService.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.os.Process;
+import java.io.File;
 
 import org.kivy.android.PythonUtil;
 
@@ -110,7 +111,9 @@ public class PythonService extends Service implements Runnable {
 
     @Override
     public void run(){
-        PythonUtil.loadLibraries(getFilesDir());
+        String app_root =  getFilesDir().getAbsolutePath() + "/app";
+        File app_root_file = new File(app_root);
+        PythonUtil.loadLibraries(app_root_file);
         this.mService = this;
         nativeStart(
             androidPrivate, androidArgument,

--- a/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/Service.tmpl.java
@@ -38,8 +38,8 @@ public class Service{{ name|capitalize }} extends PythonService {
 
     static public void start(Context ctx, String pythonServiceArgument) {
         Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        String argument = ctx.getFilesDir().getAbsolutePath();
-        intent.putExtra("androidPrivate", argument);
+        String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
+        intent.putExtra("androidPrivate", ctx.getFilesDir().getAbsolutePath());
         intent.putExtra("androidArgument", argument);
         intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
         intent.putExtra("pythonName", "{{ name }}");


### PR DESCRIPTION
Fixes SDL2 services by setting the correct path to the app, which was broken following the recent move to the app subdir.

This is more hardcoded than I'd like, I'll try to check out if we can use the PythonActivity method instead (maybe it should be a class method) to avoid the same breaking problems in the future.