### PR TITLE
This current Twisted version actually runs!

### DIFF
--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -12,10 +12,10 @@ import sh
 
 
 class TwistedRecipe(CythonRecipe):
-    version = '16.0.0'
+    version = '17.9.0'
     url = 'https://github.com/twisted/twisted/archive/twisted-{version}.tar.gz'
 
-    depends = ['setuptools', 'zope_interface']
+    depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = True


### PR DESCRIPTION
Had to update Twisted to the latest version as addTimeout to a deferred is not available in V16.0.
Could we develop a more aggressive recipe upgrades policy so we don't fall behind Linux so much?
Thanks, Enoch.