### PR TITLE
Introduces linting (tox/flake8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
   - docker
 
 before_install:
-  - docker build --tag=p4a .
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq python-tox
 
 env:
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk'
@@ -16,5 +17,10 @@ env:
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk'
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,setuptools,android'
 
+before_script:
+  # we want to fail fast on tox errors without having to `docker build` first
+  - tox
+
 script:
+  - docker build --tag=p4a .
   - docker run p4a /bin/sh -c "$COMMAND"

--- a/pythonforandroid/recipes/babel/__init__.py
+++ b/pythonforandroid/recipes/babel/__init__.py
@@ -2,14 +2,14 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class BabelRecipe(PythonRecipe):
-	name = 'babel'
-	version = '2.1.1'
-	url = 'https://pypi.python.org/packages/source/B/Babel/Babel-{version}.tar.gz'
+    name = 'babel'
+    version = '2.1.1'
+    url = 'https://pypi.python.org/packages/source/B/Babel/Babel-{version}.tar.gz'
 
-	depends = [('python2', 'python3crystax'), 'setuptools', 'pytz']
+    depends = [('python2', 'python3crystax'), 'setuptools', 'pytz']
 
-	call_hostpython_via_targetpython = False
-	install_in_hostpython = True
+    call_hostpython_via_targetpython = False
+    install_in_hostpython = True
 
 
 recipe = BabelRecipe()

--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -2,29 +2,29 @@ from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 
 class CffiRecipe(CompiledComponentsPythonRecipe):
-	name = 'cffi'
-	version = '1.4.2'
-	url = 'https://pypi.python.org/packages/source/c/cffi/cffi-{version}.tar.gz'
+    name = 'cffi'
+    version = '1.4.2'
+    url = 'https://pypi.python.org/packages/source/c/cffi/cffi-{version}.tar.gz'
 
-	depends = [('python2', 'python3crystax'), 'setuptools', 'pycparser', 'libffi']
+    depends = [('python2', 'python3crystax'), 'setuptools', 'pycparser', 'libffi']
 
-	patches = ['disable-pkg-config.patch']
+    patches = ['disable-pkg-config.patch']
 
-	# call_hostpython_via_targetpython = False
-	install_in_hostpython = True
+    # call_hostpython_via_targetpython = False
+    install_in_hostpython = True
 
-	def get_recipe_env(self, arch=None):
-		env = super(CffiRecipe, self).get_recipe_env(arch)
-		libffi = self.get_recipe('libffi', self.ctx)
-		includes = libffi.get_include_dirs(arch)
-		env['CFLAGS'] = ' -I'.join([env.get('CFLAGS', '')] + includes)
-		env['LDFLAGS'] = (env.get('CFLAGS', '') + ' -L' +
-		                  self.ctx.get_libs_dir(arch.arch))
-		env['PYTHONPATH'] = ':'.join([
-			self.ctx.get_site_packages_dir(),
-			env['BUILDLIB_PATH'],
-		])
-		return env
+    def get_recipe_env(self, arch=None):
+        env = super(CffiRecipe, self).get_recipe_env(arch)
+        libffi = self.get_recipe('libffi', self.ctx)
+        includes = libffi.get_include_dirs(arch)
+        env['CFLAGS'] = ' -I'.join([env.get('CFLAGS', '')] + includes)
+        env['LDFLAGS'] = (env.get('CFLAGS', '') + ' -L' +
+                          self.ctx.get_libs_dir(arch.arch))
+        env['PYTHONPATH'] = ':'.join([
+            self.ctx.get_site_packages_dir(),
+            env['BUILDLIB_PATH'],
+        ])
+        return env
 
 
 recipe = CffiRecipe()

--- a/pythonforandroid/recipes/dateutil/__init__.py
+++ b/pythonforandroid/recipes/dateutil/__init__.py
@@ -2,13 +2,13 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class DateutilRecipe(PythonRecipe):
-	name = 'dateutil'
-	version = '2.6.0'
-	url = 'https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz'
+    name = 'dateutil'
+    version = '2.6.0'
+    url = 'https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz'
 
-	depends = ['python2', "setuptools"]
-	call_hostpython_via_targetpython = False
-	install_in_hostpython = True
+    depends = ['python2', "setuptools"]
+    call_hostpython_via_targetpython = False
+    install_in_hostpython = True
 
 
 recipe = DateutilRecipe()

--- a/pythonforandroid/recipes/idna/__init__.py
+++ b/pythonforandroid/recipes/idna/__init__.py
@@ -2,13 +2,13 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class IdnaRecipe(PythonRecipe):
-	name = 'idna'
-	version = '2.0'
-	url = 'https://pypi.python.org/packages/source/i/idna/idna-{version}.tar.gz'
+    name = 'idna'
+    version = '2.0'
+    url = 'https://pypi.python.org/packages/source/i/idna/idna-{version}.tar.gz'
 
-	depends = [('python2', 'python3crystax'), 'setuptools']
+    depends = [('python2', 'python3crystax'), 'setuptools']
 
-	call_hostpython_via_targetpython = False
+    call_hostpython_via_targetpython = False
 
 
 recipe = IdnaRecipe()

--- a/pythonforandroid/recipes/ipaddress/__init__.py
+++ b/pythonforandroid/recipes/ipaddress/__init__.py
@@ -2,11 +2,11 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class IpaddressRecipe(PythonRecipe):
-	name = 'ipaddress'
-	version = '1.0.16'
-	url = 'https://pypi.python.org/packages/source/i/ipaddress/ipaddress-{version}.tar.gz'
+    name = 'ipaddress'
+    version = '1.0.16'
+    url = 'https://pypi.python.org/packages/source/i/ipaddress/ipaddress-{version}.tar.gz'
 
-	depends = ['python2']
+    depends = ['python2']
 
 
 recipe = IpaddressRecipe()

--- a/pythonforandroid/recipes/jpeg/__init__.py
+++ b/pythonforandroid/recipes/jpeg/__init__.py
@@ -6,30 +6,30 @@ import sh
 
 
 class JpegRecipe(NDKRecipe):
-	name = 'jpeg'
-	version = 'linaro-android'
-	url = 'git://git.linaro.org/people/tomgall/libjpeg-turbo/libjpeg-turbo.git'
+    name = 'jpeg'
+    version = 'linaro-android'
+    url = 'git://git.linaro.org/people/tomgall/libjpeg-turbo/libjpeg-turbo.git'
 
-	patches = ['build-static.patch']
+    patches = ['build-static.patch']
 
-	generated_libraries = ['libjpeg.a']
+    generated_libraries = ['libjpeg.a']
 
-	def prebuild_arch(self, arch):
-		super(JpegRecipe, self).prebuild_arch(arch)
+    def prebuild_arch(self, arch):
+        super(JpegRecipe, self).prebuild_arch(arch)
 
-		build_dir = self.get_build_dir(arch.arch)
-		app_mk = join(build_dir, 'Application.mk')
-		if not exists(app_mk):
-			shprint(sh.cp, join(self.get_recipe_dir(), 'Application.mk'), app_mk)
-		jni_ln = join(build_dir, 'jni')
-		if not exists(jni_ln):
-			shprint(sh.ln, '-s', build_dir, jni_ln)
+        build_dir = self.get_build_dir(arch.arch)
+        app_mk = join(build_dir, 'Application.mk')
+        if not exists(app_mk):
+            shprint(sh.cp, join(self.get_recipe_dir(), 'Application.mk'), app_mk)
+        jni_ln = join(build_dir, 'jni')
+        if not exists(jni_ln):
+            shprint(sh.ln, '-s', build_dir, jni_ln)
 
-	def build_arch(self, arch):
-		super(JpegRecipe, self).build_arch(arch)
-		with current_directory(self.get_lib_dir(arch)):
-			shprint(sh.mv, 'libjpeg.a', 'libjpeg-orig.a')
-			shprint(sh.ar, '-rcT', 'libjpeg.a', 'libjpeg-orig.a', 'libsimd.a')
+    def build_arch(self, arch):
+        super(JpegRecipe, self).build_arch(arch)
+        with current_directory(self.get_lib_dir(arch)):
+            shprint(sh.mv, 'libjpeg.a', 'libjpeg-orig.a')
+            shprint(sh.ar, '-rcT', 'libjpeg.a', 'libjpeg-orig.a', 'libsimd.a')
 
 
 recipe = JpegRecipe()

--- a/pythonforandroid/recipes/libmysqlclient/__init__.py
+++ b/pythonforandroid/recipes/libmysqlclient/__init__.py
@@ -6,62 +6,62 @@ from os.path import join
 
 
 class LibmysqlclientRecipe(Recipe):
-	name = 'libmysqlclient'
-	version = 'master'
-	url = 'https://github.com/0x-ff/libmysql-android/archive/{version}.zip'
-	# version = '5.5.47'
-	# url = 'http://dev.mysql.com/get/Downloads/MySQL-5.5/mysql-{version}.tar.gz'
-	# 
-	# depends = ['ncurses']
-	# 
+    name = 'libmysqlclient'
+    version = 'master'
+    url = 'https://github.com/0x-ff/libmysql-android/archive/{version}.zip'
+    # version = '5.5.47'
+    # url = 'http://dev.mysql.com/get/Downloads/MySQL-5.5/mysql-{version}.tar.gz'
+    # 
+    # depends = ['ncurses']
+    # 
 
-	# patches = ['add-custom-platform.patch']
+    # patches = ['add-custom-platform.patch']
 
-	patches = ['disable-soversion.patch']
+    patches = ['disable-soversion.patch']
 
-	def should_build(self, arch):
-		return not self.has_libs(arch, 'libmysql.so')
+    def should_build(self, arch):
+        return not self.has_libs(arch, 'libmysql.so')
 
-	def build_arch(self, arch):
-		env = self.get_recipe_env(arch)
-		with current_directory(join(self.get_build_dir(arch.arch), 'libmysqlclient')):
-			shprint(sh.cp, '-t', '.', join(self.get_recipe_dir(), 'p4a.cmake'))
-			# shprint(sh.mkdir, 'Platform')
-			# shprint(sh.cp, '-t', 'Platform', join(self.get_recipe_dir(), 'Linux.cmake'))
-			shprint(sh.rm, '-f', 'CMakeCache.txt')
-			shprint(sh.cmake, '-G', 'Unix Makefiles',
-					# '-DCMAKE_MODULE_PATH=' + join(self.get_build_dir(arch.arch), 'libmysqlclient'),
-			        '-DCMAKE_INSTALL_PREFIX=./install',
-			        '-DCMAKE_TOOLCHAIN_FILE=p4a.cmake', _env=env)
-			shprint(sh.make, _env=env)
+    def build_arch(self, arch):
+        env = self.get_recipe_env(arch)
+        with current_directory(join(self.get_build_dir(arch.arch), 'libmysqlclient')):
+            shprint(sh.cp, '-t', '.', join(self.get_recipe_dir(), 'p4a.cmake'))
+            # shprint(sh.mkdir, 'Platform')
+            # shprint(sh.cp, '-t', 'Platform', join(self.get_recipe_dir(), 'Linux.cmake'))
+            shprint(sh.rm, '-f', 'CMakeCache.txt')
+            shprint(sh.cmake, '-G', 'Unix Makefiles',
+                    # '-DCMAKE_MODULE_PATH=' + join(self.get_build_dir(arch.arch), 'libmysqlclient'),
+                    '-DCMAKE_INSTALL_PREFIX=./install',
+                    '-DCMAKE_TOOLCHAIN_FILE=p4a.cmake', _env=env)
+            shprint(sh.make, _env=env)
 
-			self.install_libs(arch, join('libmysql', 'libmysql.so'))
+            self.install_libs(arch, join('libmysql', 'libmysql.so'))
 
-	# def get_recipe_env(self, arch=None):
-	# 	env = super(LibmysqlclientRecipe, self).get_recipe_env(arch)
-	# 	env['WITHOUT_SERVER'] = 'ON'
-	# 	ncurses = self.get_recipe('ncurses', self)
-	# 	# env['CFLAGS'] += ' -I' + join(ncurses.get_build_dir(arch.arch),
-	# 	#                               'include')
-	# 	env['CURSES_LIBRARY'] = join(self.ctx.get_libs_dir(arch.arch), 'libncurses.so')
-	# 	env['CURSES_INCLUDE_PATH'] = join(ncurses.get_build_dir(arch.arch),
-	# 	                                  'include')
-	# 	return env
-	# 
-	# def build_arch(self, arch):
-	# 	env = self.get_recipe_env(arch)
-	# 	with current_directory(self.get_build_dir(arch.arch)):
-	# 		# configure = sh.Command('./configure')
-	# 		# TODO: should add openssl as an optional dep and compile support
-	# 		# shprint(configure, '--enable-shared', '--enable-assembler',
-	# 		#         '--enable-thread-safe-client', '--with-innodb',
-	# 		#         '--without-server', _env=env)
-	# 		# shprint(sh.make, _env=env)
-	# 		shprint(sh.cmake, '.', '-DCURSES_LIBRARY=' + env['CURSES_LIBRARY'],
-	# 		        '-DCURSES_INCLUDE_PATH=' + env['CURSES_INCLUDE_PATH'], _env=env)
-	# 		shprint(sh.make, _env=env)
-	# 
-	# 		self.install_libs(arch, 'libmysqlclient.so')
+    # def get_recipe_env(self, arch=None):
+    #   env = super(LibmysqlclientRecipe, self).get_recipe_env(arch)
+    #   env['WITHOUT_SERVER'] = 'ON'
+    #   ncurses = self.get_recipe('ncurses', self)
+    #   # env['CFLAGS'] += ' -I' + join(ncurses.get_build_dir(arch.arch),
+    #   #                               'include')
+    #   env['CURSES_LIBRARY'] = join(self.ctx.get_libs_dir(arch.arch), 'libncurses.so')
+    #   env['CURSES_INCLUDE_PATH'] = join(ncurses.get_build_dir(arch.arch),
+    #                                     'include')
+    #   return env
+    # 
+    # def build_arch(self, arch):
+    #   env = self.get_recipe_env(arch)
+    #   with current_directory(self.get_build_dir(arch.arch)):
+    #       # configure = sh.Command('./configure')
+    #       # TODO: should add openssl as an optional dep and compile support
+    #       # shprint(configure, '--enable-shared', '--enable-assembler',
+    #       #         '--enable-thread-safe-client', '--with-innodb',
+    #       #         '--without-server', _env=env)
+    #       # shprint(sh.make, _env=env)
+    #       shprint(sh.cmake, '.', '-DCURSES_LIBRARY=' + env['CURSES_LIBRARY'],
+    #               '-DCURSES_INCLUDE_PATH=' + env['CURSES_INCLUDE_PATH'], _env=env)
+    #       shprint(sh.make, _env=env)
+    # 
+    #       self.install_libs(arch, 'libmysqlclient.so')
 
 
 recipe = LibmysqlclientRecipe()

--- a/pythonforandroid/recipes/mysqldb/__init__.py
+++ b/pythonforandroid/recipes/mysqldb/__init__.py
@@ -3,50 +3,50 @@ from os.path import join
 
 
 class MysqldbRecipe(CompiledComponentsPythonRecipe):
-	name = 'mysqldb'
-	version = '1.2.5'
-	url = 'https://pypi.python.org/packages/source/M/MySQL-python/MySQL-python-{version}.zip'
-	site_packages_name = 'MySQLdb'
+    name = 'mysqldb'
+    version = '1.2.5'
+    url = 'https://pypi.python.org/packages/source/M/MySQL-python/MySQL-python-{version}.zip'
+    site_packages_name = 'MySQLdb'
 
-	depends = ['python2', 'setuptools', 'libmysqlclient']
+    depends = ['python2', 'setuptools', 'libmysqlclient']
 
-	patches = ['override-mysql-config.patch',
-	           'disable-zip.patch']
+    patches = ['override-mysql-config.patch',
+               'disable-zip.patch']
 
-	# call_hostpython_via_targetpython = False
+    # call_hostpython_via_targetpython = False
 
-	def convert_newlines(self, filename):
-		print('converting newlines in {}'.format(filename))
-		with open(filename, 'rb') as f:
-			data = f.read()
-		with open(filename, 'wb') as f:
-			f.write(data.replace(b'\r\n', b'\n').replace(b'\r', b'\n'))
+    def convert_newlines(self, filename):
+        print('converting newlines in {}'.format(filename))
+        with open(filename, 'rb') as f:
+            data = f.read()
+        with open(filename, 'wb') as f:
+            f.write(data.replace(b'\r\n', b'\n').replace(b'\r', b'\n'))
 
-	def prebuild_arch(self, arch):
-		super(MysqldbRecipe, self).prebuild_arch(arch)
-		setupbase = join(self.get_build_dir(arch.arch), 'setup')
-		self.convert_newlines(setupbase + '.py')
-		self.convert_newlines(setupbase + '_posix.py')
+    def prebuild_arch(self, arch):
+        super(MysqldbRecipe, self).prebuild_arch(arch)
+        setupbase = join(self.get_build_dir(arch.arch), 'setup')
+        self.convert_newlines(setupbase + '.py')
+        self.convert_newlines(setupbase + '_posix.py')
 
-	def get_recipe_env(self, arch=None):
-		env = super(MysqldbRecipe, self).get_recipe_env(arch)
+    def get_recipe_env(self, arch=None):
+        env = super(MysqldbRecipe, self).get_recipe_env(arch)
 
-		hostpython = self.get_recipe('hostpython2', self.ctx)
-		# TODO: fix hardcoded path
-		env['PYTHONPATH'] = (join(hostpython.get_build_dir(arch.arch),
-		                          'build', 'lib.linux-x86_64-2.7') +
-		                     ':' + env.get('PYTHONPATH', ''))
+        hostpython = self.get_recipe('hostpython2', self.ctx)
+        # TODO: fix hardcoded path
+        env['PYTHONPATH'] = (join(hostpython.get_build_dir(arch.arch),
+                                  'build', 'lib.linux-x86_64-2.7') +
+                             ':' + env.get('PYTHONPATH', ''))
 
-		libmysql = self.get_recipe('libmysqlclient', self.ctx)
-		mydir = join(libmysql.get_build_dir(arch.arch), 'libmysqlclient')
-		# env['CFLAGS'] += ' -I' + join(mydir, 'include')
-		# env['LDFLAGS'] += ' -L' + join(mydir)
-		libdir = self.ctx.get_libs_dir(arch.arch)
-		env['MYSQL_libs'] = env['MYSQL_libs_r'] = '-L' + libdir + ' -lmysql'
-		env['MYSQL_cflags'] = env['MYSQL_include'] = '-I' + join(mydir,
-		                                                         'include')
+        libmysql = self.get_recipe('libmysqlclient', self.ctx)
+        mydir = join(libmysql.get_build_dir(arch.arch), 'libmysqlclient')
+        # env['CFLAGS'] += ' -I' + join(mydir, 'include')
+        # env['LDFLAGS'] += ' -L' + join(mydir)
+        libdir = self.ctx.get_libs_dir(arch.arch)
+        env['MYSQL_libs'] = env['MYSQL_libs_r'] = '-L' + libdir + ' -lmysql'
+        env['MYSQL_cflags'] = env['MYSQL_include'] = '-I' + join(mydir,
+                                                                 'include')
 
-		return env
+        return env
 
 
 recipe = MysqldbRecipe()

--- a/pythonforandroid/recipes/pil/__init__.py
+++ b/pythonforandroid/recipes/pil/__init__.py
@@ -4,38 +4,38 @@ from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 
 class PILRecipe(CompiledComponentsPythonRecipe):
-	name = 'pil'
-	version = '1.1.7'
-	url = 'http://effbot.org/downloads/Imaging-{version}.tar.gz'
-	depends = ['python2', 'png', 'jpeg']
-	site_packages_name = 'PIL'
+    name = 'pil'
+    version = '1.1.7'
+    url = 'http://effbot.org/downloads/Imaging-{version}.tar.gz'
+    depends = ['python2', 'png', 'jpeg']
+    site_packages_name = 'PIL'
 
-	patches = ['disable-tk.patch',
-	           'fix-directories.patch']
+    patches = ['disable-tk.patch',
+               'fix-directories.patch']
 
-	def get_recipe_env(self, arch=None):
-		env = super(PILRecipe, self).get_recipe_env(arch)
+    def get_recipe_env(self, arch=None):
+        env = super(PILRecipe, self).get_recipe_env(arch)
 
-		png = self.get_recipe('png', self.ctx)
-		png_lib_dir = png.get_lib_dir(arch)
-		png_jni_dir = png.get_jni_dir(arch)
-		jpeg = self.get_recipe('jpeg', self.ctx)
-		jpeg_lib_dir = jpeg.get_lib_dir(arch)
-		jpeg_jni_dir = jpeg.get_jni_dir(arch)
-		env['JPEG_ROOT'] = '{}|{}'.format(jpeg_lib_dir, jpeg_jni_dir)
+        png = self.get_recipe('png', self.ctx)
+        png_lib_dir = png.get_lib_dir(arch)
+        png_jni_dir = png.get_jni_dir(arch)
+        jpeg = self.get_recipe('jpeg', self.ctx)
+        jpeg_lib_dir = jpeg.get_lib_dir(arch)
+        jpeg_jni_dir = jpeg.get_jni_dir(arch)
+        env['JPEG_ROOT'] = '{}|{}'.format(jpeg_lib_dir, jpeg_jni_dir)
 
-		cflags = ' -I{} -L{} -I{} -L{}'.format(png_jni_dir, png_lib_dir, jpeg_jni_dir, jpeg_lib_dir)
-		env['CFLAGS'] += cflags
-		env['CXXFLAGS'] += cflags
-		env['CC'] += cflags
-		env['CXX'] += cflags
+        cflags = ' -I{} -L{} -I{} -L{}'.format(png_jni_dir, png_lib_dir, jpeg_jni_dir, jpeg_lib_dir)
+        env['CFLAGS'] += cflags
+        env['CXXFLAGS'] += cflags
+        env['CC'] += cflags
+        env['CXX'] += cflags
 
-		ndk_dir = self.ctx.ndk_platform
-		ndk_lib_dir = join(ndk_dir, 'usr', 'lib')
-		ndk_include_dir = join(ndk_dir, 'usr', 'include')
-		env['ZLIB_ROOT'] = '{}|{}'.format(ndk_lib_dir, ndk_include_dir)
+        ndk_dir = self.ctx.ndk_platform
+        ndk_lib_dir = join(ndk_dir, 'usr', 'lib')
+        ndk_include_dir = join(ndk_dir, 'usr', 'include')
+        env['ZLIB_ROOT'] = '{}|{}'.format(ndk_lib_dir, ndk_include_dir)
 
-		return env
+        return env
 
 
 recipe = PILRecipe()

--- a/pythonforandroid/recipes/png/__init__.py
+++ b/pythonforandroid/recipes/png/__init__.py
@@ -2,11 +2,11 @@ from pythonforandroid.recipe import NDKRecipe
 
 
 class PngRecipe(NDKRecipe):
-	name = 'png'
-	version = '1.6.15'
-	url = 'https://github.com/julienr/libpng-android/archive/{version}.zip'
+    name = 'png'
+    version = '1.6.15'
+    url = 'https://github.com/julienr/libpng-android/archive/{version}.zip'
 
-	generated_libraries = ['libpng.a']
+    generated_libraries = ['libpng.a']
 
 
 recipe = PngRecipe()

--- a/pythonforandroid/recipes/pycparser/__init__.py
+++ b/pythonforandroid/recipes/pycparser/__init__.py
@@ -2,15 +2,15 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PycparserRecipe(PythonRecipe):
-	name = 'pycparser'
-	version = '2.14'
-	url = 'https://pypi.python.org/packages/source/p/pycparser/pycparser-{version}.tar.gz'
+    name = 'pycparser'
+    version = '2.14'
+    url = 'https://pypi.python.org/packages/source/p/pycparser/pycparser-{version}.tar.gz'
 
-	depends = [('python2', 'python3crystax'), 'setuptools']
+    depends = [('python2', 'python3crystax'), 'setuptools']
 
-	call_hostpython_via_targetpython = False
+    call_hostpython_via_targetpython = False
 
-	install_in_hostpython = True
+    install_in_hostpython = True
 
 
 recipe = PycparserRecipe()

--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -19,7 +19,7 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
         env['LDFLAGS'] += " -shared -llog"
         env['LDFLAGS'] += " -landroid -lpython2.7"
         env['LDFLAGS'] += " --sysroot={ctx.ndk_dir}/platforms/android-{ctx.android_api}/arch-{arch_noeabi}".format(
-		ctx=self.ctx, arch_noeabi=arch_noeabi)
+            ctx=self.ctx, arch_noeabi=arch_noeabi)
         return env
 
 recipe = PymunkRecipe()

--- a/pythonforandroid/recipes/pytz/__init__.py
+++ b/pythonforandroid/recipes/pytz/__init__.py
@@ -2,14 +2,14 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PytzRecipe(PythonRecipe):
-	name = 'pytz'
-	version = '2015.7'
-	url = 'https://pypi.python.org/packages/source/p/pytz/pytz-{version}.tar.bz2'
+    name = 'pytz'
+    version = '2015.7'
+    url = 'https://pypi.python.org/packages/source/p/pytz/pytz-{version}.tar.bz2'
 
-	depends = [('python2', 'python3crystax')]
+    depends = [('python2', 'python3crystax')]
 
-	call_hostpython_via_targetpython = False
-	install_in_hostpython = True
+    call_hostpython_via_targetpython = False
+    install_in_hostpython = True
 
 
 recipe = PytzRecipe()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = pep8
+# no setup.py to be ran
+skipsdist = True
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 pythonforandroid/
+
+[flake8]
+ignore =
+    E111, E114, E115, E116, E202, E121, E123, E124, E225, E126, E127, E128,
+    E129, E201, E203, E221, E226, E231, E241, E251, E261, E265, E266, E271,
+    E302, E303, E305, E401, E402, E501, E502, E703, E722, E741, F401, F403,
+    F812, F821, F841, F811, W291, W292, W293, W391, W503


### PR DESCRIPTION
Makes sure lint checks are ran before `docker build` so we fail fast.
Currently `flake8` errors are ignored except for `E101` and `W191`.
This will demonstrate the fail fast case.
Next commit will fix these two errors in the code base.