### PR TITLE
compile numpy for x86

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -9,6 +9,9 @@ from pythonforandroid.recipe import Recipe
 
 class Arch(object):
 
+    include_prefix = None
+    '''The prefix for the include dir in the NDK.'''
+
     toolchain_prefix = None
     '''The prefix for the toolchain dir in the NDK.'''
 
@@ -44,7 +47,7 @@ class Arch(object):
             # post-15 NDK per
             # https://android.googlesource.com/platform/ndk/+/ndk-r15-release/docs/UnifiedHeaders.md
             env['CFLAGS'] += ' -isystem {}/sysroot/usr/include/{}'.format(
-                self.ctx.ndk_dir, self.ctx.toolchain_prefix)
+                self.ctx.ndk_dir, self.ctx.include_prefix)
         else:
             sysroot = self.ctx.ndk_platform
             env['CFLAGS'] += ' -I{}'.format(self.ctx.ndk_platform)
@@ -67,10 +70,12 @@ class Arch(object):
         if py_platform in ['linux2', 'linux3']:
             py_platform = 'linux'
 
+        include_prefix = self.ctx.include_prefix
         toolchain_prefix = self.ctx.toolchain_prefix
         toolchain_version = self.ctx.toolchain_version
         command_prefix = self.command_prefix
 
+        env['INCLUDE_PREFIX'] = include_prefix
         env['TOOLCHAIN_PREFIX'] = toolchain_prefix
         env['TOOLCHAIN_VERSION'] = toolchain_version
 
@@ -138,6 +143,7 @@ class Arch(object):
 
 class ArchARM(Arch):
     arch = "armeabi"
+    include_prefix = 'arm-linux-androideabi'
     toolchain_prefix = 'arm-linux-androideabi'
     command_prefix = 'arm-linux-androideabi'
     platform_dir = 'arch-arm'
@@ -157,6 +163,7 @@ class ArchARMv7_a(ArchARM):
 
 class Archx86(Arch):
     arch = 'x86'
+    include_prefix = 'i686-linux-android'
     toolchain_prefix = 'x86'
     command_prefix = 'i686-linux-android'
     platform_dir = 'arch-x86'
@@ -171,7 +178,8 @@ class Archx86(Arch):
 
 class Archx86_64(Arch):
     arch = 'x86_64'
-    toolchain_prefix = 'x86'
+    include_prefix = 'x86_64-linux-android'
+    toolchain_prefix = 'x86_64'
     command_prefix = 'x86_64-linux-android'
     platform_dir = 'arch-x86'
 
@@ -185,6 +193,7 @@ class Archx86_64(Arch):
 
 class ArchAarch_64(Arch):
     arch = 'arm64-v8a'
+    include_prefix = 'aarch64-linux-android'
     toolchain_prefix = 'aarch64-linux-android'
     command_prefix = 'aarch64-linux-android'
     platform_dir = 'arch-arm64'

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -364,6 +364,7 @@ class Context(object):
         # This would need to be changed if supporting multiarch APKs
         arch = self.archs[0]
         platform_dir = arch.platform_dir
+        include_prefix = arch.include_prefix
         toolchain_prefix = arch.toolchain_prefix
         toolchain_version = None
         self.ndk_platform = join(
@@ -379,6 +380,13 @@ class Context(object):
         py_platform = sys.platform
         if py_platform in ['linux2', 'linux3']:
             py_platform = 'linux'
+
+        self.include_prefix = include_prefix
+        include_path = join(self.ndk_dir, 'sysroot/usr/include/', self.include_prefix)
+        if not os.path.isdir(include_path):
+            warning('include directory doesn\'t exist: {}'.format(
+                include_path))
+            ok = False
 
         toolchain_versions = []
         toolchain_path = join(self.ndk_dir, 'toolchains')
@@ -446,6 +454,7 @@ class Context(object):
         self._ndk_ver = None
         self.ndk = None
 
+        self.include_prefix = None
         self.toolchain_prefix = None
         self.toolchain_version = None
 

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -48,8 +48,6 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
     def prebuild_arch(self, arch):
         super(NumpyRecipe, self).prebuild_arch(arch)
 
-        warning('Numpy is built assuming the archiver name is '
-                'arm-linux-androideabi-ar, which may not always be true!')
 
 
 recipe = NumpyRecipe()

--- a/pythonforandroid/recipes/numpy/patches/ar.patch
+++ b/pythonforandroid/recipes/numpy/patches/ar.patch
@@ -5,7 +5,7 @@
          self.mkpath(os.path.dirname(output_filename))
          tmp_objects = objects + self.objects
 +        from os import environ
-+        self.archiver[0] = 'arm-linux-androideabi-ar'
++        self.archiver[0] = environ["AR"]
          while tmp_objects:
              objects = tmp_objects[:50]
              tmp_objects = tmp_objects[50:]


### PR DESCRIPTION
different architectures have different include location, this PR allows to specify different include directory per architecture, so python x86 can be built.

numpy now uses the AR binary corresponding to architecture.

