### PR TITLE
Add support for minimum Android API.

### DIFF
--- a/pythonforandroid/patching.py
+++ b/pythonforandroid/patching.py
@@ -30,31 +30,31 @@ def is_arch(xarch):
 
 def is_api_gt(apiver):
     def is_x(recipe, **kwargs):
-        return recipe.ctx.android_api > apiver
+        return recipe.ctx.android_min_api > apiver
     return is_x
 
 
 def is_api_gte(apiver):
     def is_x(recipe, **kwargs):
-        return recipe.ctx.android_api >= apiver
+        return recipe.ctx.android_min_api >= apiver
     return is_x
 
 
 def is_api_lt(apiver):
     def is_x(recipe, **kwargs):
-        return recipe.ctx.android_api < apiver
+        return recipe.ctx.android_min_api < apiver
     return is_x
 
 
 def is_api_lte(apiver):
     def is_x(recipe, **kwargs):
-        return recipe.ctx.android_api <= apiver
+        return recipe.ctx.android_min_api <= apiver
     return is_x
 
 
 def is_api(apiver):
     def is_x(recipe, **kwargs):
-        return recipe.ctx.android_api == apiver
+        return recipe.ctx.android_min_api == apiver
     return is_x
 
 
@@ -68,4 +68,3 @@ def is_ndk(ndk):
     def is_x(recipe, **kwargs):
         return recipe.ctx.ndk == ndk
     return is_x
-

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -884,7 +884,7 @@ class CppCompiledComponentsPythonRecipe(CompiledComponentsPythonRecipe):
         )
         env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         env['CFLAGS'] += " -I{pyroot}/include/python2.7 " \
-                        " -I{ctx.ndk_dir}/platforms/android-{ctx.android_api}/arch-{arch_noeabi}/usr/include" \
+                        " -I{ctx.ndk_dir}/platforms/android-{ctx.android_min_api}/arch-{arch_noeabi}/usr/include" \
                         " -I{ctx.ndk_dir}/sources/cxx-stl/gnu-libstdc++/{ctx.toolchain_version}/include" \
                         " -I{ctx.ndk_dir}/sources/cxx-stl/gnu-libstdc++/{ctx.toolchain_version}/libs/{arch.arch}/include".format(**keys)
         env['CXXFLAGS'] = env['CFLAGS'] + ' -frtti -fexceptions'

--- a/pythonforandroid/recipes/boost/__init__.py
+++ b/pythonforandroid/recipes/boost/__init__.py
@@ -25,7 +25,7 @@ class BoostRecipe(Recipe):
                 bash = sh.Command('bash')
                 shprint(bash, join(self.ctx.ndk_dir, 'build/tools/make-standalone-toolchain.sh'),
                         '--arch=' + env['ARCH'],
-                        '--platform=android-' + str(self.ctx.android_api),
+                        '--platform=android-' + str(self.ctx.android_min_api),
                         '--toolchain=' + env['CROSSHOST'] + '-' + env['TOOLCHAIN_VERSION'],
                         '--install-dir=' + env['CROSSHOME']
                 )
@@ -57,7 +57,7 @@ class BoostRecipe(Recipe):
         env['BOOST_ROOT'] = env['BOOST_BUILD_PATH']  # find boost source
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
         env['ARCH'] = self.select_build_arch(arch)
-        env['ANDROIDAPI'] = str(self.ctx.android_api)
+        env['ANDROIDAPI'] = str(self.ctx.android_min_api)
         env['CROSSHOST'] = env['ARCH'] + '-linux-androideabi'
         env['CROSSHOME'] = join(env['BOOST_ROOT'], 'standalone-' + env['ARCH'] + '-toolchain')
         env['TOOLCHAIN_PREFIX'] = join(env['CROSSHOME'], 'bin', env['CROSSHOST'])

--- a/pythonforandroid/recipes/boost/user-config.jam
+++ b/pythonforandroid/recipes/boost/user-config.jam
@@ -1,7 +1,7 @@
 import os ;
 
 local ANDROIDNDK = [ os.environ ANDROIDNDK ] ;
-local ANDROIDAPI = [ os.environ ANDROIDAPI ] ;
+local ANDROIDMINAPI = [ os.environ ANDROIDMINAPI ] ;
 local TOOLCHAIN_VERSION = [ os.environ TOOLCHAIN_VERSION ] ;
 local TOOLCHAIN_PREFIX = [ os.environ TOOLCHAIN_PREFIX ] ;
 local ARCH = [ os.environ ARCH ] ;
@@ -16,11 +16,11 @@ using gcc : $(ARCH) : $(TOOLCHAIN_PREFIX)-g++ :
 <cxxflags>-DBOOST_AC_USE_PTHREADS
 <cxxflags>-frtti
 <cxxflags>-fexceptions
-<compileflags>-I$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)/usr/include
+<compileflags>-I$(ANDROIDNDK)/platforms/android-$(ANDROIDMINAPI)/arch-$(ARCH)/usr/include
 <compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/include
 <compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)/include
 <compileflags>-I$(PYTHON_ROOT)/include/python2.7
-<linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)
+<linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDMINAPI)/arch-$(ARCH)
 <linkflags>-L$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)
 <linkflags>-L$(PYTHON_ROOT)/lib
 <linkflags>-lgnustl_shared

--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -40,7 +40,7 @@ class FFMpegRecipe(Recipe):
 
             if 'openssl' in self.ctx.recipe_build_order:
                 flags += [
-                    '--enable-openssl', 
+                    '--enable-openssl',
                     '--enable-nonfree',
                     '--enable-protocol=https,tls_openssl',
                 ]
@@ -48,7 +48,7 @@ class FFMpegRecipe(Recipe):
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-L' + build_dir]
 
-            if 'ffpyplayer_codecs' in self.ctx.recipe_build_order:                
+            if 'ffpyplayer_codecs' in self.ctx.recipe_build_order:
                 # libx264
                 flags += ['--enable-libx264']
                 build_dir = Recipe.get_recipe('libx264', self.ctx).get_build_dir(arch.arch)
@@ -107,16 +107,16 @@ class FFMpegRecipe(Recipe):
 
             # android:
             flags += [
-                '--target-os=android', 
-                '--cross-prefix=arm-linux-androideabi-', 
+                '--target-os=android',
+                '--cross-prefix=arm-linux-androideabi-',
                 '--arch=arm',
                 '--sysroot=' + self.ctx.ndk_platform,
                 '--enable-neon',
                 '--prefix={}'.format(realpath('.')),
             ]
             cflags += [
-                '-mfpu=vfpv3-d16', 
-                '-mfloat-abi=softfp', 
+                '-mfpu=vfpv3-d16',
+                '-mfloat-abi=softfp',
                 '-fPIC',
             ]
 

--- a/pythonforandroid/recipes/icu/__init__.py
+++ b/pythonforandroid/recipes/icu/__init__.py
@@ -21,7 +21,7 @@ class ICURecipe(NDKRecipe):
         return lib_dir
 
     def prepare_build_dir(self, arch):
-        if self.ctx.android_api > 19:
+        if self.ctx.android_min_api > 19:
             # greater versions do not have /usr/include/sys/exec_elf.h
             raise RuntimeError("icu needs an android api <= 19")
 

--- a/pythonforandroid/recipes/leveldb/__init__.py
+++ b/pythonforandroid/recipes/leveldb/__init__.py
@@ -32,7 +32,7 @@ class LevelDBRecipe(Recipe):
         if 'snappy' in recipe.ctx.recipe_build_order:
             env['CFLAGS'] += ' -DSNAPPY' + \
                              ' -I./snappy'
-        env['CFLAGS'] += ' -I' + self.ctx.ndk_dir + '/platforms/android-' + str(self.ctx.android_api) + '/arch-' + arch.arch.replace('eabi', '') + '/usr/include' + \
+        env['CFLAGS'] += ' -I' + self.ctx.ndk_dir + '/platforms/android-' + str(self.ctx.android_min_api) + '/arch-' + arch.arch.replace('eabi', '') + '/usr/include' + \
                          ' -I' + self.ctx.ndk_dir + '/sources/cxx-stl/gnu-libstdc++/' + self.ctx.toolchain_version + '/include' + \
                          ' -I' + self.ctx.ndk_dir + '/sources/cxx-stl/gnu-libstdc++/' + self.ctx.toolchain_version + '/libs/' + arch.arch + '/include'
         env['CXXFLAGS'] = env['CFLAGS']

--- a/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
+++ b/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
@@ -14,7 +14,7 @@
  <compileflags>-I$(PYTHON_ROOT)/include/python2.7
 +<compileflags>-I$(OPENSSL_BUILD_PATH)/include
 +<compileflags>-I$(OPENSSL_BUILD_PATH)/include/openssl
- <linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)
+ <linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDMINAPI)/arch-$(ARCH)
  <linkflags>-L$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)
  <linkflags>-L$(PYTHON_ROOT)/lib
 +<linkflags>-L$(OPENSSL_BUILD_PATH)

--- a/pythonforandroid/recipes/protobuf_cpp/__init__.py
+++ b/pythonforandroid/recipes/protobuf_cpp/__init__.py
@@ -92,7 +92,7 @@ class ProtobufCppRecipe(PythonRecipe):
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
         env['TARGET_OS'] = 'OS_ANDROID_CROSSCOMPILE'
         env['CFLAGS'] += ' -I' + self.ctx.ndk_dir + '/platforms/android-' + str(
-            self.ctx.android_api) + '/arch-' + arch.arch.replace('eabi', '') + '/usr/include' + \
+            self.ctx.android_min_api) + '/arch-' + arch.arch.replace('eabi', '') + '/usr/include' + \
                          ' -I' + self.ctx.ndk_dir + '/sources/cxx-stl/gnu-libstdc++/' + self.ctx.toolchain_version + '/include' + \
                          ' -I' + self.ctx.ndk_dir + '/sources/cxx-stl/gnu-libstdc++/' + self.ctx.toolchain_version + '/libs/' + arch.arch + '/include' + \
                          ' -I' + env['PYTHON_ROOT'] + '/include/python2.7'

--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -18,7 +18,7 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
         arch_noeabi = arch.arch.replace('eabi', '')
         env['LDFLAGS'] += " -shared -llog"
         env['LDFLAGS'] += " -landroid -lpython2.7"
-        env['LDFLAGS'] += " --sysroot={ctx.ndk_dir}/platforms/android-{ctx.android_api}/arch-{arch_noeabi}".format(
+        env['LDFLAGS'] += " --sysroot={ctx.ndk_dir}/platforms/android-{ctx.android_min_api}/arch-{arch_noeabi}".format(
 		ctx=self.ctx, arch_noeabi=arch_noeabi)
         return env
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -141,6 +141,7 @@ def require_prebuilt_dist(func):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
+                                      user_android_min_api=self.android_min_api,
                                       user_ndk_ver=self.ndk_version)
         dist = self._dist
         if dist.needs_build:
@@ -256,6 +257,9 @@ class ToolchainCL(object):
         generic_parser.add_argument(
             '--android-api', '--android_api', dest='android_api', default=0, type=int,
             help='The Android API level to build against.')
+        generic_parser.add_argument(
+            '--android-minapi', '--android_minapi', dest='android_min_api', default=0, type=int,
+            help='The Minimum Android API level to build against (will be used for all C compilation).')
         generic_parser.add_argument(
             '--ndk-version', '--ndk_version', dest='ndk_version', default='',
             help=('The version of the Android NDK. This is optional, '
@@ -499,6 +503,7 @@ class ToolchainCL(object):
         self.sdk_dir = args.sdk_dir
         self.ndk_dir = args.ndk_dir
         self.android_api = args.android_api
+        self.android_min_api = args.android_min_api
         self.ndk_version = args.ndk_version
         self.ctx.symlink_java_src = args.symlink_java_src
         self.ctx.java_build_tool = args.java_build_tool
@@ -904,6 +909,7 @@ class ToolchainCL(object):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
+                                      user_android_min_api=self.android_min_api,
                                       user_ndk_ver=self.ndk_version)
         android = sh.Command(join(ctx.sdk_dir, 'tools', args.tool))
         output = android(
@@ -931,6 +937,7 @@ class ToolchainCL(object):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
+                                      user_android_min_api=self.android_min_api,
                                       user_ndk_ver=self.ndk_version)
         if platform in ('win32', 'cygwin'):
             adb = sh.Command(join(ctx.sdk_dir, 'platform-tools', 'adb.exe'))


### PR DESCRIPTION
This allows the compilation to use a different version for compiling while targetting a higher API version.

Typically, you may need to use API 23 for Java, but want to run on devices with API 19. If you compile with API 23, when running on older device (let's say 4.4.2), you'll end up with a symbol not found "srand", "signal", etc.

It is important to set the Android API minimum version when compiling in order to avoid theses symbol issues.

CF: https://stackoverflow.com/a/41079462/69877