### PR TITLE
Ndk 15

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -49,6 +49,11 @@ class Arch(object):
             sysroot = self.ctx.ndk_platform
             env['CFLAGS'] += ' -I{}'.format(self.ctx.ndk_platform)
         env['CFLAGS'] += ' -isysroot {} '.format(sysroot)
+        env['CFLAGS'] += '-I' + join(self.ctx.get_python_install_dir(),
+                                     'include/python{}'.format(
+                                         self.ctx.python_recipe.version[0:3])
+                                    )
+
         env['LDFLAGS'] += '--sysroot {} '.format(self.ctx.ndk_platform)
 
         env["CXXFLAGS"] = env["CFLAGS"]

--- a/pythonforandroid/recipes/hostpython2/__init__.py
+++ b/pythonforandroid/recipes/hostpython2/__init__.py
@@ -2,6 +2,7 @@
 from pythonforandroid.toolchain import Recipe, shprint, current_directory, info, warning
 from os.path import join, exists
 from os import chdir
+import os
 import sh
 
 
@@ -36,6 +37,8 @@ class Hostpython2Recipe(Recipe):
                                            'hostpgen')
                 return
             
+            if 'LIBS' in os.environ:
+                os.environ.pop('LIBS')
             configure = sh.Command('./configure')
 
             shprint(configure)

--- a/pythonforandroid/recipes/ifaddrs/__init__.py
+++ b/pythonforandroid/recipes/ifaddrs/__init__.py
@@ -1,0 +1,68 @@
+""" ifaddrs for Android
+"""
+from os.path import join, exists
+import sh
+from pythonforandroid.logger import info, shprint
+
+from pythonforandroid.toolchain import (CompiledComponentsPythonRecipe,
+                                        current_directory)
+
+class IFAddrRecipe(CompiledComponentsPythonRecipe):
+    version = 'master'
+    url = 'git+https://github.com/morristech/android-ifaddrs.git'
+    depends = [('hostpython2', 'hostpython3'), ('python2', 'python3crystax')]
+
+    call_hostpython_via_targetpython = False
+    site_packages_name = 'ifaddrs'
+    generated_libraries = ['libifaddrs.so']
+
+    def should_build(self, arch):
+        """It's faster to build than check"""
+        return not (exists(join(self.ctx.libs_dir, arch.arch, 'libifaddrs.so'))
+                    and exists(join(self.ctx.get_python_install_dir(), 'lib'
+                        "libifaddrs.so"))
+                    )
+
+    def prebuild_arch(self, arch):
+        """Make the build and target directories"""
+        path = self.get_build_dir(arch.arch)
+        if not  exists(path):
+            info("creating {}".format(path))
+            shprint(sh.mkdir, '-p', path)
+
+    def build_arch(self, arch):
+        """simple shared compile"""
+        env = self.get_recipe_env(arch, with_flags_in_cc=False)
+        for path in (self.get_build_dir(arch.arch),
+            join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Lib'),
+            join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include'),
+                    ):
+            if not  exists(path):
+                info("creating {}".format(path))
+                shprint(sh.mkdir, '-p', path)
+        cli = env['CC'].split()
+        cc = sh.Command(cli[0])
+
+        with current_directory(self.get_build_dir(arch.arch)):
+            cflags = env['CFLAGS'].split()
+            cflags.extend(['-I.', '-c', '-l.', 'ifaddrs.c', '-I.'])
+            shprint(cc, *cflags, _env=env)
+
+            cflags = env['CFLAGS'].split()
+            cflags.extend(['-shared', '-I.', 'ifaddrs.o', '-o', 'libifaddrs.so'])
+            cflags.extend(env['LDFLAGS'].split())
+            shprint(cc, *cflags, _env=env)
+
+            shprint(sh.cp, 'libifaddrs.so', self.ctx.get_libs_dir(arch.arch))
+            shprint(sh.cp, "libifaddrs.so", join(self.ctx.get_python_install_dir(), 'lib'))
+            # drop header in to the Python include directory
+            shprint(sh.cp, "ifaddrs.h", join(self.ctx.get_python_install_dir(),
+                                          'include/python{}'.format(
+                                              self.ctx.python_recipe.version[0:3]
+                                          )
+                                         )
+                   )
+            include_path = join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include')
+            shprint(sh.cp, "ifaddrs.h", include_path)
+
+recipe = IFAddrRecipe()

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -1,71 +1,83 @@
-from pythonforandroid.recipe import Recipe
-from pythonforandroid.logger import shprint
-from pythonforandroid.util import current_directory
 from os.path import exists, join
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.logger import info, shprint
+from pythonforandroid.util import current_directory
 import sh
-import glob
 
 
 class LibffiRecipe(Recipe):
-	name = 'libffi'
-	version = 'v3.2.1'
-	url = 'https://github.com/atgreen/libffi/archive/{version}.zip'
+    name = 'libffi'
+    version = 'v3.2.1'
+    url = 'https://github.com/atgreen/libffi/archive/{version}.zip'
 
-	patches = ['remove-version-info.patch']
+    patches = ['remove-version-info.patch']
 
-	def get_host(self, arch):
-		with current_directory(self.get_build_dir(arch.arch)):
-			host = None
-			with open('Makefile') as f:
-				for line in f:
-					if line.startswith('host = '):
-						host = line.strip()[7:]
-						break
+    def get_host(self, arch):
+        with current_directory(self.get_build_dir(arch.arch)):
+            host = None
+            with open('Makefile') as f:
+                for line in f:
+                    if line.startswith('host = '):
+                        host = line.strip()[7:]
+                        break
 
-			if not host or not exists(host):
-				raise RuntimeError('failed to find build output! ({})'
-				                   .format(host))
-			
-			return host
+            if not host or not exists(host):
+                raise RuntimeError('failed to find build output! ({})'
+                                   .format(host))
 
-	def should_build(self, arch):
-		# return not bool(glob.glob(join(self.ctx.get_libs_dir(arch.arch),
-		#                                'libffi.so*')))
-		return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
-		# return not exists(join(self.ctx.get_python_install_dir(), 'lib',
-		#                        'libffi.so'))
+            return host
 
-	def build_arch(self, arch):
-		env = self.get_recipe_env(arch)
-		with current_directory(self.get_build_dir(arch.arch)):
-			if not exists('configure'):
-				shprint(sh.Command('./autogen.sh'), _env=env)
-			shprint(sh.Command('autoreconf'), '-vif', _env=env)
-			shprint(sh.Command('./configure'), '--host=' + arch.toolchain_prefix,
-			        '--prefix=' + self.ctx.get_python_install_dir(),
-			        '--enable-shared', _env=env)
-			shprint(sh.make, '-j5', 'libffi.la', _env=env)
+    def should_build(self, arch):
+        return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
 
+    def build_arch(self, arch):
+        env = self.get_recipe_env(arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            if not exists('configure'):
+                shprint(sh.Command('./autogen.sh'), _env=env)
+            shprint(sh.Command('autoreconf'), '-vif', _env=env)
+            shprint(sh.Command('./configure'),
+                    '--host=' + arch.toolchain_prefix,
+                    '--prefix=' + self.ctx.get_python_install_dir(),
+                    '--enable-shared', _env=env)
+            #'--with-sysroot={}'.format(self.ctx.ndk_platform),
+            #'--target={}'.format(arch.toolchain_prefix),
 
-			# dlname = None
-			# with open(join(host, 'libffi.la')) as f:
-			# 	for line in f:
-			# 		if line.startswith('dlname='):
-			# 			dlname = line.strip()[8:-1]
-			# 			break
-			# 
-			# if not dlname or not exists(join(host, '.libs', dlname)):
-			# 	raise RuntimeError('failed to locate shared object! ({})'
-			# 	                   .format(dlname))
+            # ndk 15 introduces unified headers required --sysroot and
+            # -isysroot for libraries and headers. libtool's head explodes
+            # trying to weave them into it's own magic. The result is a link
+            # failure tryng to link libc. We call make to compile the bits
+            # and manually link...
 
-			# shprint(sh.sed, '-i', 's/^dlname=.*$/dlname=\'libffi.so\'/', join(host, 'libffi.la'))
+            try:
+                shprint(sh.make, '-j5', 'libffi.la', _env=env)
+            except sh.ErrorReturnCode_2:
+                info("make libffi.la failed as expected")
+            cc = sh.Command(env['CC'].split()[0])
+            cflags = env['CC'].split()[1:]
 
-			shprint(sh.cp, '-t', self.ctx.get_libs_dir(arch.arch),
-			        join(self.get_host(arch), '.libs', 'libffi.so')) #,
-			        # join(host, 'libffi.la'))
+            cflags.extend(['-march=armv7-a', '-mfloat-abi=softfp', '-mfpu=vfp',
+                           '-mthumb', '-shared', '-fPIC', '-DPIC',
+                           'src/.libs/prep_cif.o', 'src/.libs/types.o',
+                           'src/.libs/raw_api.o', 'src/.libs/java_raw_api.o',
+                           'src/.libs/closures.o', 'src/arm/.libs/sysv.o',
+                           'src/arm/.libs/ffi.o', ]
+                         )
 
-	def get_include_dirs(self, arch):
-		return [join(self.get_build_dir(arch.arch), self.get_host(arch), 'include')]
+            ldflags = env['LDFLAGS'].split()
+            cflags.extend(ldflags)
+            cflags.extend(['-Wl,-soname', '-Wl,libffi.so', '-o',
+                           '.libs/libffi.so'])
+
+            with current_directory(self.get_host(arch)):
+                shprint(cc, *cflags, _env=env)
+
+            shprint(sh.cp, '-t', self.ctx.get_libs_dir(arch.arch),
+                    join(self.get_host(arch), '.libs', 'libffi.so'))
+
+    def get_include_dirs(self, arch):
+        return [join(self.get_build_dir(arch.arch), self.get_host(arch),
+                     'include')]
 
 
 recipe = LibffiRecipe()

--- a/pythonforandroid/recipes/libglob/__init__.py
+++ b/pythonforandroid/recipes/libglob/__init__.py
@@ -1,0 +1,74 @@
+"""
+    android libglob
+    available via '-lglob' LDFLAG
+"""
+from os.path import exists, join, dirname
+from pythonforandroid.toolchain import (CompiledComponentsPythonRecipe,
+                                        current_directory)
+from pythonforandroid.logger import shprint, info, warning, info_main
+import sh
+
+class LibGlobRecipe(CompiledComponentsPythonRecipe):
+    """Make a glob.h and glob.so for the python_install_dir()"""
+    version = '0.0.1'
+    url = None
+    # 
+    # glob.h and glob.c extracted from
+    # https://github.com/white-gecko/TokyoCabinet, e.g.:
+    #   https://raw.githubusercontent.com/white-gecko/TokyoCabinet/master/glob.h
+    #   https://raw.githubusercontent.com/white-gecko/TokyoCabinet/master/glob.c
+    # and pushed in via patch
+    name = 'libglob'
+
+    depends = [('hostpython2', 'hostpython3'), ('python2', 'python3crystax')]
+    patches = ['glob.patch']
+
+    def should_build(self, arch):
+        """It's faster to build than check"""
+        return True
+
+    def prebuild_arch(self, arch):
+        """Make the build and target directories"""
+        path = self.get_build_dir(arch.arch)
+        if not  exists(path):
+            info("creating {}".format(path))
+            shprint(sh.mkdir, '-p', path)
+
+    def build_arch(self, arch):
+        """simple shared compile"""
+        env = self.get_recipe_env(arch, with_flags_in_cc=False)
+        for path in (self.get_build_dir(arch.arch),
+            join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Lib'),
+            join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include'),
+                    ):
+            if not  exists(path):
+                info("creating {}".format(path))
+                shprint(sh.mkdir, '-p', path)
+        cli = env['CC'].split()
+        cc = sh.Command(cli[0])
+
+        with current_directory(self.get_build_dir(arch.arch)):
+            cflags = env['CFLAGS'].split()
+            cflags.extend(['-I.', '-c', '-l.', 'glob.c', '-I.']) # , '-o', 'glob.o'])
+            shprint(cc, *cflags, _env=env)
+
+            cflags = env['CFLAGS'].split()
+            srindex = cflags.index('--sysroot')
+            if srindex:
+                cflags[srindex+1] = self.ctx.ndk_platform
+            cflags.extend(['-shared', '-I.', 'glob.o', '-o', 'libglob.so'])
+            shprint(cc, *cflags, _env=env)
+
+            shprint(sh.cp, 'libglob.so', join(self.ctx.libs_dir, arch.arch))
+            shprint(sh.cp, "libglob.so", join(self.ctx.get_python_install_dir(), 'lib'))
+            # drop header in to the Python include directory
+            shprint(sh.cp, "glob.h", join(self.ctx.get_python_install_dir(),
+                                          'include/python{}'.format(
+                                              self.ctx.python_recipe.version[0:3]
+                                          )
+                                         )
+                   )
+            include_path = join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include')
+            shprint(sh.cp, "glob.h", include_path)
+
+recipe = LibGlobRecipe()

--- a/pythonforandroid/recipes/libglob/glob.patch
+++ b/pythonforandroid/recipes/libglob/glob.patch
@@ -1,0 +1,1016 @@
+diff -Nur /tmp/x/glob.c libglob/glob.c
+--- /tmp/x/glob.c	1969-12-31 19:00:00.000000000 -0500
++++ libglob/glob.c	2017-08-19 15:23:19.910414868 -0400
+@@ -0,0 +1,906 @@
++/*
++ * Natanael Arndt, 2011: removed collate.h dependencies
++ *  (my changes are trivial)
++ *
++ * Copyright (c) 1989, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * This code is derived from software contributed to Berkeley by
++ * Guido van Rossum.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#if defined(LIBC_SCCS) && !defined(lint)
++static char sccsid[] = "@(#)glob.c	8.3 (Berkeley) 10/13/93";
++#endif /* LIBC_SCCS and not lint */
++#include <sys/cdefs.h>
++__FBSDID("$FreeBSD$");
++
++/*
++ * glob(3) -- a superset of the one defined in POSIX 1003.2.
++ *
++ * The [!...] convention to negate a range is supported (SysV, Posix, ksh).
++ *
++ * Optional extra services, controlled by flags not defined by POSIX:
++ *
++ * GLOB_QUOTE:
++ *	Escaping convention: \ inhibits any special meaning the following
++ *	character might have (except \ at end of string is retained).
++ * GLOB_MAGCHAR:
++ *	Set in gl_flags if pattern contained a globbing character.
++ * GLOB_NOMAGIC:
++ *	Same as GLOB_NOCHECK, but it will only append pattern if it did
++ *	not contain any magic characters.  [Used in csh style globbing]
++ * GLOB_ALTDIRFUNC:
++ *	Use alternately specified directory access functions.
++ * GLOB_TILDE:
++ *	expand ~user/foo to the /home/dir/of/user/foo
++ * GLOB_BRACE:
++ *	expand {1,2}{a,b} to 1a 1b 2a 2b
++ * gl_matchc:
++ *	Number of matches in the current invocation of glob.
++ */
++
++/*
++ * Some notes on multibyte character support:
++ * 1. Patterns with illegal byte sequences match nothing - even if
++ *    GLOB_NOCHECK is specified.
++ * 2. Illegal byte sequences in filenames are handled by treating them as
++ *    single-byte characters with a value of the first byte of the sequence
++ *    cast to wchar_t.
++ * 3. State-dependent encodings are not currently supported.
++ */
++
++#include <sys/param.h>
++#include <sys/stat.h>
++
++#include <ctype.h>
++#include <dirent.h>
++#include <errno.h>
++#include <glob.h>
++#include <limits.h>
++#include <pwd.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <wchar.h>
++
++#define	DOLLAR		'$'
++#define	DOT		'.'
++#define	EOS		'\0'
++#define	LBRACKET	'['
++#define	NOT		'!'
++#define	QUESTION	'?'
++#define	QUOTE		'\\'
++#define	RANGE		'-'
++#define	RBRACKET	']'
++#define	SEP		'/'
++#define	STAR		'*'
++#define	TILDE		'~'
++#define	UNDERSCORE	'_'
++#define	LBRACE		'{'
++#define	RBRACE		'}'
++#define	SLASH		'/'
++#define	COMMA		','
++
++#ifndef DEBUG
++
++#define	M_QUOTE		0x8000000000ULL
++#define	M_PROTECT	0x4000000000ULL
++#define	M_MASK		0xffffffffffULL
++#define	M_CHAR		0x00ffffffffULL
++
++typedef uint_fast64_t Char;
++
++#else
++
++#define	M_QUOTE		0x80
++#define	M_PROTECT	0x40
++#define	M_MASK		0xff
++#define	M_CHAR		0x7f
++
++typedef char Char;
++
++#endif
++
++
++#define	CHAR(c)		((Char)((c)&M_CHAR))
++#define	META(c)		((Char)((c)|M_QUOTE))
++#define	M_ALL		META('*')
++#define	M_END		META(']')
++#define	M_NOT		META('!')
++#define	M_ONE		META('?')
++#define	M_RNG		META('-')
++#define	M_SET		META('[')
++#define	ismeta(c)	(((c)&M_QUOTE) != 0)
++
++
++static int	 compare(const void *, const void *);
++static int	 g_Ctoc(const Char *, char *, size_t);
++static int	 g_lstat(Char *, struct stat *, glob_t *);
++static DIR	*g_opendir(Char *, glob_t *);
++static const Char *g_strchr(const Char *, wchar_t);
++#ifdef notdef
++static Char	*g_strcat(Char *, const Char *);
++#endif
++static int	 g_stat(Char *, struct stat *, glob_t *);
++static int	 glob0(const Char *, glob_t *, size_t *);
++static int	 glob1(Char *, glob_t *, size_t *);
++static int	 glob2(Char *, Char *, Char *, Char *, glob_t *, size_t *);
++static int	 glob3(Char *, Char *, Char *, Char *, Char *, glob_t *, size_t *);
++static int	 globextend(const Char *, glob_t *, size_t *);
++static const Char *	
++		 globtilde(const Char *, Char *, size_t, glob_t *);
++static int	 globexp1(const Char *, glob_t *, size_t *);
++static int	 globexp2(const Char *, const Char *, glob_t *, int *, size_t *);
++static int	 match(Char *, Char *, Char *);
++#ifdef DEBUG
++static void	 qprintf(const char *, Char *);
++#endif
++
++int
++glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob)
++{
++	const char *patnext;
++	size_t limit;
++	Char *bufnext, *bufend, patbuf[MAXPATHLEN], prot;
++	mbstate_t mbs;
++	wchar_t wc;
++	size_t clen;
++
++	patnext = pattern;
++	if (!(flags & GLOB_APPEND)) {
++		pglob->gl_pathc = 0;
++		pglob->gl_pathv = NULL;
++		if (!(flags & GLOB_DOOFFS))
++			pglob->gl_offs = 0;
++	}
++	if (flags & GLOB_LIMIT) {
++		limit = pglob->gl_matchc;
++		if (limit == 0)
++			limit = ARG_MAX;
++	} else
++		limit = 0;
++	pglob->gl_flags = flags & ~GLOB_MAGCHAR;
++	pglob->gl_errfunc = errfunc;
++	pglob->gl_matchc = 0;
++
++	bufnext = patbuf;
++	bufend = bufnext + MAXPATHLEN - 1;
++	if (flags & GLOB_NOESCAPE) {
++		memset(&mbs, 0, sizeof(mbs));
++		while (bufend - bufnext >= MB_CUR_MAX) {
++			clen = mbrtowc(&wc, patnext, MB_LEN_MAX, &mbs);
++			if (clen == (size_t)-1 || clen == (size_t)-2)
++				return (GLOB_NOMATCH);
++			else if (clen == 0)
++				break;
++			*bufnext++ = wc;
++			patnext += clen;
++		}
++	} else {
++		/* Protect the quoted characters. */
++		memset(&mbs, 0, sizeof(mbs));
++		while (bufend - bufnext >= MB_CUR_MAX) {
++			if (*patnext == QUOTE) {
++				if (*++patnext == EOS) {
++					*bufnext++ = QUOTE | M_PROTECT;
++					continue;
++				}
++				prot = M_PROTECT;
++			} else
++				prot = 0;
++			clen = mbrtowc(&wc, patnext, MB_LEN_MAX, &mbs);
++			if (clen == (size_t)-1 || clen == (size_t)-2)
++				return (GLOB_NOMATCH);
++			else if (clen == 0)
++				break;
++			*bufnext++ = wc | prot;
++			patnext += clen;
++		}
++	}
++	*bufnext = EOS;
++
++	if (flags & GLOB_BRACE)
++	    return globexp1(patbuf, pglob, &limit);
++	else
++	    return glob0(patbuf, pglob, &limit);
++}
++
++/*
++ * Expand recursively a glob {} pattern. When there is no more expansion
++ * invoke the standard globbing routine to glob the rest of the magic
++ * characters
++ */
++static int
++globexp1(const Char *pattern, glob_t *pglob, size_t *limit)
++{
++	const Char* ptr = pattern;
++	int rv;
++
++	/* Protect a single {}, for find(1), like csh */
++	if (pattern[0] == LBRACE && pattern[1] == RBRACE && pattern[2] == EOS)
++		return glob0(pattern, pglob, limit);
++
++	while ((ptr = g_strchr(ptr, LBRACE)) != NULL)
++		if (!globexp2(ptr, pattern, pglob, &rv, limit))
++			return rv;
++
++	return glob0(pattern, pglob, limit);
++}
++
++
++/*
++ * Recursive brace globbing helper. Tries to expand a single brace.
++ * If it succeeds then it invokes globexp1 with the new pattern.
++ * If it fails then it tries to glob the rest of the pattern and returns.
++ */
++static int
++globexp2(const Char *ptr, const Char *pattern, glob_t *pglob, int *rv, size_t *limit)
++{
++	int     i;
++	Char   *lm, *ls;
++	const Char *pe, *pm, *pm1, *pl;
++	Char    patbuf[MAXPATHLEN];
++
++	/* copy part up to the brace */
++	for (lm = patbuf, pm = pattern; pm != ptr; *lm++ = *pm++)
++		continue;
++	*lm = EOS;
++	ls = lm;
++
++	/* Find the balanced brace */
++	for (i = 0, pe = ++ptr; *pe; pe++)
++		if (*pe == LBRACKET) {
++			/* Ignore everything between [] */
++			for (pm = pe++; *pe != RBRACKET && *pe != EOS; pe++)
++				continue;
++			if (*pe == EOS) {
++				/*
++				 * We could not find a matching RBRACKET.
++				 * Ignore and just look for RBRACE
++				 */
++				pe = pm;
++			}
++		}
++		else if (*pe == LBRACE)
++			i++;
++		else if (*pe == RBRACE) {
++			if (i == 0)
++				break;
++			i--;
++		}
++
++	/* Non matching braces; just glob the pattern */
++	if (i != 0 || *pe == EOS) {
++		*rv = glob0(patbuf, pglob, limit);
++		return 0;
++	}
++
++	for (i = 0, pl = pm = ptr; pm <= pe; pm++)
++		switch (*pm) {
++		case LBRACKET:
++			/* Ignore everything between [] */
++			for (pm1 = pm++; *pm != RBRACKET && *pm != EOS; pm++)
++				continue;
++			if (*pm == EOS) {
++				/*
++				 * We could not find a matching RBRACKET.
++				 * Ignore and just look for RBRACE
++				 */
++				pm = pm1;
++			}
++			break;
++
++		case LBRACE:
++			i++;
++			break;
++
++		case RBRACE:
++			if (i) {
++			    i--;
++			    break;
++			}
++			/* FALLTHROUGH */
++		case COMMA:
++			if (i && *pm == COMMA)
++				break;
++			else {
++				/* Append the current string */
++				for (lm = ls; (pl < pm); *lm++ = *pl++)
++					continue;
++				/*
++				 * Append the rest of the pattern after the
++				 * closing brace
++				 */
++				for (pl = pe + 1; (*lm++ = *pl++) != EOS;)
++					continue;
++
++				/* Expand the current pattern */
++#ifdef DEBUG
++				qprintf("globexp2:", patbuf);
++#endif
++				*rv = globexp1(patbuf, pglob, limit);
++
++				/* move after the comma, to the next string */
++				pl = pm + 1;
++			}
++			break;
++
++		default:
++			break;
++		}
++	*rv = 0;
++	return 0;
++}
++
++
++
++/*
++ * expand tilde from the passwd file.
++ */
++static const Char *
++globtilde(const Char *pattern, Char *patbuf, size_t patbuf_len, glob_t *pglob)
++{
++	struct passwd *pwd;
++	char *h;
++	const Char *p;
++	Char *b, *eb;
++
++	if (*pattern != TILDE || !(pglob->gl_flags & GLOB_TILDE))
++		return pattern;
++
++	/* 
++	 * Copy up to the end of the string or / 
++	 */
++	eb = &patbuf[patbuf_len - 1];
++	for (p = pattern + 1, h = (char *) patbuf;
++	    h < (char *)eb && *p && *p != SLASH; *h++ = *p++)
++		continue;
++
++	*h = EOS;
++
++	if (((char *) patbuf)[0] == EOS) {
++		/*
++		 * handle a plain ~ or ~/ by expanding $HOME first (iff
++		 * we're not running setuid or setgid) and then trying
++		 * the password file
++		 */
++		if (issetugid() != 0 ||
++		    (h = getenv("HOME")) == NULL) {
++			if (((h = getlogin()) != NULL &&
++			     (pwd = getpwnam(h)) != NULL) ||
++			    (pwd = getpwuid(getuid())) != NULL)
++				h = pwd->pw_dir;
++			else
++				return pattern;
++		}
++	}
++	else {
++		/*
++		 * Expand a ~user
++		 */
++		if ((pwd = getpwnam((char*) patbuf)) == NULL)
++			return pattern;
++		else
++			h = pwd->pw_dir;
++	}
++
++	/* Copy the home directory */
++	for (b = patbuf; b < eb && *h; *b++ = *h++)
++		continue;
++
++	/* Append the rest of the pattern */
++	while (b < eb && (*b++ = *p++) != EOS)
++		continue;
++	*b = EOS;
++
++	return patbuf;
++}
++
++
++/*
++ * The main glob() routine: compiles the pattern (optionally processing
++ * quotes), calls glob1() to do the real pattern matching, and finally
++ * sorts the list (unless unsorted operation is requested).  Returns 0
++ * if things went well, nonzero if errors occurred.
++ */
++static int
++glob0(const Char *pattern, glob_t *pglob, size_t *limit)
++{
++	const Char *qpatnext;
++	int err;
++	size_t oldpathc;
++	Char *bufnext, c, patbuf[MAXPATHLEN];
++
++	qpatnext = globtilde(pattern, patbuf, MAXPATHLEN, pglob);
++	oldpathc = pglob->gl_pathc;
++	bufnext = patbuf;
++
++	/* We don't need to check for buffer overflow any more. */
++	while ((c = *qpatnext++) != EOS) {
++		switch (c) {
++		case LBRACKET:
++			c = *qpatnext;
++			if (c == NOT)
++				++qpatnext;
++			if (*qpatnext == EOS ||
++			    g_strchr(qpatnext+1, RBRACKET) == NULL) {
++				*bufnext++ = LBRACKET;
++				if (c == NOT)
++					--qpatnext;
++				break;
++			}
++			*bufnext++ = M_SET;
++			if (c == NOT)
++				*bufnext++ = M_NOT;
++			c = *qpatnext++;
++			do {
++				*bufnext++ = CHAR(c);
++				if (*qpatnext == RANGE &&
++				    (c = qpatnext[1]) != RBRACKET) {
++					*bufnext++ = M_RNG;
++					*bufnext++ = CHAR(c);
++					qpatnext += 2;
++				}
++			} while ((c = *qpatnext++) != RBRACKET);
++			pglob->gl_flags |= GLOB_MAGCHAR;
++			*bufnext++ = M_END;
++			break;
++		case QUESTION:
++			pglob->gl_flags |= GLOB_MAGCHAR;
++			*bufnext++ = M_ONE;
++			break;
++		case STAR:
++			pglob->gl_flags |= GLOB_MAGCHAR;
++			/* collapse adjacent stars to one,
++			 * to avoid exponential behavior
++			 */
++			if (bufnext == patbuf || bufnext[-1] != M_ALL)
++			    *bufnext++ = M_ALL;
++			break;
++		default:
++			*bufnext++ = CHAR(c);
++			break;
++		}
++	}
++	*bufnext = EOS;
++#ifdef DEBUG
++	qprintf("glob0:", patbuf);
++#endif
++
++	if ((err = glob1(patbuf, pglob, limit)) != 0)
++		return(err);
++
++	/*
++	 * If there was no match we are going to append the pattern
++	 * if GLOB_NOCHECK was specified or if GLOB_NOMAGIC was specified
++	 * and the pattern did not contain any magic characters
++	 * GLOB_NOMAGIC is there just for compatibility with csh.
++	 */
++	if (pglob->gl_pathc == oldpathc) {
++		if (((pglob->gl_flags & GLOB_NOCHECK) ||
++		    ((pglob->gl_flags & GLOB_NOMAGIC) &&
++			!(pglob->gl_flags & GLOB_MAGCHAR))))
++			return(globextend(pattern, pglob, limit));
++		else
++			return(GLOB_NOMATCH);
++	}
++	if (!(pglob->gl_flags & GLOB_NOSORT))
++		qsort(pglob->gl_pathv + pglob->gl_offs + oldpathc,
++		    pglob->gl_pathc - oldpathc, sizeof(char *), compare);
++	return(0);
++}
++
++static int
++compare(const void *p, const void *q)
++{
++	return(strcmp(*(char **)p, *(char **)q));
++}
++
++static int
++glob1(Char *pattern, glob_t *pglob, size_t *limit)
++{
++	Char pathbuf[MAXPATHLEN];
++
++	/* A null pathname is invalid -- POSIX 1003.1 sect. 2.4. */
++	if (*pattern == EOS)
++		return(0);
++	return(glob2(pathbuf, pathbuf, pathbuf + MAXPATHLEN - 1,
++	    pattern, pglob, limit));
++}
++
++/*
++ * The functions glob2 and glob3 are mutually recursive; there is one level
++ * of recursion for each segment in the pattern that contains one or more
++ * meta characters.
++ */
++static int
++glob2(Char *pathbuf, Char *pathend, Char *pathend_last, Char *pattern,
++      glob_t *pglob, size_t *limit)
++{
++	struct stat sb;
++	Char *p, *q;
++	int anymeta;
++
++	/*
++	 * Loop over pattern segments until end of pattern or until
++	 * segment with meta character found.
++	 */
++	for (anymeta = 0;;) {
++		if (*pattern == EOS) {		/* End of pattern? */
++			*pathend = EOS;
++			if (g_lstat(pathbuf, &sb, pglob))
++				return(0);
++
++			if (((pglob->gl_flags & GLOB_MARK) &&
++			    pathend[-1] != SEP) && (S_ISDIR(sb.st_mode)
++			    || (S_ISLNK(sb.st_mode) &&
++			    (g_stat(pathbuf, &sb, pglob) == 0) &&
++			    S_ISDIR(sb.st_mode)))) {
++				if (pathend + 1 > pathend_last)
++					return (GLOB_ABORTED);
++				*pathend++ = SEP;
++				*pathend = EOS;
++			}
++			++pglob->gl_matchc;
++			return(globextend(pathbuf, pglob, limit));
++		}
++
++		/* Find end of next segment, copy tentatively to pathend. */
++		q = pathend;
++		p = pattern;
++		while (*p != EOS && *p != SEP) {
++			if (ismeta(*p))
++				anymeta = 1;
++			if (q + 1 > pathend_last)
++				return (GLOB_ABORTED);
++			*q++ = *p++;
++		}
++
++		if (!anymeta) {		/* No expansion, do next segment. */
++			pathend = q;
++			pattern = p;
++			while (*pattern == SEP) {
++				if (pathend + 1 > pathend_last)
++					return (GLOB_ABORTED);
++				*pathend++ = *pattern++;
++			}
++		} else			/* Need expansion, recurse. */
++			return(glob3(pathbuf, pathend, pathend_last, pattern, p,
++			    pglob, limit));
++	}
++	/* NOTREACHED */
++}
++
++static int
++glob3(Char *pathbuf, Char *pathend, Char *pathend_last,
++      Char *pattern, Char *restpattern,
++      glob_t *pglob, size_t *limit)
++{
++	struct dirent *dp;
++	DIR *dirp;
++	int err;
++	char buf[MAXPATHLEN];
++
++	/*
++	 * The readdirfunc declaration can't be prototyped, because it is
++	 * assigned, below, to two functions which are prototyped in glob.h
++	 * and dirent.h as taking pointers to differently typed opaque
++	 * structures.
++	 */
++	struct dirent *(*readdirfunc)();
++
++	if (pathend > pathend_last)
++		return (GLOB_ABORTED);
++	*pathend = EOS;
++	errno = 0;
++
++	if ((dirp = g_opendir(pathbuf, pglob)) == NULL) {
++		/* TODO: don't call for ENOENT or ENOTDIR? */
++		if (pglob->gl_errfunc) {
++			if (g_Ctoc(pathbuf, buf, sizeof(buf)))
++				return (GLOB_ABORTED);
++			if (pglob->gl_errfunc(buf, errno) ||
++			    pglob->gl_flags & GLOB_ERR)
++				return (GLOB_ABORTED);
++		}
++		return(0);
++	}
++
++	err = 0;
++
++	/* Search directory for matching names. */
++	if (pglob->gl_flags & GLOB_ALTDIRFUNC)
++		readdirfunc = pglob->gl_readdir;
++	else
++		readdirfunc = readdir;
++	while ((dp = (*readdirfunc)(dirp))) {
++		char *sc;
++		Char *dc;
++		wchar_t wc;
++		size_t clen;
++		mbstate_t mbs;
++
++		/* Initial DOT must be matched literally. */
++		if (dp->d_name[0] == DOT && *pattern != DOT)
++			continue;
++		memset(&mbs, 0, sizeof(mbs));
++		dc = pathend;
++		sc = dp->d_name;
++		while (dc < pathend_last) {
++			clen = mbrtowc(&wc, sc, MB_LEN_MAX, &mbs);
++			if (clen == (size_t)-1 || clen == (size_t)-2) {
++				wc = *sc;
++				clen = 1;
++				memset(&mbs, 0, sizeof(mbs));
++			}
++			if ((*dc++ = wc) == EOS)
++				break;
++			sc += clen;
++		}
++		if (!match(pathend, pattern, restpattern)) {
++			*pathend = EOS;
++			continue;
++		}
++		err = glob2(pathbuf, --dc, pathend_last, restpattern,
++		    pglob, limit);
++		if (err)
++			break;
++	}
++
++	if (pglob->gl_flags & GLOB_ALTDIRFUNC)
++		(*pglob->gl_closedir)(dirp);
++	else
++		closedir(dirp);
++	return(err);
++}
++
++
++/*
++ * Extend the gl_pathv member of a glob_t structure to accomodate a new item,
++ * add the new item, and update gl_pathc.
++ *
++ * This assumes the BSD realloc, which only copies the block when its size
++ * crosses a power-of-two boundary; for v7 realloc, this would cause quadratic
++ * behavior.
++ *
++ * Return 0 if new item added, error code if memory couldn't be allocated.
++ *
++ * Invariant of the glob_t structure:
++ *	Either gl_pathc is zero and gl_pathv is NULL; or gl_pathc > 0 and
++ *	gl_pathv points to (gl_offs + gl_pathc + 1) items.
++ */
++static int
++globextend(const Char *path, glob_t *pglob, size_t *limit)
++{
++	char **pathv;
++	size_t i, newsize, len;
++	char *copy;
++	const Char *p;
++
++	if (*limit && pglob->gl_pathc > *limit) {
++		errno = 0;
++		return (GLOB_NOSPACE);
++	}
++
++	newsize = sizeof(*pathv) * (2 + pglob->gl_pathc + pglob->gl_offs);
++	pathv = pglob->gl_pathv ?
++		    realloc((char *)pglob->gl_pathv, newsize) :
++		    malloc(newsize);
++	if (pathv == NULL) {
++		if (pglob->gl_pathv) {
++			free(pglob->gl_pathv);
++			pglob->gl_pathv = NULL;
++		}
++		return(GLOB_NOSPACE);
++	}
++
++	if (pglob->gl_pathv == NULL && pglob->gl_offs > 0) {
++		/* first time around -- clear initial gl_offs items */
++		pathv += pglob->gl_offs;
++		for (i = pglob->gl_offs + 1; --i > 0; )
++			*--pathv = NULL;
++	}
++	pglob->gl_pathv = pathv;
++
++	for (p = path; *p++;)
++		continue;
++	len = MB_CUR_MAX * (size_t)(p - path);	/* XXX overallocation */
++	if ((copy = malloc(len)) != NULL) {
++		if (g_Ctoc(path, copy, len)) {
++			free(copy);
++			return (GLOB_NOSPACE);
++		}
++		pathv[pglob->gl_offs + pglob->gl_pathc++] = copy;
++	}
++	pathv[pglob->gl_offs + pglob->gl_pathc] = NULL;
++	return(copy == NULL ? GLOB_NOSPACE : 0);
++}
++
++/*
++ * pattern matching function for filenames.  Each occurrence of the *
++ * pattern causes a recursion level.
++ */
++static int
++match(Char *name, Char *pat, Char *patend)
++{
++	int ok, negate_range;
++	Char c, k;
++
++	while (pat < patend) {
++		c = *pat++;
++		switch (c & M_MASK) {
++		case M_ALL:
++			if (pat == patend)
++				return(1);
++			do
++			    if (match(name, pat, patend))
++				    return(1);
++			while (*name++ != EOS);
++			return(0);
++		case M_ONE:
++			if (*name++ == EOS)
++				return(0);
++			break;
++		case M_SET:
++			ok = 0;
++			if ((k = *name++) == EOS)
++				return(0);
++			if ((negate_range = ((*pat & M_MASK) == M_NOT)) != EOS)
++				++pat;
++			while (((c = *pat++) & M_MASK) != M_END)
++				if ((*pat & M_MASK) == M_RNG) {
++					if (CHAR(c) <= CHAR(k) && CHAR(k) <= CHAR(pat[1])) ok = 1;
++					pat += 2;
++				} else if (c == k)
++					ok = 1;
++			if (ok == negate_range)
++				return(0);
++			break;
++		default:
++			if (*name++ != c)
++				return(0);
++			break;
++		}
++	}
++	return(*name == EOS);
++}
++
++/* Free allocated data belonging to a glob_t structure. */
++void
++globfree(glob_t *pglob)
++{
++	size_t i;
++	char **pp;
++
++	if (pglob->gl_pathv != NULL) {
++		pp = pglob->gl_pathv + pglob->gl_offs;
++		for (i = pglob->gl_pathc; i--; ++pp)
++			if (*pp)
++				free(*pp);
++		free(pglob->gl_pathv);
++		pglob->gl_pathv = NULL;
++	}
++}
++
++static DIR *
++g_opendir(Char *str, glob_t *pglob)
++{
++	char buf[MAXPATHLEN];
++
++	if (!*str)
++		strcpy(buf, ".");
++	else {
++		if (g_Ctoc(str, buf, sizeof(buf)))
++			return (NULL);
++	}
++
++	if (pglob->gl_flags & GLOB_ALTDIRFUNC)
++		return((*pglob->gl_opendir)(buf));
++
++	return(opendir(buf));
++}
++
++static int
++g_lstat(Char *fn, struct stat *sb, glob_t *pglob)
++{
++	char buf[MAXPATHLEN];
++
++	if (g_Ctoc(fn, buf, sizeof(buf))) {
++		errno = ENAMETOOLONG;
++		return (-1);
++	}
++	if (pglob->gl_flags & GLOB_ALTDIRFUNC)
++		return((*pglob->gl_lstat)(buf, sb));
++	return(lstat(buf, sb));
++}
++
++static int
++g_stat(Char *fn, struct stat *sb, glob_t *pglob)
++{
++	char buf[MAXPATHLEN];
++
++	if (g_Ctoc(fn, buf, sizeof(buf))) {
++		errno = ENAMETOOLONG;
++		return (-1);
++	}
++	if (pglob->gl_flags & GLOB_ALTDIRFUNC)
++		return((*pglob->gl_stat)(buf, sb));
++	return(stat(buf, sb));
++}
++
++static const Char *
++g_strchr(const Char *str, wchar_t ch)
++{
++
++	do {
++		if (*str == ch)
++			return (str);
++	} while (*str++);
++	return (NULL);
++}
++
++static int
++g_Ctoc(const Char *str, char *buf, size_t len)
++{
++	mbstate_t mbs;
++	size_t clen;
++
++	memset(&mbs, 0, sizeof(mbs));
++	while (len >= MB_CUR_MAX) {
++		clen = wcrtomb(buf, *str, &mbs);
++		if (clen == (size_t)-1)
++			return (1);
++		if (*str == L'\0')
++			return (0);
++		str++;
++		buf += clen;
++		len -= clen;
++	}
++	return (1);
++}
++
++#ifdef DEBUG
++static void
++qprintf(const char *str, Char *s)
++{
++	Char *p;
++
++	(void)printf("%s:\n", str);
++	for (p = s; *p; p++)
++		(void)printf("%c", CHAR(*p));
++	(void)printf("\n");
++	for (p = s; *p; p++)
++		(void)printf("%c", *p & M_PROTECT ? '"' : ' ');
++	(void)printf("\n");
++	for (p = s; *p; p++)
++		(void)printf("%c", ismeta(*p) ? '_' : ' ');
++	(void)printf("\n");
++}
++#endif
+diff -Nur /tmp/x/glob.h libglob/glob.h
+--- /tmp/x/glob.h	1969-12-31 19:00:00.000000000 -0500
++++ libglob/glob.h	2017-08-19 15:22:18.367109399 -0400
+@@ -0,0 +1,102 @@
++/*
++ * Copyright (c) 1989, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * This code is derived from software contributed to Berkeley by
++ * Guido van Rossum.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	@(#)glob.h	8.1 (Berkeley) 6/2/93
++ * $FreeBSD$
++ */
++
++#ifndef _GLOB_H_
++#define	_GLOB_H_
++
++#include <sys/cdefs.h>
++#include <sys/types.h>
++#define     ARG_MAX     6553
++
++#ifndef	_SIZE_T_DECLARED
++typedef	__size_t	size_t;
++#define	_SIZE_T_DECLARED
++#endif
++
++struct stat;
++typedef struct {
++	size_t gl_pathc;	/* Count of total paths so far. */
++	size_t gl_matchc;	/* Count of paths matching pattern. */
++	size_t gl_offs;		/* Reserved at beginning of gl_pathv. */
++	int gl_flags;		/* Copy of flags parameter to glob. */
++	char **gl_pathv;	/* List of paths matching pattern. */
++				/* Copy of errfunc parameter to glob. */
++	int (*gl_errfunc)(const char *, int);
++
++	/*
++	 * Alternate filesystem access methods for glob; replacement
++	 * versions of closedir(3), readdir(3), opendir(3), stat(2)
++	 * and lstat(2).
++	 */
++	void (*gl_closedir)(void *);
++	struct dirent *(*gl_readdir)(void *);
++	void *(*gl_opendir)(const char *);
++	int (*gl_lstat)(const char *, struct stat *);
++	int (*gl_stat)(const char *, struct stat *);
++} glob_t;
++
++/* Believed to have been introduced in 1003.2-1992 */
++#define	GLOB_APPEND	0x0001	/* Append to output from previous call. */
++#define	GLOB_DOOFFS	0x0002	/* Use gl_offs. */
++#define	GLOB_ERR	0x0004	/* Return on error. */
++#define	GLOB_MARK	0x0008	/* Append / to matching directories. */
++#define	GLOB_NOCHECK	0x0010	/* Return pattern itself if nothing matches. */
++#define	GLOB_NOSORT	0x0020	/* Don't sort. */
++#define	GLOB_NOESCAPE	0x2000	/* Disable backslash escaping. */
++
++/* Error values returned by glob(3) */
++#define	GLOB_NOSPACE	(-1)	/* Malloc call failed. */
++#define	GLOB_ABORTED	(-2)	/* Unignored error. */
++#define	GLOB_NOMATCH	(-3)	/* No match and GLOB_NOCHECK was not set. */
++#define	GLOB_NOSYS	(-4)	/* Obsolete: source comptability only. */
++
++#define	GLOB_ALTDIRFUNC	0x0040	/* Use alternately specified directory funcs. */
++#define	GLOB_BRACE	0x0080	/* Expand braces ala csh. */
++#define	GLOB_MAGCHAR	0x0100	/* Pattern had globbing characters. */
++#define	GLOB_NOMAGIC	0x0200	/* GLOB_NOCHECK without magic chars (csh). */
++#define	GLOB_QUOTE	0x0400	/* Quote special chars with \. */
++#define	GLOB_TILDE	0x0800	/* Expand tilde names from the passwd file. */
++#define	GLOB_LIMIT	0x1000	/* limit number of returned paths */
++
++/* source compatibility, these are the old names */
++#define GLOB_MAXPATH	GLOB_LIMIT
++#define	GLOB_ABEND	GLOB_ABORTED
++
++__BEGIN_DECLS
++int	glob(const char *, int, int (*)(const char *, int), glob_t *);
++void	globfree(glob_t *);
++__END_DECLS
++
++#endif /* !_GLOB_H_ */

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -111,6 +111,8 @@ class Python2Recipe(TargetPythonRecipe):
                 f = 'LDFLAGS'
                 env[f] = env[f] + l if f in env else l
 
+            # NDK has langinfo.h but doesn't define nl_langinfo()
+            env['ac_cv_header_langinfo_h'] = 'no'
             configure = sh.Command('./configure')
             # AND: OFLAG isn't actually set, should it be?
             shprint(configure,


### PR DESCRIPTION
Android NDK introduced optional unified headers in version 14. In 15, they are no longer optional. This request corrects flags as specifies an https://android.googlesource.com/platform/ndk/+/ndk-r15-release/docs/UnifiedHeaders.md

The changes broke the libffi and python2 in different ways. Fixes are included.

I suspect there's going to be impact on other recipes as well. Is there a test mechanism to test all available recipes?