### PR TITLE
fixes find_library when deployed external storage

### DIFF
--- a/pythonforandroid/recipes/python2/patches/ctypes-find-library-updated.patch
+++ b/pythonforandroid/recipes/python2/patches/ctypes-find-library-updated.patch
@@ -12,7 +12,7 @@ index 52b3520..01b13a9 100644
 +if True:
 +    def find_library(name):
 +        # Check the user app lib dir
-+        app_root = os.path.abspath('./').split(os.path.sep)[0:4]
++        app_root = os.path.abspath('../../').split(os.path.sep)
 +        lib_search = os.path.sep.join(app_root) + os.path.sep + 'lib'
 +        for filename in os.listdir(lib_search):
 +            if filename.endswith('.so') and name in filename:


### PR DESCRIPTION
Fixes `find_library()` `OSError`/`FileNotFoundError` exception when app
deployed external SD storage.
Apps deployed on external SD storage have different root prefix.
External SD storage apps root dir prefix is like:
```
/mnt/expand/<sd-card-id>/user/0/<package.domain>.<package.name>/files/app
```
While internal storage apps root dir prefix is:
```
/data/data/<package.domain>.<package.name>/files/app
```
Hence the `[0:4]` trick doesn't work.