### PR TITLE
commit to localrecipe branch:

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -47,6 +47,8 @@ class Context(object):
 
     symlink_java_src = False # If True, will symlink instead of copying during build
 
+    P4A_force_build = False  #  True forces local recipes rebuild, see toolchain.dist_from_args()
+
     @property
     def packages_path(self):
         '''Where packages are downloaded before being unpacked'''
@@ -540,6 +542,9 @@ def build_recipes(build_order, python_modules, ctx):
     # download is arch independent
     info_main('# Downloading recipes ')
     for recipe in recipes:
+        if ctx.P4A_force_build and not recipe.force_build:
+            info_main('recipe {0} not marked for force build, skip download'.format(recipe.name))
+            continue
         recipe.download_if_necessary()
 
     for arch in ctx.archs:
@@ -547,6 +552,9 @@ def build_recipes(build_order, python_modules, ctx):
 
         info_main('# Unpacking recipes')
         for recipe in recipes:
+            if ctx.P4A_force_build and not recipe.force_build:
+                info_main('recipe {0} not marked for force build, skip unpack'.format(recipe.name))
+                continue
             ensure_dir(recipe.get_build_container_dir(arch.arch))
             recipe.prepare_build_dir(arch.arch)
 
@@ -561,7 +569,7 @@ def build_recipes(build_order, python_modules, ctx):
         info_main('# Building recipes')
         for recipe in recipes:
             info_main('Building {} for {}'.format(recipe.name, arch.arch))
-            if recipe.should_build(arch):
+            if recipe.force_build or recipe.should_build(arch):
                 recipe.build_arch(arch)
             else:
                 info('{} said it is already built, skipping'

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -153,12 +153,19 @@ def dist_from_args(ctx, args):
     '''Parses out any distribution-related arguments, and uses them to
     obtain a Distribution class instance for the build.
     '''
-    return Distribution.get_distribution(
+    #  check if distribution force build requested
+    force_build = bool( os.environ.get('P4A_force_build') ) or args.force_build
+    dist = Distribution.get_distribution(
         ctx,
         name=args.dist_name,
         recipes=split_argument_list(args.requirements),
+        force_build=force_build,
         extra_dist_dirs=split_argument_list(args.extra_dist_dirs),
         require_perfect_match=args.require_perfect_match)
+
+    #  for distribution where user requested local recipe rebuild P4A_force_build set tue
+    ctx.P4A_force_build = dist.P4A_force_build  #  see Distribution.get_distribution()
+    return dist
 
 
 def build_dist_from_args(ctx, dist, args):
@@ -505,7 +512,10 @@ class ToolchainCL(object):
         self.ctx.copy_libs = args.copy_libs
 
         # Each subparser corresponds to a method
-        getattr(self, args.subparser_name.replace('-', '_'))(args)
+        #  make executed command starts build, let's make it more visible
+        # getattr(self, args.subparser_name.replace('-', '_'))(args)
+        cmd = args.subparser_name.replace('-', '_')
+        getattr(self, cmd)(args)
 
     def hook(self, name):
         if not self.args.hook:


### PR DESCRIPTION
Allow local edition of recipes. Recipe replacing standard one is located in a
directory defined in an environment variable P4A_{name}_DIR,
where {name} stands for the recipe name. P4A_force_build set (True)
forces local recipes rebuild, other (standard download) recipes are reused.
On linux P4A downloads and builds are stored in
~/.local/share/python-for-android/ (no change),
to initialize p4a build erase the directory.

Changes to be committed:
    modified:   pythonforandroid/build.py
    modified:   pythonforandroid/distribution.py
    modified:   pythonforandroid/recipe.py
    modified:   pythonforandroid/toolchain.py