### PR TITLE
Include jar files in build.gradle

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -261,6 +261,7 @@ main.py that loads it.''')
     shutil.copy(args.presplash or default_presplash,
                 'src/main/res/drawable/presplash.jpg')
 
+    jars = []
     # If extra Java jars were requested, copy them into the libs directory
     if args.add_jar:
         for jarname in args.add_jar:
@@ -268,7 +269,7 @@ main.py that loads it.''')
                 print('Requested jar does not exist: {}'.format(jarname))
                 sys.exit(-1)
             shutil.copy(jarname, 'src/main/libs')
-
+            jars.append(basename(jarname))
     # if extra aar were requested, copy them into the libs directory
     aars = []
     if args.add_aar:
@@ -379,6 +380,7 @@ main.py that loads it.''')
         'build.gradle',
         args=args,
         aars=aars,
+        jars=jars,
         android_api=android_api,
         build_tools_version=build_tools_version)
 

--- a/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
@@ -62,6 +62,9 @@ dependencies {
 	{%- for aar in aars %}
 	compile(name: '{{ aar }}', ext: 'aar')
 	{%- endfor -%}
+        {%- for jar in jars %}
+        compile files('src/main/libs/{{ jar }}')
+        {%- endfor -%}
 	{%- if args.depends -%}
 	{%- for depend in args.depends %}
 	compile '{{ depend }}'


### PR DESCRIPTION
Jars from `android.add_jar` were copied to a directory but never referenced in the gradle build script.

Closes: #1208 