### PR TITLE
Added command handling if p4a is run with no arguments

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -467,6 +467,10 @@ class ToolchainCL(object):
 
         self.args = args
 
+        if args.subparser_name is None:
+            parser.print_help()
+            exit(1)
+
         setup_color(args.color)
 
         if args.debug:


### PR DESCRIPTION
Fixes https://github.com/kivy/python-for-android/issues/1058