### PR TITLE
Compile pyo with sdl2

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -28,6 +28,10 @@ curdir = dirname(__file__)
 
 # Try to find a host version of Python that matches our ARM version.
 PYTHON = join(curdir, 'python-install', 'bin', 'python.host')
+if not exists(PYTHON):
+    print('Could not find hostpython, will not compile to .pyo (this is normal with python3)')
+    PYTHON = None
+PYTHON = None
 
 BLACKLIST_PATTERNS = [
     # code versionning
@@ -38,13 +42,14 @@ BLACKLIST_PATTERNS = [
 
     # pyc/py
     '*.pyc',
-    # '*.py',  # AND: Need to fix this to add it back
 
     # temp files
     '~',
     '*.bak',
     '*.swp',
 ]
+if PYTHON is not None:
+    BLACKLIST_PATTERNS.append('*.py')
 
 WHITELIST_PATTERNS = []
 
@@ -202,9 +207,9 @@ def compile_dir(dfn):
     '''
     Compile *.py in directory `dfn` to *.pyo
     '''
-
-    return  # AND: Currently leaving out the compile to pyo step because it's somehow broken
     # -OO = strip docstrings
+    if PYTHON is None:
+        return
     subprocess.call([PYTHON, '-OO', '-m', 'compileall', '-f', dfn])
 
 

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -31,7 +31,6 @@ PYTHON = join(curdir, 'python-install', 'bin', 'python.host')
 if not exists(PYTHON):
     print('Could not find hostpython, will not compile to .pyo (this is normal with python3)')
     PYTHON = None
-PYTHON = None
 
 BLACKLIST_PATTERNS = [
     # code versionning
@@ -375,7 +374,7 @@ main.py that loads it.''')
 
 
 def parse_args(args=None):
-    global BLACKLIST_PATTERNS, WHITELIST_PATTERNS
+    global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
     default_android_api = 12
     import argparse
     ap = argparse.ArgumentParser(description='''\
@@ -460,6 +459,8 @@ tools directory of the Android SDK.
                          'NAME:PATH_TO_PY[:foreground]')
     ap.add_argument('--add-source', dest='extra_source_dirs', action='append',
                     help='Include additional source dirs in Java build')
+    ap.add_argument('--no-compile-pyo', dest='no_compile_pyo', action='store_true',
+                    help='Do not optimise .py files to .pyo.')
 
     if args is None:
         args = sys.argv[1:]
@@ -484,6 +485,10 @@ tools directory of the Android SDK.
 
     if args.services is None:
         args.services = []
+
+    if args.no_compile_pyo:
+        PYTHON = None
+        BLACKLIST_PATTERNS.remove('*.py')
 
     if args.blacklist:
         with open(args.blacklist) as fd:

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java
@@ -82,6 +82,7 @@ public class PythonActivity extends SDLActivity {
         SDLActivity.nativeSetEnv("ANDROID_ENTRYPOINT", "main.pyo");
         SDLActivity.nativeSetEnv("PYTHONHOME", app_root_dir);
         SDLActivity.nativeSetEnv("PYTHONPATH", app_root_dir + ":" + app_root_dir + "/lib");
+        SDLActivity.nativeSetEnv("PYTHONOPTIMIZE", "2");
 
         try {
             Log.v(TAG, "Access to our meta-data...");


### PR DESCRIPTION
Makes the SDL2 bootstrap compile all .py to .pyo files automatically, like the pygame bootstrap. This reduces APK size and speeds up execution. It only affects python2 builds for now.

I also added a `--no-compile-pyo` option to disable this behaviour.