### PR TITLE
Add 'enable-ssl.patch' to Python2Recipe.patches

### DIFF
--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -31,6 +31,7 @@ class Python2Recipe(TargetPythonRecipe):
                'patches/fix-dlfcn.patch',
                'patches/parsetuple.patch',
                'patches/ctypes-find-library-updated.patch',
+               'patches/enable-ssl.patch',
                ('patches/fix-configure-darwin.patch', is_darwin),
                ('patches/fix-distutils-darwin.patch', is_darwin),
                ('patches/fix-ftime-removal.patch', is_api_gt(19)),


### PR DESCRIPTION
This PR is supposed to fix the issue that ssl cannot be imported in python2 
See issue #934