### PR TITLE
fix pyyaml: handle crash, remove setuptools dep for Py3 support

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -783,8 +783,13 @@ class PythonRecipe(Recipe):
             hppath.append(join(dirname(self.hostpython_location), 'Lib'))
             hppath.append(join(hppath[0], 'site-packages'))
             builddir = join(dirname(self.hostpython_location), 'build')
-            hppath += [join(builddir, d) for d in listdir(builddir)
-                       if isdir(join(builddir, d))]
+            try:
+                listed = listdir(builddir)
+                hppath += [join(builddir, d) for d in listed
+                           if isdir(join(builddir, d))]
+            except OSError as err:
+                debug('%s', err)
+
             if 'PYTHONPATH' in env:
                 env['PYTHONPATH'] = ':'.join(hppath + [env['PYTHONPATH']])
             else:

--- a/pythonforandroid/recipes/pyyaml/__init__.py
+++ b/pythonforandroid/recipes/pyyaml/__init__.py
@@ -4,7 +4,8 @@ from pythonforandroid.toolchain import PythonRecipe
 class PyYamlRecipe(PythonRecipe):
     version = "3.11"
     url = 'http://pyyaml.org/download/pyyaml/PyYAML-{version}.tar.gz'
-    depends = [('python2', 'python3crystax'), "setuptools"]
+    #~ depends = [('python2', 'python3crystax'), "setuptools"]
+    depends = [ ('python2', 'python3crystax') ]
     site_packages_name = 'pyyaml'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -14,7 +14,7 @@ class SetuptoolsRecipe(PythonRecipe):
     version = '18.3.1'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.tar.gz'
 
-    depends = ['python2']
+    depends = [ ('python2', 'python3crystax') ]
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = True


### PR DESCRIPTION
See #1031 for exception info:

    OSError: [Errno 2] No such file or directory: 'build'