### PR TITLE
Recipes updates with CrystaX/Python3 support

### DIFF
--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 
@@ -15,15 +16,32 @@ class CffiRecipe(CompiledComponentsPythonRecipe):
 
     def get_recipe_env(self, arch=None):
         env = super(CffiRecipe, self).get_recipe_env(arch)
+        # sets linker to use the correct gcc (cross compiler)
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         libffi = self.get_recipe('libffi', self.ctx)
         includes = libffi.get_include_dirs(arch)
         env['CFLAGS'] = ' -I'.join([env.get('CFLAGS', '')] + includes)
         env['LDFLAGS'] = (env.get('CFLAGS', '') + ' -L' +
                           self.ctx.get_libs_dir(arch.arch))
+        env['LDFLAGS'] += ' -L{}'.format(os.path.join(self.ctx.bootstrap.build_dir, 'libs', arch.arch))
+        # required for libc and libdl
+        ndk_dir = self.ctx.ndk_platform
+        ndk_lib_dir = os.path.join(ndk_dir, 'usr', 'lib')
+        env['LDFLAGS'] += ' -L{}'.format(ndk_lib_dir)
+        env['LDFLAGS'] += " --sysroot={}".format(self.ctx.ndk_platform)
         env['PYTHONPATH'] = ':'.join([
             self.ctx.get_site_packages_dir(),
             env['BUILDLIB_PATH'],
         ])
+        if self.ctx.ndk == 'crystax':
+            # only keeps major.minor (discards patch)
+            python_version = self.ctx.python_recipe.version[0:3]
+            ndk_dir_python = os.path.join(self.ctx.ndk_dir, 'sources/python/', python_version)
+            env['LDFLAGS'] += ' -L{}'.format(os.path.join(ndk_dir_python, 'libs', arch.arch))
+            env['LDFLAGS'] += ' -lpython{}m'.format(python_version)
+            # until `pythonforandroid/archs.py` gets merged upstream:
+            # https://github.com/kivy/python-for-android/pull/1250/files#diff-569e13021e33ced8b54385f55b49cbe6
+            env['CFLAGS'] += ' -I{}/include/python/'.format(ndk_dir_python)
         return env
 
 

--- a/pythonforandroid/recipes/decorator/__init__.py
+++ b/pythonforandroid/recipes/decorator/__init__.py
@@ -2,9 +2,10 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class DecoratorPyRecipe(PythonRecipe):
-    version = '4.0.9'
+    version = '4.2.1'
     url = 'https://pypi.python.org/packages/source/d/decorator/decorator-{version}.tar.gz'
-    depends = ['hostpython2', 'setuptools']
+    url = 'https://github.com/micheles/decorator/archive/{version}.tar.gz'
+    depends = [('python2', 'python3crystax'), 'setuptools']
     site_packages_name = 'decorator'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/idna/__init__.py
+++ b/pythonforandroid/recipes/idna/__init__.py
@@ -3,8 +3,8 @@ from pythonforandroid.recipe import PythonRecipe
 
 class IdnaRecipe(PythonRecipe):
     name = 'idna'
-    version = '2.0'
-    url = 'https://pypi.python.org/packages/source/i/idna/idna-{version}.tar.gz'
+    version = '2.6'
+    url = 'https://github.com/kjd/idna/archive/v{version}.tar.gz'
 
     depends = [('python2', 'python3crystax'), 'setuptools']
 

--- a/pythonforandroid/recipes/pycryptodome/__init__.py
+++ b/pythonforandroid/recipes/pycryptodome/__init__.py
@@ -2,10 +2,15 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PycryptodomeRecipe(PythonRecipe):
-    version = 'v3.4.6'
-    url = 'https://github.com/Legrandin/pycryptodome/archive/{version}.tar.gz'
+    version = '3.4.6'
+    url = 'https://github.com/Legrandin/pycryptodome/archive/v{version}.tar.gz'
+    depends = [('python2', 'python3crystax'), 'setuptools', 'cffi']
 
-    depends = ['python2', 'setuptools', 'cffi']
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+        env = super(PycryptodomeRecipe, self).get_recipe_env(arch, with_flags_in_cc)
+        # sets linker to use the correct gcc (cross compiler)
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
+        return env
 
 
 recipe = PycryptodomeRecipe()

--- a/pythonforandroid/recipes/pysha3/__init__.py
+++ b/pythonforandroid/recipes/pysha3/__init__.py
@@ -1,11 +1,28 @@
+import os
 from pythonforandroid.recipe import PythonRecipe
 
 
+# TODO: CompiledComponentsPythonRecipe
 class Pysha3Recipe(PythonRecipe):
     version = '1.0.2'
     url = 'https://github.com/tiran/pysha3/archive/{version}.tar.gz'
+    depends = [('python2', 'python3crystax'), 'setuptools']
 
-    depends = ['python2', 'setuptools']
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+        env = super(Pysha3Recipe, self).get_recipe_env(arch, with_flags_in_cc)
+        # sets linker to use the correct gcc (cross compiler)
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
+        # CFLAGS may only be used to specify C compiler flags, for macro definitions use CPPFLAGS
+        env['CPPFLAGS'] = env['CFLAGS'] + ' -I{}/sources/python/3.5/include/python/'.format(self.ctx.ndk_dir)
+        env['CFLAGS'] = ''
+        # LDFLAGS may only be used to specify linker flags, for libraries use LIBS
+        env['LDFLAGS'] = env['LDFLAGS'].replace('-lm', '').replace('-lcrystax', '')
+        env['LDFLAGS'] += ' -L{}'.format(os.path.join(self.ctx.bootstrap.build_dir, 'libs', arch.arch))
+        env['LIBS'] = ' -lm'
+        if self.ctx.ndk == 'crystax':
+            env['LIBS'] += ' -lcrystax -lpython{}m'.format(self.ctx.python_recipe.version[0:3])
+        env['LDSHARED'] += env['LIBS']
+        return env
 
 
 recipe = Pysha3Recipe()

--- a/pythonforandroid/recipes/pyyaml/__init__.py
+++ b/pythonforandroid/recipes/pyyaml/__init__.py
@@ -2,11 +2,10 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PyYamlRecipe(PythonRecipe):
-    version = "3.11"
+    version = "3.12"
     url = 'http://pyyaml.org/download/pyyaml/PyYAML-{version}.tar.gz'
     depends = [('python2', 'python3crystax'), "setuptools"]
     site_packages_name = 'pyyaml'
-    call_hostpython_via_targetpython = False
 
 
 recipe = PyYamlRecipe()

--- a/pythonforandroid/recipes/requests/__init__.py
+++ b/pythonforandroid/recipes/requests/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class RequestsRecipe(PythonRecipe):
     version = '2.13.0'
     url = 'https://github.com/kennethreitz/requests/archive/v{version}.tar.gz'
-    depends = ['hostpython2', 'setuptools']
+    depends = [('hostpython2', 'hostpython3crystax'), 'setuptools']
     site_packages_name = 'requests'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/scrypt/__init__.py
+++ b/pythonforandroid/recipes/scrypt/__init__.py
@@ -1,15 +1,13 @@
+import os
 from pythonforandroid.recipe import CythonRecipe
-from os.path import join
 
 
 class ScryptRecipe(CythonRecipe):
 
-    url = 'https://bitbucket.org/mhallin/py-scrypt/get/default.zip'
-
-    depends = ['python2', 'setuptools', 'openssl']
-
+    version = '0.8.6'
+    url = 'https://bitbucket.org/mhallin/py-scrypt/get/v{version}.zip'
+    depends = [('python2', 'python3crystax'), 'setuptools', 'openssl']
     call_hostpython_via_targetpython = False
-
     patches = ["remove_librt.patch"]
 
     def get_recipe_env(self, arch, with_flags_in_cc=True):
@@ -19,12 +17,21 @@ class ScryptRecipe(CythonRecipe):
         env = super(ScryptRecipe, self).get_recipe_env(arch, with_flags_in_cc)
         openssl_build_dir = self.get_recipe(
             'openssl', self.ctx).get_build_dir(arch.arch)
-        print("openssl_build_dir:", openssl_build_dir)
-        env['CC'] = '%s -I%s' % (env['CC'], join(openssl_build_dir, 'include'))
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
+        env['CFLAGS'] += ' -I{}'.format(os.path.join(openssl_build_dir, 'include'))
+        env['LDFLAGS'] += ' -L{}'.format(
             self.ctx.get_libs_dir(arch.arch) +
             '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
             openssl_build_dir)
+        # required additional library and path for Crystax
+        if self.ctx.ndk == 'crystax':
+            # only keeps major.minor (discards patch)
+            python_version = self.ctx.python_recipe.version[0:3]
+            ndk_dir_python = os.path.join(self.ctx.ndk_dir, 'sources/python/', python_version)
+            env['LDFLAGS'] += ' -L{}'.format(os.path.join(ndk_dir_python, 'libs', arch.arch))
+            env['LDFLAGS'] += ' -lpython{}m'.format(python_version)
+            # until `pythonforandroid/archs.py` gets merged upstream:
+            # https://github.com/kivy/python-for-android/pull/1250/files#diff-569e13021e33ced8b54385f55b49cbe6
+            env['CFLAGS'] += ' -I{}/include/python/'.format(ndk_dir_python)
         return env
 
 

--- a/pythonforandroid/recipes/scrypt/remove_librt.patch
+++ b/pythonforandroid/recipes/scrypt/remove_librt.patch
@@ -1,7 +1,6 @@
-diff -r 91d194b6a6bd setup.py
---- a/setup.py	Sat Sep 17 15:29:49 2016 +0200
-+++ b/setup.py	Mon May 29 07:30:24 2017 +0000
-@@ -13,7 +13,6 @@
+--- a/setup.py	2018-05-06 23:25:08.757522119 +0200
++++ b/setup.py	2018-05-06 23:25:30.269797365 +0200
+@@ -15,7 +15,6 @@
  
  if sys.platform.startswith('linux'):
      define_macros = [('HAVE_CLOCK_GETTIME', '1'),
@@ -9,11 +8,12 @@ diff -r 91d194b6a6bd setup.py
                       ('HAVE_POSIX_MEMALIGN', '1'),
                       ('HAVE_STRUCT_SYSINFO', '1'),
                       ('HAVE_STRUCT_SYSINFO_MEM_UNIT', '1'),
-@@ -21,7 +20,7 @@
+@@ -23,8 +22,7 @@
                       ('HAVE_SYSINFO', '1'),
                       ('HAVE_SYS_SYSINFO_H', '1'),
                       ('_FILE_OFFSET_BITS', '64')]
 -    libraries = ['crypto', 'rt']
+-    includes = ['/usr/local/include', '/usr/include']
 +    libraries = ['crypto']
      CFLAGS.append('-O2')
  elif sys.platform.startswith('win32'):

--- a/pythonforandroid/recipes/secp256k1/__init__.py
+++ b/pythonforandroid/recipes/secp256k1/__init__.py
@@ -1,4 +1,4 @@
-from os.path import join
+import os
 from pythonforandroid.recipe import PythonRecipe
 
 
@@ -9,25 +9,37 @@ class Secp256k1Recipe(PythonRecipe):
     call_hostpython_via_targetpython = False
 
     depends = [
-        'openssl', 'hostpython2', 'python2', 'setuptools',
-        'libffi', 'cffi', 'libffi', 'libsecp256k1']
+        'openssl', ('hostpython2', 'hostpython3crystax'),
+        ('python2', 'python3crystax'), 'setuptools',
+        'libffi', 'cffi', 'libsecp256k1']
 
     patches = [
         "cross_compile.patch", "drop_setup_requires.patch",
         "pkg-config.patch", "find_lib.patch", "no-download.patch"]
 
-    def get_recipe_env(self, arch=None):
-        env = super(Secp256k1Recipe, self).get_recipe_env(arch)
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+        env = super(Secp256k1Recipe, self).get_recipe_env(arch, with_flags_in_cc)
+        # sets linker to use the correct gcc (cross compiler)
+        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         libsecp256k1 = self.get_recipe('libsecp256k1', self.ctx)
         libsecp256k1_dir = libsecp256k1.get_build_dir(arch.arch)
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
-        env['CFLAGS'] = ' -I' + join(libsecp256k1_dir, 'include')
-        env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python2.7'
-        env['LDSHARED'] = env['CC'] + \
-            ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         env['LDFLAGS'] += ' -L{}'.format(libsecp256k1_dir)
-        # TODO: hardcoded Python version
-        env['LDFLAGS'] += " -landroid -lpython2.7 -lsecp256k1"
+        env['CFLAGS'] = ' -I' + os.path.join(libsecp256k1_dir, 'include')
+        # only keeps major.minor (discards patch)
+        python_version = self.ctx.python_recipe.version[0:3]
+        # required additional library and path for Crystax
+        if self.ctx.ndk == 'crystax':
+            ndk_dir_python = os.path.join(self.ctx.ndk_dir, 'sources/python/', python_version)
+            env['LDFLAGS'] += ' -L{}'.format(os.path.join(ndk_dir_python, 'libs', arch.arch))
+            env['LDFLAGS'] += ' -lpython{}m'.format(python_version)
+            # until `pythonforandroid/archs.py` gets merged upstream:
+            # https://github.com/kivy/python-for-android/pull/1250/files#diff-569e13021e33ced8b54385f55b49cbe6
+            env['CFLAGS'] += ' -I{}/include/python/'.format(ndk_dir_python)
+        else:
+            env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+            env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python{}'.format(python_version)
+            env['LDFLAGS'] += " -lpython{}".format(python_version)
+        env['LDFLAGS'] += " -lsecp256k1"
         return env
 
 


### PR DESCRIPTION
Adds CrystaX/Python3 support to 9 recipes:

  - cffi: fixes build in both Python2 and Python3
  - decorator: updates version and adds python3crystax support
  - idna: updates version
  - pycryptodome: fixes version string & adds python3crystax support
  - python3crystax: adds python3crystax support
  - pyyaml: updates version & drops host python via target python
  - requests: adds python3crystax support
  - scrypt: fixes version & adds python3crystax support
  - secp256k1: adds python3crystax support

These recipes were tested with CrystaX/Python3 in
https://github.com/AndreMiras/EtherollApp
See last `buildozer android debug` build success:
https://travis-ci.org/AndreMiras/EtherollApp/jobs/386381704