### PR TITLE
Fix enum-compat

### DIFF
--- a/pythonforandroid/recipes/enum-compat/__init__.py
+++ b/pythonforandroid/recipes/enum-compat/__init__.py
@@ -1,0 +1,9 @@
+from pythonforandroid.toolchain import PythonRecipe
+
+class EnumCompatRecipe(PythonRecipe):
+    version = "0.0.2"
+    url = "https://pypi.python.org/packages/95/6e/26bdcba28b66126f66cf3e4cd03bcd63f7ae330d29ee68b1f6b623550bfa/enum-compat-{version}.tar.gz"
+
+    call_hostpython_via_targetpython = False
+
+recipe = EnumCompatRecipe()


### PR DESCRIPTION
One of the "packages" I use in one of my p4a-projects has `enum-compat` as a requirements, but because of that my build keeps failing.
So I created this "patch", hoping that not only I have this issue and that this PR might be helping someone in the future