### PR TITLE
allow setting launchMode for the main activity in the manifest

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -297,6 +297,8 @@ main.py that loads it.''')
     
     args.add_activity = args.add_activity or []
 
+    args.activity_launch_mode = args.activity_launch_mode or ''
+
     if args.extra_source_dirs:
         esd = []
         for spec in args.extra_source_dirs:
@@ -514,6 +516,8 @@ tools directory of the Android SDK.
                           'the appropriate environment variables.'))
     ap.add_argument('--add-activity', dest='add_activity', action='append',
                     help='Add this Java class as an Activity to the manifest.')
+    ap.add_argument('--activity-launch-mode', dest='activity_launch_mode',
+                    help='Set the launch mode of the main activity in the manifest.')
 
     if args is None:
         args = sys.argv[1:]

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -65,6 +65,9 @@
                   android:label="@string/app_name"
                   android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
+                  {% if args.activity_launch_mode %}
+                  android:launchMode="{{ args.activity_launch_mode }}"
+                  {% endif %}
                   >
 
             {% if args.launcher %}


### PR DESCRIPTION
As in title, this allows setting the [activity launch mode](https://developer.android.com/guide/topics/manifest/activity-element.html#lmode) in the AndroidManifest from buildozer.spec.

It is cumbersome to manually (or via custom scripts) modify the manifest at `[app project]/.buildozer/android/platform/python-for-android/dist/[app]/templates/AndroidManifest.tmpl.xml`.

related: https://github.com/kivy/buildozer/pull/650