### PR TITLE
Build `testapp_sqlite_openssl` using `setup_testapp_python2.py`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ script:
   - docker run p4a /bin/sh -c 'uname -a'
   - docker run p4a /bin/sh -c '. venv/bin/activate && p4a apk --help'
   - docker run p4a /bin/sh -c '. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk'
+  # overrides requirements to skip `peewee` pure python module, see:
+  # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
+  # python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3
+  - docker run p4a /bin/sh -c '. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3'


### PR DESCRIPTION
Has the following requirements:
sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3

peewee had to be skipped because pure python modules fail with
nested virtualenv issue, see:
https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054

refs #1263