### PR TITLE
Try system python when performing compileall

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -491,6 +491,9 @@ tools directory of the Android SDK.
                          'NAME:PATH_TO_PY[:foreground]')
     ap.add_argument('--add-source', dest='extra_source_dirs', action='append',
                     help='Include additional source dirs in Java build')
+    ap.add_argument('--try-system-python-compile', dest='try_system_python_compile',
+                    action='store_true',
+                    help='Use the system python during compileall if possible.')
     ap.add_argument('--no-compile-pyo', dest='no_compile_pyo', action='store_true',
                     help='Do not optimise .py files to .pyo.')
     ap.add_argument('--sign', action='store_true',
@@ -523,6 +526,17 @@ tools directory of the Android SDK.
 
     if args.services is None:
         args.services = []
+
+    if args.try_system_python_compile:
+        # Hardcoding python2.7 is okay for now, as python3 skips the
+        # compilation anyway
+        python_executable = 'python2.7'
+        try:
+            subprocess.call([python_executable, '--version'])
+        except (OSError, subprocess.CalledProcessError):
+            pass
+        else:
+            PYTHON = python_executable
 
     if args.no_compile_pyo:
         PYTHON = None

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -530,13 +530,14 @@ tools directory of the Android SDK.
     if args.try_system_python_compile:
         # Hardcoding python2.7 is okay for now, as python3 skips the
         # compilation anyway
-        python_executable = 'python2.7'
-        try:
-            subprocess.call([python_executable, '--version'])
-        except (OSError, subprocess.CalledProcessError):
-            pass
-        else:
-            PYTHON = python_executable
+        if not exists('crystax_python'):
+            python_executable = 'python2.7'
+            try:
+                subprocess.call([python_executable, '--version'])
+            except (OSError, subprocess.CalledProcessError):
+                pass
+            else:
+                PYTHON = python_executable
 
     if args.no_compile_pyo:
         PYTHON = None


### PR DESCRIPTION
This is kind of messy, but there doesn't seem to be a very neat way to do it.

The point of doing this is that the compileall can fail for some files if it tries to load .so files (which hostpython doesn't have available). In particular, this occurs for files which try to access unicode characters with `'\N{...}'`. For instance, several files in sympy do this, and currently crash when sympy is imported on the device. This PR would make the compilation work in such cases.

For now, I think discussion would be better than straight merging, but having the change documented could help someone.