### PR TITLE
The pypi python return http 403 error on http

### DIFF
--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -5,7 +5,7 @@ from pythonforandroid.toolchain import CompiledComponentsPythonRecipe, warning
 class NumpyRecipe(CompiledComponentsPythonRecipe):
     
     version = '1.9.2'
-    url = 'http://pypi.python.org/packages/source/n/numpy/numpy-{version}.tar.gz'
+    url = 'https://pypi.python.org/packages/source/n/numpy/numpy-{version}.tar.gz'
     site_packages_name= 'numpy'
 
     depends = ['python2']


### PR DESCRIPTION
The pypi python server return : error 403 : SSL is required. So build failed with an empty archive that can t be extracted.