### PR TITLE
android_new: fix force_build option

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -159,8 +159,9 @@ def dist_from_args(ctx, args):
     return Distribution.get_distribution(
         ctx,
         name=args.dist_name,
-        ndk_api=args.ndk_api,
         recipes=split_argument_list(args.requirements),
+        ndk_api=args.ndk_api,
+        force_build=args.force_build,
         require_perfect_match=args.require_perfect_match,
         allow_replace_dist=args.allow_replace_dist)
 


### PR DESCRIPTION
In current master, the ```force-build``` argument is defined, but never used. Small patch to fix it, and clean up a bit of PEP8.

I have also added the config option to Buildozer here: [https://github.com/kivy/buildozer/pull/464](https://github.com/kivy/buildozer/pull/464)