### PR TITLE
Add ``screenSize`` to android:configChanges in AndroidManifest.xml if API >= 13

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -63,7 +63,7 @@
 
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
-                  android:configChanges="keyboardHidden|orientation"
+                  android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
                   >
             <intent-filter>

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -57,7 +57,7 @@
 
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
-                  android:configChanges="keyboardHidden|orientation"
+                  android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
                   >
             <intent-filter>


### PR DESCRIPTION
According to https://developer.android.com/guide/topics/manifest/activity-element.html#config -> orientation:

If your application targets API level 13 or higher (as declared by the minSdkVersion and targetSdkVersion attributes), then you should also declare the "screenSize" configuration, because it also changes when a device switches between portrait and landscape orientations.

If ``screenSize`` not given app freezes on orientation change.

