### PR TITLE
Builds setuptools with both python2 & hostpython3crystax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,12 @@ before_install:
   - docker build --tag=p4a .
 
 env:
-  - COMMAND='uname -a'
-  - COMMAND='. venv/bin/activate && p4a apk --help'
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk'
   # overrides requirements to skip `peewee` pure python module, see:
   # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
-  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,setuptools,android'
 
 script:
   - docker run p4a /bin/sh -c "$COMMAND"


### PR DESCRIPTION
Covers `setuptools` case in both `python2` and `hostpython3crystax`.
The `hostpython3crystax` build is supposed to fail until branch
`feature/ticket1154_hostpython3crystax_build_dir_and_synlink` is merged.
The merge will be done in next commit to demonstrate the fix.
Also adds android recipe case.
Plus removed the `uname -a` and `p4a apk --help` simple test cases since
the maximum of parallel run seems to be 5.