### PR TITLE
Made sdl2 build.gradle work with Java 7

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
@@ -54,7 +54,12 @@ android {
         main {
             jniLibs.srcDir 'libs' 
             }
-        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 
 }
 


### PR DESCRIPTION
This seems to fix the error message about needing `-source 7`.