### PR TITLE
Made logger convert output to utf-8 including errors

### DIFF
--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -174,6 +174,8 @@ def shprint(command, *args, **kwargs):
         output = command(*args, **kwargs)
         for line in output:
             if logger.level > logging.DEBUG:
+                if isinstance(line, bytes):
+                    line = line.decode('utf-8', errors='replace')
                 msg = line.replace(
                     '\n', ' ').replace(
                         '\t', ' ').replace(


### PR DESCRIPTION
This prevents a regular error in the python2 build where the output is in byte format but is not valid utf-8, so the logger crashes in python3 because the output is assumed to be a str.