### PR TITLE
Add the ndk platform libs dir during biglink

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -674,7 +674,8 @@ def biglink(ctx, arch):
             join(ctx.get_libs_dir(arch.arch), 'libpymodules.so'),
             obj_dir.split(' '),
             extra_link_dirs=[join(ctx.bootstrap.build_dir,
-                                'obj', 'local', arch.arch)],
+                                  'obj', 'local', arch.arch),
+                             os.path.abspath('.')],
             env=env)
 
 


### PR DESCRIPTION
This seems to be necessary for building the webview bootstrap with the latest NDK, although I'm not sure why. Still looking into it.