### PR TITLE
Fixed ssl, sqlite and crystax library loads on Android versions before ~4.4

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -5,38 +5,48 @@ import java.io.File;
 import android.util.Log;
 import java.util.ArrayList;
 import java.io.FilenameFilter;
+// import android.os.PatternMatcher;
+import java.util.regex.Pattern;
 
 public class PythonUtil {
 	private static final String TAG = "pythonutil";
 
+    protected static void addLibraryIfExists(ArrayList<String> libsList, String pattern, File libsDir) {
+        // pattern should be the name of the lib file, without the
+        // preceding "lib" or suffix ".so", for instance "ssl.*" will
+        // match files of the form "libssl.*.so".
+        File [] files = libsDir.listFiles();
+
+        pattern = "lib" + pattern + "\\.so";
+        Pattern p = Pattern.compile(pattern);
+        for (int i = 0; i < files.length; ++i) {
+            File file = files[i];
+            String name = file.getName();
+            Log.v(TAG, "Checking pattern " + pattern + " against " + name);
+            if (p.matcher(name).matches()) {
+                Log.v(TAG, "Pattern " + pattern + " matched file " + name);
+                libsList.add(name.substring(3, name.length() - 3));
+            }
+        }
+    }
+
     protected static ArrayList<String> getLibraries(File filesDir) {
 
-        ArrayList<String> MyList = new ArrayList<String>();
-        MyList.add("SDL2");
-        MyList.add("SDL2_image");
-        MyList.add("SDL2_mixer");
-        MyList.add("SDL2_ttf");
+        String libsDirPath = filesDir.getParentFile().getParentFile().getAbsolutePath() + "/lib/";
+        File libsDir = new File(libsDirPath);
 
-        String absPath = filesDir.getParentFile().getParentFile().getAbsolutePath() + "/lib/";
-        filesDir = new File(absPath);
-        File [] files = filesDir.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return  name.matches(".*ssl.*") || name.matches(".*crypto.*");
-            }
-        });
-
-        for (int i = 0; i < files.length; ++i) {
-            File mfl = files[i];
-            String name = mfl.getName();
-            name = name.substring(3, name.length() - 3);
-            MyList.add(name);
-        };
-
-        MyList.add("python2.7");
-        MyList.add("python3.5m");
-        MyList.add("main");
-        return MyList;
+        ArrayList<String> libsList = new ArrayList<String>();
+        addLibraryIfExists(libsList, "crystax", libsDir);
+        libsList.add("SDL2");
+        libsList.add("SDL2_image");
+        libsList.add("SDL2_mixer");
+        libsList.add("SDL2_ttf");
+        addLibraryIfExists(libsList, "ssl.*", libsDir);
+        addLibraryIfExists(libsList, "crypto.*", libsDir);
+        libsList.add("python2.7");
+        libsList.add("python3.5m");
+        libsList.add("main");
+        return libsList;
     }
 
     public static void loadLibraries(File filesDir) {

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -5,7 +5,6 @@ import java.io.File;
 import android.util.Log;
 import java.util.ArrayList;
 import java.io.FilenameFilter;
-// import android.os.PatternMatcher;
 import java.util.regex.Pattern;
 
 public class PythonUtil {
@@ -37,6 +36,7 @@ public class PythonUtil {
 
         ArrayList<String> libsList = new ArrayList<String>();
         addLibraryIfExists(libsList, "crystax", libsDir);
+        addLibraryIfExists(libsList, "sqlite3", libsDir);
         libsList.add("SDL2");
         libsList.add("SDL2_image");
         libsList.add("SDL2_mixer");

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -3,32 +3,48 @@ package org.kivy.android;
 import java.io.File;
 
 import android.util.Log;
-
+import java.util.ArrayList;
+import java.io.FilenameFilter;
 
 public class PythonUtil {
 	private static final String TAG = "pythonutil";
 
-	protected static String[] getLibraries() {
-        return new String[] {
-            "SDL2",
-            "SDL2_image",
-            "SDL2_mixer",
-            "SDL2_ttf",
-            "crypto1.0.2h",
-            "ssl1.0.2h",
-            "python2.7",
-            "python3.5m",
-            "python3.6m",
-            "main"
+    protected static ArrayList<String> getLibraries(File filesDir) {
+
+        ArrayList<String> MyList = new ArrayList<String>();
+        MyList.add("SDL2");
+        MyList.add("SDL2_image");
+        MyList.add("SDL2_mixer");
+        MyList.add("SDL2_ttf");
+
+        String absPath = filesDir.getParentFile().getParentFile().getAbsolutePath() + "/lib/";
+        filesDir = new File(absPath);
+        File [] files = filesDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return  name.matches(".*ssl.*") || name.matches(".*crypto.*");
+            }
+        });
+
+        for (int i = 0; i < files.length; ++i) {
+            File mfl = files[i];
+            String name = mfl.getName();
+            name = name.substring(3, name.length() - 3);
+            MyList.add(name);
         };
+
+        MyList.add("python2.7");
+        MyList.add("python3.5m");
+        MyList.add("main");
+        return MyList;
     }
 
-	public static void loadLibraries(File filesDir) {
+    public static void loadLibraries(File filesDir) {
 
         String filesDirPath = filesDir.getAbsolutePath();
         boolean foundPython = false;
 
-		for (String lib : getLibraries()) {
+		for (String lib : getLibraries(filesDir)) {
             Log.v(TAG, "Loading library: " + lib);
 		    try {
                 System.loadLibrary(lib);
@@ -68,3 +84,4 @@ public class PythonUtil {
         Log.v(TAG, "Loaded everything!");
     }
 }
+

--- a/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonUtil.java
@@ -14,6 +14,8 @@ public class PythonUtil {
             "SDL2_image",
             "SDL2_mixer",
             "SDL2_ttf",
+            "crypto1.0.2h",
+            "ssl1.0.2h",
             "python2.7",
             "python3.5m",
             "python3.6m",


### PR DESCRIPTION
This PR rebases and restructures https://github.com/kivy/python-for-android/pull/903.

I've tested this only in the emulator, but I was able to reproduce the original issue, and this rebased PR seems to fix everything.

Fixes #866.