### PR TITLE
Delete the kivy-examples dir from the dist under python3

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -48,7 +48,6 @@ class KivyRecipe(CythonRecipe):
         super(KivyRecipe, self).install_python_package(arch)
         site_packages_dir = self.ctx.get_site_packages_dir(arch)
         usr_dir = join(site_packages_dir, 'usr', 'share', 'kivy-examples')
-        print('usr_dir is', usr_dir)
         if exists(usr_dir) and isdir(usr_dir):
             rmtree(usr_dir)
 

--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -1,6 +1,7 @@
 
 from pythonforandroid.toolchain import CythonRecipe, shprint, current_directory, ArchARM
-from os.path import exists, join
+from os.path import exists, join, isdir
+from shutil import rmtree
 import sh
 import glob
 
@@ -42,5 +43,13 @@ class KivyRecipe(CythonRecipe):
                 ])
 
         return env
+
+    def install_python_package(self, arch):
+        super(KivyRecipe, self).install_python_package(arch)
+        site_packages_dir = self.ctx.get_site_packages_dir(arch)
+        usr_dir = join(site_packages_dir, 'usr', 'share', 'kivy-examples')
+        print('usr_dir is', usr_dir)
+        if exists(usr_dir) and isdir(usr_dir):
+            rmtree(usr_dir)
 
 recipe = KivyRecipe()


### PR DESCRIPTION
Currently the Kivy examples are included automatically under python3, due to a difference in where setuptools installs them. They add about 9MB to the APK size, and are definitely undesirable.