### PR TITLE
Python 3 fix for android package

### DIFF
--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -175,7 +175,7 @@ api_version = autoclass('android.os.Build$VERSION').SDK_INT
 version_codes = autoclass('android.os.Build$VERSION_CODES')
 
 
-python_act = autoclass(JAVA_NAMESPACE + '.PythonActivity')
+python_act = autoclass(JAVA_NAMESPACE.decode("utf-8") + '.PythonActivity')
 Rect = autoclass('android.graphics.Rect')
 mActivity = python_act.mActivity
 if mActivity:


### PR DESCRIPTION
This should work with Python 2 and 3. It's tested on Python 3.5 only. I did test `.decode` on unicode and regular str in Python 2.7 and it's fine.
Without this change, a buildozer requirements line like this
`requirements = python3crystax,kivy==master,pyjnius,android`
will result in a python error stating that a string cannot be concatenated to a bytes object, i.e. JAVA_NAMESPACE is a bytes object.