### PR TITLE
setup.py: fix installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ recursively_include(package_data, 'pythonforandroid/recipes',
 recursively_include(package_data, 'pythonforandroid/bootstraps',
                     ['*.properties', '*.xml', '*.java', '*.tmpl', '*.txt', '*.png',
                      '*.mk', '*.c', '*.h', '*.py', '*.sh', '*.jpg', '*.aidl',
-                     '*.gradle', ])
+                     '*.gradle', '.gitkeep', 'gradlew*', '*.jar', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps',
                     ['sdl-config', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps/webview',


### PR DESCRIPTION
fixes missing `assets` and `drawable` folder, `gladlew` executable. 