### PR TITLE
Log every python library load error

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -29,9 +29,13 @@ public class PythonUtil {
 		    try {
                 System.loadLibrary(lib);
             } catch(UnsatisfiedLinkError e) {
-                if (lib.startsWith("python") && !skippedPython) {
-                    skippedPython = true;
-                    continue;
+                if (lib.startsWith("python")){
+                    Log.v(TAG, e.getMessage());
+                    Log.v(TAG, "It's ok not to load python2 library for python3 app and vice versa.");
+                    if (!skippedPython) {
+                        skippedPython = true;
+                        continue;
+                    }
                 }
                 throw e;
             }


### PR DESCRIPTION
Fix the situation when something happens while loading python2.7 library. Since it is loading first it's error is discarding and the error from only last python3 is shown.

This patch show every error with a note that there are some cases when it is normal.

Allows to debug python2 load library errors.