### PR TITLE
Completing md5sum comparison and download

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -14,7 +14,7 @@ try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
-from pythonforandroid.logger import (logger, info, warning, error, shprint, info_main)
+from pythonforandroid.logger import (logger, info, warning, error, debug, shprint, info_main)
 from pythonforandroid.util import (urlretrieve, current_directory, ensure_dir)
 
 # this import is necessary to keep imp.load_source from complaining :)
@@ -360,11 +360,15 @@ class Recipe(with_metaclass(RecipeMeta)):
                 if not exists(marker_filename):
                     shprint(sh.rm, filename)
                 elif self.md5sum:
-                    current_md5 = shprint(sh.md5sum, filename)
-                    print('downloaded md5: {}'.format(current_md5))
-                    print('expected md5: {}'.format(self.md5sum))
-                    print('md5 not handled yet, exiting')
-                    exit(1)
+                    current_md5 = shprint(sh.md5sum, filename).split()[0]
+                    if current_md5 == self.md5sum:
+                        debug('Downloaded expected content!')
+                        do_download = False
+                    else:
+                        info('Downloaded unexpected content...')
+                        debug('* Generated md5sum: {}'.format(current_md5))
+                        debug('* Expected md5sum: {}'.format(self.md5sum))
+
                 else:
                     do_download = False
                     info('{} download already cached, skipping'
@@ -375,18 +379,22 @@ class Recipe(with_metaclass(RecipeMeta)):
 
             # If we got this far, we will download
             if do_download:
-                print('Downloading {} from {}'.format(self.name, url))
+                debug('Downloading {} from {}'.format(self.name, url))
 
                 shprint(sh.rm, '-f', marker_filename)
                 self.download_file(url, filename)
                 shprint(sh.touch, marker_filename)
 
                 if exists(filename) and isfile(filename) and self.md5sum:
+                    current_md5 = shprint(sh.md5sum, filename).split()[0]
                     if self.md5sum is not None:
-                        print('downloaded md5: {}'.format(current_md5))
-                        print('expected md5: {}'.format(self.md5sum))
-                        print('md5 not handled yet, exiting')
-                        exit(1)
+                        if current_md5 == self.md5sum:
+                            debug('Downloaded expected content!')
+                        else:
+                            info('Downloaded unexpected content...')
+                            debug('* Generated md5sum: {}'.format(current_md5))
+                            debug('* Expected md5sum: {}'.format(self.md5sum))
+                            exit(1)
 
     def unpack(self, arch):
         info_main('Unpacking {} for {}'.format(self.name, arch))

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -381,11 +381,12 @@ class Recipe(with_metaclass(RecipeMeta)):
                 self.download_file(url, filename)
                 shprint(sh.touch, marker_filename)
 
-                if self.md5sum is not None:
-                    print('downloaded md5: {}'.format(current_md5))
-                    print('expected md5: {}'.format(self.md5sum))
-                    print('md5 not handled yet, exiting')
-                    exit(1)
+                if exists(filename) and isfile(filename) and self.md5sum:
+                    if self.md5sum is not None:
+                        print('downloaded md5: {}'.format(current_md5))
+                        print('expected md5: {}'.format(self.md5sum))
+                        print('md5 not handled yet, exiting')
+                        exit(1)
 
     def unpack(self, arch):
         info_main('Unpacking {} for {}'.format(self.name, arch))


### PR DESCRIPTION
This is the error message which appears without the change:

```
[INFO]:    # Downloading recipes
[INFO]:    Downloading qt5
[DEBUG]:   -> running mkdir -p /home/thopiekar/.local/share/python-for-android/packages/qt5
[INFO]:    -> directory context /home/thopiekar/.local/share/python-for-android/packages/qt5
[DEBUG]:   -> running basename http://download.qt.io/official_releases/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.tar.gz
[DEBUG]:        qt-everywhere-opensource-src-5.7.0.tar.gz
[WARNING]: Should check headers here! Skipping for now.
Downloading qt5 from http://download.qt.io/official_releases/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.tar.gz
[DEBUG]:   -> running rm -f .mark-qt-everywhere-opensource-src-5.7.0.tar.gz
[INFO]:    Downloading qt5 from http://download.qt.io/official_releases/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.tar.gz
[DEBUG]:   -> running touch .mark-qt-everywhere-opensource-src-5.7.0.tar.gz
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/media/hdd/home/thopiekar/Projekte/GIT/thopiekar/python-for-android_fork/pythonforandroid/toolchain.py", line 837, in <module>
    main()
  File "/media/hdd/home/thopiekar/Projekte/GIT/thopiekar/python-for-android_fork/pythonforandroid/toolchain.py", line 834, in main
    ToolchainCL()
  File "/media/hdd/home/thopiekar/Projekte/GIT/thopiekar/python-for-android_fork/pythonforandroid/toolchain.py", line 489, in __init__
    getattr(self, args.subparser_name.replace('-', '_'))(args)
  File "/media/hdd/home/thopiekar/Projekte/GIT/thopiekar/python-for-android_fork/pythonforandroid/toolchain.py", line 147, in wrapper_func
    build_dist_from_args(ctx, dist, args)
  File "/media/hdd/home/thopiekar/Projekte/GIT/thopiekar/python-for-android_fork/pythonforandroid/toolchain.py", line 190, in build_dist_from_args
    build_recipes(build_order, python_modules, ctx)
  File "pythonforandroid/build.py", line 540, in build_recipes
  File "pythonforandroid/recipe.py", line 342, in download_if_necessary
  File "pythonforandroid/recipe.py", line 385, in download
UnboundLocalError: local variable 'current_md5' referenced before assignment
```
