### PR TITLE
Removed '-j5' from openssl make

### DIFF
--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -26,6 +26,7 @@ class OpenSSLRecipe(Recipe):
         env['OPENSSL_VERSION'] = self.version
         env['CFLAGS'] += ' ' + env['LDFLAGS']
         env['CC'] += ' ' + env['LDFLAGS']
+        env['MAKE'] = 'make'  # This removes the '-j5', which isn't safe
         return env
 
     def select_build_arch(self, arch):


### PR DESCRIPTION
The '-j5' option causes the openssl build to fail with NDK 16, at least for me. I'm not sure if this means the build order is technically still improperly specified, but since it works it's probably a fine fix for now.