### PR TITLE
Groestlcoin hash

### DIFF
--- a/pythonforandroid/recipes/groestlcoin_hash/__init__.py
+++ b/pythonforandroid/recipes/groestlcoin_hash/__init__.py
@@ -1,0 +1,12 @@
+from pythonforandroid.recipe import CythonRecipe
+
+
+class GroestlcoinHashRecipe(CythonRecipe):
+    version = '1.0.1'
+    url = 'https://github.com/Groestlcoin/groestlcoin-hash-python/archive/{version}.tar.gz'
+    depends = ['python3crystax']
+    call_hostpython_via_targetpython = True
+    cythonize = False
+
+
+recipe = GroestlcoinHashRecipe()


### PR DESCRIPTION
Adds a recipe for groestlcoin_hash, a hash algorithm used by the Groestlcoin cryptocurrency.

This PR depends on #1217 because as with any electrum fork, the app using this recipe uses this patched p4a to allow using ssl with python3crystax, so this recipe wasn't tested on p4a master.

The overriden `get_recipe_env` could maybe be removed and the change it does be backported to the `CythonRecipe.get_recipe_env` method, at the same place `-lpython{}m' is added, so other recipes could benefit from it. I don't know if it could potentially lead to issues with others though, so that's an open question for me.