### PR TITLE
Setuptools for Python3 (Crystax)

### DIFF
--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -1,20 +1,11 @@
-
-from pythonforandroid.toolchain import (
-    PythonRecipe,
-    Recipe,
-    current_directory,
-    info,
-    shprint,
-)
-from os.path import join
-import sh
+from pythonforandroid.toolchain import PythonRecipe
 
 
 class SetuptoolsRecipe(PythonRecipe):
     version = '18.3.1'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.tar.gz'
 
-    depends = ['python2']
+    depends = [('python2', 'python3crystax')]
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = True


### PR DESCRIPTION
Adds python3crystax support to setuptools recipe.
Also removed unused imports.

Before the fix, running `buildozer android debug` was resulting the following:
```
[INFO]:    No existing dists meet the given requirements!
[INFO]:    No dist exists that meets your requirements, so one will be built.
[ERROR]:   Didn't find any valid dependency graphs.
[ERROR]:   This means that some of your requirements pull in conflicting dependencies.
[ERROR]:   Exiting.
# Command failed: /usr/bin/python -m pythonforandroid.toolchain create --dist_name=myapp --bootstrap=sdl2 --requirements=python3crystax,kivy,setuptools --arch armeabi-v7a --copy-libs --color=always --storage-dir=/home/ubuntu/demo/.buildozer/android/platform/build
# 
# Buildozer failed to execute the last command
# The error might be hidden in the log above this error
# Please read the full log, and search for it before
# raising an issue with buildozer itself.
# In case of a bug report, please add a full log with log_level = 2
```

Test program:
```
from kivy.app import App
from kivy.uix.label import Label
import pkg_resources


class MyApp(App):

    def build(self):
        version = pkg_resources.get_distribution("setuptools").version
        return Label(text="version: " + version)


if __name__ == '__main__':
    MyApp().run()
```

Side note, this is a simple fix to merge, but it actually requires few more changes to `pythonforandroid/recipe.py` and `pythonforandroid/recipes/hostpython3crystax/__init__.py` that are soon to come.