### PR TITLE
Switch --permission to accept >=1 parameters

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/build.py
+++ b/pythonforandroid/bootstraps/pygame/build/build.py
@@ -415,7 +415,7 @@ tools directory of the Android SDK.
                           'Usually one of "landscape", "portrait" or '
                           '"sensor"'))
     ap.add_argument('--permission', dest='permissions', action='append',
-                    help='The permissions to give this app.')
+                    help='The permissions to give this app.', nargs='+')
     ap.add_argument('--ignore-path', dest='ignore_path', action='append',
                     help='Ignore path when building the app')
     ap.add_argument('--icon', dest='icon',
@@ -488,6 +488,9 @@ tools directory of the Android SDK.
 
     if args.permissions is None:
         args.permissions = []
+    elif args.permissions:
+        if isinstance(args.permissions[0], list):
+            args.permissions = [p for perm in args.permissions for p in perm]
 
     if args.ignore_path is None:
         args.ignore_path = []

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -417,7 +417,7 @@ tools directory of the Android SDK.
     ap.add_argument('--icon', dest='icon',
                     help='A png file to use as the icon for the application.')
     ap.add_argument('--permission', dest='permissions', action='append',
-                    help='The permissions to give this app.')
+                    help='The permissions to give this app.', nargs='+')
     ap.add_argument('--meta-data', dest='meta_data', action='append',
                     help='Custom key=value to add in application metadata')
     ap.add_argument('--presplash', dest='presplash',
@@ -488,6 +488,9 @@ tools directory of the Android SDK.
 
     if args.permissions is None:
         args.permissions = []
+    elif args.permissions:
+        if isinstance(args.permissions[0], list):
+            args.permissions = [p for perm in args.permissions for p in perm]
 
     if args.meta_data is None:
         args.meta_data = []

--- a/pythonforandroid/bootstraps/webview/build/build.py
+++ b/pythonforandroid/bootstraps/webview/build/build.py
@@ -404,7 +404,7 @@ tools directory of the Android SDK.
     ap.add_argument('--icon', dest='icon',
                     help='A png file to use as the icon for the application.')
     ap.add_argument('--permission', dest='permissions', action='append',
-                    help='The permissions to give this app.')
+                    help='The permissions to give this app.', nargs='+')
     ap.add_argument('--meta-data', dest='meta_data', action='append',
                     help='Custom key=value to add in application metadata')
     ap.add_argument('--presplash', dest='presplash',
@@ -465,6 +465,9 @@ tools directory of the Android SDK.
 
     if args.permissions is None:
         args.permissions = []
+    elif args.permissions:
+        if isinstance(args.permissions[0], list):
+            args.permissions = [p for perm in args.permissions for p in perm]
 
     if args.meta_data is None:
         args.meta_data = []


### PR DESCRIPTION
Usage results:

* single value

      ['param']
* two or more values

      ['param1', 'param2']
* two or more `--permission` args with at least one value each

      [['param1', 'param2'], ['param3', 'param4']]

which is later flattened.

Closes #673