### PR TITLE
Complete closure of the application with SDL2.

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/libsdl/app/SDLActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/libsdl/app/SDLActivity.java
@@ -258,6 +258,9 @@ public class SDLActivity extends Activity {
         super.onDestroy();
         // Reset everything in case the user re opens the app
         SDLActivity.initialize();
+
+        // Completely closes application.
+        System.exit(0);
     }
 
     @Override


### PR DESCRIPTION
Added `System.exit(0); ` in  _SDLActivite.java_ _onDestroy()_ class to fix this issue kivy/kivy#4264, but I still think that is not right way and need to find more 'Android' method.