### PR TITLE
replace split text with split

### DIFF
--- a/pythonforandroid/bootstraps/sdl2_gradle/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2_gradle/build/build.py
@@ -278,7 +278,7 @@ main.py that loads it.''')
                 print('Requested aar does not exists: {}'.format(aarname))
                 sys.exit(-1)
             shutil.copy(aarname, 'libs')
-            aars.append(basename(aarname).splitext()[0])
+            aars.append(basename(aarname).split('.')[0])
 
     versioned_name = (args.name.replace(' ', '').replace('\'', '') +
                       '-' + args.version)


### PR DESCRIPTION
Was failing with `aars.append(basename(aarname).splitext()[0])
AttributeError: 'str' object has no attribute 'splitext'`