### PR TITLE
Allow adding activities to the manifest

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/build.py
+++ b/pythonforandroid/bootstraps/pygame/build/build.py
@@ -241,6 +241,7 @@ def make_package(args):
     # Annoying fixups.
     args.name = args.name.replace('\'', '\\\'')
     args.icon_name = args.icon_name.replace('\'', '\\\'')
+    args.add_activity = args.add_activity or []
 
     # Figure out versions of the private and public data.
     private_version = str(time.time())
@@ -475,6 +476,8 @@ tools directory of the Android SDK.
                     help='Custom key=value to add in strings.xml resource file')
     ap.add_argument('--manifest-extra', dest='manifest_extra', action='append',
                     help='Custom file to add at the end of the manifest')
+    ap.add_argument('--add-activity', dest='add_activity', action='append',
+                    help='Add this Java class as an Activity to the manifest.')
 
     if args is None:
         args = sys.argv[1:]

--- a/pythonforandroid/bootstraps/pygame/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/pygame/build/templates/AndroidManifest.tmpl.xml
@@ -94,6 +94,10 @@
 	</receiver>
 	{% endif %}
 
+  {% for a in args.add_activity  %}
+  <activity android:name="{{ a }}"></activity>
+  {% endfor %}
+
   </application>
 
   <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.sdk_version }}"/>

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -293,6 +293,8 @@ main.py that loads it.''')
     if args.intent_filters:
         with open(args.intent_filters) as fd:
             args.intent_filters = fd.read()
+    
+    args.add_activity = args.add_activity or []
 
     if args.extra_source_dirs:
         esd = []
@@ -508,6 +510,8 @@ tools directory of the Android SDK.
     ap.add_argument('--sign', action='store_true',
                     help=('Try to sign the APK with your credentials. You must set '
                           'the appropriate environment variables.'))
+    ap.add_argument('--add-activity', dest='add_activity', action='append',
+                    help='Add this Java class as an Activity to the manifest.')
 
     if args is None:
         args = sys.argv[1:]

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -119,6 +119,9 @@
             </intent-filter>
         </receiver>
         {% endif %}
+    {% for a in args.add_activity  %}
+    <activity android:name="{{ a }}"></activity>
+    {% endfor %}
     </application>
 
 </manifest>


### PR DESCRIPTION
This allows users to add their own activities to the manifest file. This can be used to start Java activities using pyjnius, e.g.:

```python
        PythonActivity = autoclass('org.kivy.android.PythonActivity')
        SimpleScannerActivity = autoclass("org.electrum.qr.SimpleScannerActivity")
        Intent = autoclass('android.content.Intent')
        intent = Intent(PythonActivity.mActivity, SimpleScannerActivity)
        activity.bind(on_activity_result=on_qr_result)
        PythonActivity.mActivity.startActivityForResult(intent, 0)
```

This will be used in Electrum to scan QR codes using an embedded copy of zxing for Android.