### PR TITLE
Added support for Python 3.6

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -16,6 +16,7 @@ public class PythonUtil {
             "SDL2_ttf",
             "python2.7",
             "python3.5m",
+            "python3.6m",
             "main"
         };
     }
@@ -23,17 +24,22 @@ public class PythonUtil {
 	public static void loadLibraries(File filesDir) {
 
         String filesDirPath = filesDir.getAbsolutePath();
-        boolean skippedPython = false;
+        boolean foundPython = false;
 
 		for (String lib : getLibraries()) {
 		    try {
                 System.loadLibrary(lib);
-            } catch(UnsatisfiedLinkError e) {
-                if (lib.startsWith("python") && !skippedPython) {
-                    skippedPython = true;
-                    continue;
+                if (lib.startsWith("python")) {
+                    foundPython = true;
                 }
-                throw e;
+            } catch(UnsatisfiedLinkError e) {
+                // If this is the last possible libpython
+                // load, and it has failed, give a more
+                // general error
+                if (lib.startsWith("python3.6") && !foundPython) {
+                    throw new java.lang.RuntimeException("Could not load any libpythonXXX.so");
+                }
+                continue;
             }
         }
 
@@ -52,5 +58,5 @@ public class PythonUtil {
         }
 
         Log.v(TAG, "Loaded everything!");
-	}
+    }
 }

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -818,7 +818,6 @@ class PythonRecipe(Recipe):
 
         with current_directory(self.get_build_dir(arch.arch)):
             hostpython = sh.Command(self.hostpython_location)
-            # hostpython = sh.Command('python3.5')
 
 
             if self.ctx.python_recipe.from_crystax:
@@ -986,7 +985,6 @@ class CythonRecipe(PythonRecipe):
             site_packages_dirs = command(
                 '-c', 'import site; print("\\n".join(site.getsitepackages()))')
             site_packages_dirs = site_packages_dirs.stdout.decode('utf-8').split('\n')
-            # env['PYTHONPATH'] = '/usr/lib/python3.5/site-packages/:/usr/lib/python3.5'
             if 'PYTHONPATH' in env:
                 env['PYTHONPATH'] = env + ':{}'.format(':'.join(site_packages_dirs))
             else:
@@ -994,7 +992,6 @@ class CythonRecipe(PythonRecipe):
 
         with current_directory(self.get_build_dir(arch.arch)):
             hostpython = sh.Command(self.ctx.hostpython)
-            # hostpython = sh.Command('python3.5')
             shprint(hostpython, '-c', 'import sys; print(sys.path)', _env=env)
             print('cwd is', realpath(curdir))
             info('Trying first build of {} to get cython files: this is '
@@ -1089,12 +1086,14 @@ class CythonRecipe(PythonRecipe):
                      self.ctx.python_recipe.version, 'include',
                      'python')) + env['CFLAGS']
 
-            # Temporarily hardcode the -lpython3.5 as this does not
+            # Temporarily hardcode the -lpython3.x as this does not
             # get applied automatically in some environments.  This
             # will need generalising, along with the other hardcoded
             # py3.5 references, to support other python3 or crystax
             # python versions.
-            env['LDFLAGS'] = env['LDFLAGS'] + ' -lpython3.5m'
+            python3_version = self.ctx.python_recipe.version
+            python3_version = '.'.join(python3_version.split('.')[:2])
+            env['LDFLAGS'] = env['LDFLAGS'] + ' -lpython{}m'.format(python3_version)
 
         return env
 


### PR DESCRIPTION
~~Not for merging yet.~~

This PR removes some final references to python3.5 to make everything generic, so that python3.6 can be used by adding `python3crystax=3.6` in the requirements (the default remains 3.5 for now).

This won't actually do anything yet as CrystaX doesn't come with a prebuilt Python 3.6, but I've got this working as well. I'll add support for downloading a prebuilt one that I've generated, or for building a new one locally, shortly.