### PR TITLE
Continuous integration with Travis and Docker, fixes #625

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+before_install:
+  - docker build --tag=p4a .
+
+script:
+  - docker run p4a /bin/sh -c 'uname -a'
+  - docker run p4a /bin/sh -c '. venv/bin/activate && p4a apk --help'
+  - docker run p4a /bin/sh -c '. venv/bin/activate && p4a apk --private testapps/testapp/ --package=com.github.kivy --name "Testapp" --version 0.1 --sdk_dir /opt/android/android-sdk/ --android_api 19 --ndk_dir /opt/android/android-ndk/ --ndk-version 16b --bootstrap=sdl2 --requirements=python2,kivy'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# Dockerfile with:
+# 	- Android build environment
+# 	- python-for-android dependencies
+# Build with:
+# docker build --tag=p4a .
+# Run with:
+# docker run p4a /bin/sh -c '. venv/bin/activate && p4a apk --help'
+# Or for interactive shell:
+# docker run -it --rm p4a
+#
+# TODO:
+#	- delete archives to keep small the container small
+#	- setup caching (for apt, pip, ndk, sdk and p4a recipes downloads)
+FROM ubuntu:16.04
+
+
+# get the latest version from https://developer.android.com/ndk/downloads/index.html
+ENV ANDROID_NDK_VERSION="16b"
+# get the latest version from https://developer.android.com/studio/index.html
+ENV ANDROID_SDK_TOOLS_VERSION="3859397"
+
+ENV ANDROID_HOME="/opt/android"
+ENV ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk" \
+	ANDROID_SDK_HOME="${ANDROID_HOME}/android-sdk"
+ENV ANDROID_NDK_HOME_V="${ANDROID_NDK_HOME}-r${ANDROID_NDK_VERSION}"
+ENV ANDROID_NDK_ARCHIVE="android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip" \
+	ANDROID_SDK_TOOLS_ARCHIVE="sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip"
+ENV ANDROID_NDK_DL_URL="https://dl.google.com/android/repository/${ANDROID_NDK_ARCHIVE}" \
+	ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
+
+# install system dependencies
+RUN apt update && apt install --yes --no-install-recommends \
+	python virtualenv python-pip wget curl lbzip2 patch
+
+# build dependencies
+# https://buildozer.readthedocs.io/en/latest/installation.html#android-on-ubuntu-16-04-64bit
+RUN dpkg --add-architecture i386 &&  apt-get update && apt install --yes --no-install-recommends \
+	build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
+	libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python2.7-dev \
+	openjdk-8-jdk unzip zlib1g-dev zlib1g:i386
+RUN	pip install --upgrade cython==0.21
+
+# download and install Android NDK
+RUN curl --progress-bar "${ANDROID_NDK_DL_URL}" --output "${ANDROID_NDK_ARCHIVE}" && \
+    mkdir --parents "${ANDROID_NDK_HOME_V}" && \
+    unzip -q "${ANDROID_NDK_ARCHIVE}" -d "${ANDROID_HOME}" && \
+	ln -sfn "${ANDROID_NDK_HOME_V}" "${ANDROID_NDK_HOME}"
+
+# download and install Android SDK
+RUN curl --progress-bar "${ANDROID_SDK_TOOLS_DL_URL}" --output "${ANDROID_SDK_TOOLS_ARCHIVE}" && \
+    mkdir --parents "${ANDROID_SDK_HOME}" && \
+    unzip -q "${ANDROID_SDK_TOOLS_ARCHIVE}" -d "${ANDROID_SDK_HOME}"
+
+# update Android SDK, install Android API, Build Tools...
+RUN mkdir --parents "${ANDROID_SDK_HOME}/.android/" && \
+	echo '### User Sources for Android SDK Manager' > "${ANDROID_SDK_HOME}/.android/repositories.cfg"
+RUN yes | "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" --licenses
+RUN "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "platforms;android-19"
+RUN "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "build-tools;26.0.2"
+
+# install python-for-android from current branch
+WORKDIR /app
+COPY . /app
+RUN virtualenv --python=python venv && . venv/bin/activate && pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 python-for-android
 ==================
 
+|Build Status|
+
+.. |Build Status| image:: https://secure.travis-ci.org/kivy/python-for-android.png?branch=master
+   :target: https://travis-ci.org/kivy/python-for-android
+
 python-for-android is a packager for Python apps on Android. You can
 create your own Python distribution including the modules and
 dependencies you want, and bundle it in an APK along with your own code.


### PR DESCRIPTION
This is a first step to python-for-android continuous integration.
It currently only verifies that p4a creates an APK by cross compiling
a limited set of recipes.

How it works; On git push Travis "executes" `.travis.yml` instructions:

1. the `before_install` section runs `docker build` to prepare the environment
2. the `script` section is the actual test, building the APK with `docker run`
3. based the exit status Travis build will be green or red

For example editing `pythonforandroid/recipes/hostpython2/__init__.py` and
introducing an error e.g. replace `-j5` with `--wrong-flag` would make it fail.

Things to improve:

 - improve `.travis.yml` readability
 - test more recipes
 - bring Python3 and Crystax support
 - speed up build/run by caching downloads
 - and much more