### PR TITLE
Update __init__.py to support SDL2

### DIFF
--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -16,13 +16,13 @@ class AudiostreamRecipe(CythonRecipe):
             sdl_include = 'sdl'
             sdl_mixer_include = 'sdl_mixer'
         elif 'sdl2' in self.ctx.recipe_build_order:
-            sdl_include = 'SDL'
+            sdl_include = 'SDL2'
             sdl_mixer_include = 'SDL2_mixer'
             
             #note: audiostream library is not yet able to judge whether it is being used with sdl or with sdl2.
             #this causes linking to fail against SDL2 (compiling against SDL2 works)
             #need to find a way to fix this in audiostream's setup.py
-            raise RuntimeError('Audiostream library is not yet able to configure itself to link against SDL2.  Patch on audiostream library needed - any help much appreciated!')
+            #raise RuntimeError('Audiostream library is not yet able to configure itself to link against SDL2.  Patch on audiostream library needed - any help much appreciated!')
 
         env = super(AudiostreamRecipe, self).get_recipe_env(arch)
         env['CFLAGS'] += ' -I{jni_path}/{sdl_include}/include -I{jni_path}/{sdl_mixer_include}'.format(

--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -12,19 +12,16 @@ class AudiostreamRecipe(CythonRecipe):
     depends = ['python2', ('sdl', 'sdl2'), 'pyjnius']
 
     def get_recipe_env(self, arch):
+        env = super(AudiostreamRecipe, self).get_recipe_env(arch)
         if 'sdl' in self.ctx.recipe_build_order:
             sdl_include = 'sdl'
             sdl_mixer_include = 'sdl_mixer'
         elif 'sdl2' in self.ctx.recipe_build_order:
             sdl_include = 'SDL2'
             sdl_mixer_include = 'SDL2_mixer'
-            
-            #note: audiostream library is not yet able to judge whether it is being used with sdl or with sdl2.
-            #this causes linking to fail against SDL2 (compiling against SDL2 works)
-            #need to find a way to fix this in audiostream's setup.py
-            #raise RuntimeError('Audiostream library is not yet able to configure itself to link against SDL2.  Patch on audiostream library needed - any help much appreciated!')
+            env['USE_SDL2'] = 'True'
+            env['SDL2_INCLUDE_DIR'] = '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include'
 
-        env = super(AudiostreamRecipe, self).get_recipe_env(arch)
         env['CFLAGS'] += ' -I{jni_path}/{sdl_include}/include -I{jni_path}/{sdl_mixer_include}'.format(
                               jni_path = join(self.ctx.bootstrap.build_dir, 'jni'),
                               sdl_include = sdl_include,


### PR DESCRIPTION
I managed to get audiostream compiled and working using sdl2 on android.
I had to change the setup.py for audiostream, but I need help making my edits be system-independent, and how to make it able to use sdl OR sdl2....
My modified setup.py is over at: https://github.com/snuq/audiostream/blob/master/setup.py
Mostly i changed instances of 'SDL' into 'SDL2', and included '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include'