### PR TITLE
Gevent Crystax/Python3 support

### DIFF
--- a/pythonforandroid/recipes/gevent/__init__.py
+++ b/pythonforandroid/recipes/gevent/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pythonforandroid.toolchain import CompiledComponentsPythonRecipe
 
 
@@ -6,5 +7,22 @@ class GeventRecipe(CompiledComponentsPythonRecipe):
     url = 'https://pypi.python.org/packages/source/g/gevent/gevent-{version}.tar.gz'
     depends = [('python2', 'python3crystax'), 'greenlet']
     patches = ["gevent.patch"]
+
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+        env = super(GeventRecipe, self).get_recipe_env(arch, with_flags_in_cc)
+        # sets linker to use the correct gcc (cross compiler)
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
+        # CFLAGS may only be used to specify C compiler flags, for macro definitions use CPPFLAGS
+        env['CPPFLAGS'] = env['CFLAGS'] + ' -I{}/sources/python/3.5/include/python/'.format(self.ctx.ndk_dir)
+        env['CFLAGS'] = ''
+        # LDFLAGS may only be used to specify linker flags, for libraries use LIBS
+        env['LDFLAGS'] = env['LDFLAGS'].replace('-lm', '').replace('-lcrystax', '')
+        env['LDFLAGS'] += ' -L{}'.format(os.path.join(self.ctx.bootstrap.build_dir, 'libs', arch.arch))
+        env['LIBS'] = ' -lm'
+        if self.ctx.ndk == 'crystax':
+            env['LIBS'] += ' -lcrystax -lpython{}m'.format(self.ctx.python_recipe.version[0:3])
+        env['LDSHARED'] += env['LIBS']
+        return env
+
 
 recipe = GeventRecipe()

--- a/pythonforandroid/recipes/gevent/gevent.patch
+++ b/pythonforandroid/recipes/gevent/gevent.patch
@@ -15,7 +15,7 @@ diff -Naur gevent-1.1.1/setup.py gevent-1.1.1_diff/setup.py
  ares_configure_command = ' '.join(["(cd ", _quoted_abspath('c-ares/'),
                                     " && if [ -r ares_build.h ]; then cp ares_build.h ares_build.h.orig; fi ",
 -                                   " && /bin/sh ./configure " + _m32 + "CONFIG_COMMANDS= CONFIG_FILES= ",
-+                                   " && /bin/sh ./configure --host={} ".format(os.environ['TOOLCHAIN_PREFIX']) + "CFLAGS= LDFLAGS= CONFIG_COMMANDS= CONFIG_FILES= ",
++                                   " && /bin/sh ./configure --host={} ".format(os.environ['TOOLCHAIN_PREFIX']) + "CONFIG_COMMANDS= CONFIG_FILES= ",
                                     " && cp ares_config.h ares_build.h \"$OLDPWD\" ",
                                     " && mv ares_build.h.orig ares_build.h)",
                                     "> configure-output.txt"])


### PR DESCRIPTION
Makes sure the arm cross linker is being used for LDSHARED.
Fixes configure script complaining about CFLAGS and LDFLAGS and
simplified `gevent.patch` (less is more), since flags are now
sanitized during `get_recipe_env()` call.

Also depends on #1249 (symlink system Python to hostpython3crystax).