### PR TITLE
Add recipe to install ffpyplayer with many video formats support for old toolchain

### DIFF
--- a/recipes/ffmpeg2/patches/fix-libshine-configure.patch
+++ b/recipes/ffmpeg2/patches/fix-libshine-configure.patch
@@ -1,0 +1,11 @@
+--- ./configure.orig	2016-09-19 04:41:33.000000000 +0300
++++ ./configure	2016-12-06 19:12:05.046025000 +0300
+@@ -5260,7 +5260,7 @@
+ enabled libquvi           && require_pkg_config libquvi quvi/quvi.h quvi_init
+ enabled librtmp           && require_pkg_config librtmp librtmp/rtmp.h RTMP_Socket
+ enabled libschroedinger   && require_pkg_config schroedinger-1.0 schroedinger/schro.h schro_init
+-enabled libshine          && require_pkg_config shine shine/layer3.h shine_encode_buffer
++enabled libshine          && require "shine" shine/layer3.h shine_encode_buffer -lshine
+ enabled libsmbclient      && { use_pkg_config smbclient libsmbclient.h smbc_init ||
+                                require smbclient libsmbclient.h smbc_init -lsmbclient; }
+ enabled libsnappy         && require snappy snappy-c.h snappy_compress -lsnappy

--- a/recipes/ffpyplayer/recipe.sh
+++ b/recipes/ffpyplayer/recipe.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-VERSION_ffpyplayer=${VERSION_ffpyplayer:-master}
+VERSION_ffpyplayer=${VERSION_ffpyplayer:-v3.2}
 URL_ffpyplayer=http://github.com/matham/ffpyplayer/archive/$VERSION_ffpyplayer.zip
 DEPS_ffpyplayer=(python ffmpeg2)
+DEPS_OPTIONAL_ffpyplayer=(openssl ffpyplayer_codecs)
 MD5_ffpyplayer=
 BUILD_ffpyplayer=$BUILD_PATH/ffpyplayer/$(get_directory $URL_ffpyplayer)
 RECIPE_ffpyplayer=$RECIPES_PATH/ffpyplayer

--- a/recipes/ffpyplayer/recipe.sh
+++ b/recipes/ffpyplayer/recipe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION_ffpyplayer=${VERSION_ffpyplayer:-v3.2}
+VERSION_ffpyplayer=${VERSION_ffpyplayer:-master}
 URL_ffpyplayer=http://github.com/matham/ffpyplayer/archive/$VERSION_ffpyplayer.zip
 DEPS_ffpyplayer=(python ffmpeg2)
 DEPS_OPTIONAL_ffpyplayer=(openssl ffpyplayer_codecs)

--- a/recipes/ffpyplayer_codecs/recipe.sh
+++ b/recipes/ffpyplayer_codecs/recipe.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+VERSION_ffpyplayer_codecs=
+URL_ffpyplayer_codecs=
+DEPS_ffpyplayer_codecs=(libshine libx264)
+MD5_ffpyplayer_codecs=
+BUILD_ffpyplayer_codecs=$BUILD_PATH/ffpyplayer_codecs/$(get_directory $URL_ffpyplayer_codecs)
+RECIPE_ffpyplayer_codecs=$RECIPES_PATH/ffpyplayer_codecs
+
+function prebuild_ffpyplayer_codecs() {
+	true
+}
+
+function build_ffpyplayer_codecs() {
+	true
+}
+
+function postbuild_ffpyplayer_codecs() {
+	true
+}
+

--- a/recipes/libshine/recipe.sh
+++ b/recipes/libshine/recipe.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+VERSION_libshine=${VERSION_libshine:-master}
+URL_libshine=https://github.com/toots/shine/archive/$VERSION_libshine.zip
+DEPS_libshine=()
+MD5_libshine=
+BUILD_libshine=$BUILD_PATH/libshine/$(get_directory $URL_libshine)
+RECIPE_libshine=$RECIPES_PATH/libshine
+
+function prebuild_libshine() {
+	true
+}
+
+function shouldbuild_libshine() {
+	if [ -f "$BUILD_libshine/lib/libshine.a" ]; then
+		DO_BUILD=0
+	fi
+}
+
+function build_libshine() {
+	cd $BUILD_libshine
+
+	push_arm
+
+	# configure
+	mkdir -p $BUILD_libshine
+	make distclean
+
+	try ./bootstrap
+
+	try ./configure \
+	  --host=arm-linux \
+	  --enable-pic \
+	  --disable-shared \
+ 	  --enable-static \
+	  --prefix=$BUILD_libshine
+
+	make clean
+	try make -j$MAKE_JOBS
+	try make install
+
+	pop_arm
+}
+
+function postbuild_libshine() {
+	true
+}

--- a/recipes/libx264/recipe.sh
+++ b/recipes/libx264/recipe.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+VERSION_libx264=${VERSION_libx264:-last_stable_x264}
+URL_libx264=ftp://ftp.videolan.org/pub/x264/snapshots/$VERSION_libx264.tar.bz2
+DEPS_libx264=()
+MD5_libx264=
+BUILD_libx264=$BUILD_PATH/libx264/$(get_directory $URL_libx264)
+RECIPE_libx264=$RECIPES_PATH/libx264
+
+function prebuild_libx264() {
+	true
+}
+
+function shouldbuild_libx264() {
+	if [ -f "$BUILD_libx264/lib/libx264.a" ]; then
+		DO_BUILD=0
+	fi
+}
+
+function build_libx264() {
+	cd $BUILD_libx264
+
+	push_arm
+
+	# configure
+	mkdir -p $BUILD_libx264
+	make distclean
+
+	try ./configure \
+	  --cross-prefix=arm-linux-androideabi- \
+	  --sysroot="$NDKPLATFORM" \
+	  --host=arm-linux \
+	  --disable-asm \
+	  --disable-cli \
+	  --enable-pic \
+	  --disable-shared \
+ 	  --enable-static \
+	  --prefix=$BUILD_libx264
+
+	make clean
+	try make -j$MAKE_JOBS
+	try make install
+
+	pop_arm
+}
+
+function postbuild_libx264() {
+	true
+}


### PR DESCRIPTION
Current `ffpyplayer` recipe supports only `h264+aac` (only `.mp4` file format).

This is confusing (since rarely mentioned anywhere) and probably doesn't meet people expectations (if I'm going to use video, probably I want to support more formats then only `.mp4`). Here's some discussions/questions about it: [1](https://groups.google.com/forum/#!msg/kivy-users/ypJOZXlUEqM/8eDajQ_hbzUJ), [2](https://groups.google.com/forum/#!msg/kivy-users/ypJOZXlUEqM/2XE_7GChAAAJ), [3](https://github.com/kivy/python-for-android/issues/400), [4](https://github.com/kivy/kivy/issues/2649#issuecomment-64537795), [5](http://stackoverflow.com/q/40359297/1113207).

With this PR your can specify `ffpyplayer_codecs` (additionally to `ffpyplayer`) to enable all default codecs and `libx264`, `libshine` also. I tested it on couple of videos and couldn't find any that couldn't be processed.

I'm new with bash and p4a, so I would ask you to check PR before merging. Thanks.