### PR TITLE
Fix twisted and cryptography build for python 3

### DIFF
--- a/pythonforandroid/recipes/enum34/__init__.py
+++ b/pythonforandroid/recipes/enum34/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class Enum34Recipe(PythonRecipe):
     version = '1.1.3'
     url = 'https://pypi.python.org/packages/source/e/enum34/enum34-{version}.tar.gz'
-    depends = ['python2', 'setuptools']
+    depends = [('python2', 'python3crystax'), 'setuptools']
     site_packages_name = 'enum'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/ipaddress/__init__.py
+++ b/pythonforandroid/recipes/ipaddress/__init__.py
@@ -6,7 +6,7 @@ class IpaddressRecipe(PythonRecipe):
     version = '1.0.16'
     url = 'https://pypi.python.org/packages/source/i/ipaddress/ipaddress-{version}.tar.gz'
 
-    depends = ['python2']
+    depends = [('python2', 'python3crystax')]
 
 
 recipe = IpaddressRecipe()

--- a/pythonforandroid/recipes/pyasn1/__init__.py
+++ b/pythonforandroid/recipes/pyasn1/__init__.py
@@ -5,7 +5,7 @@ from pythonforandroid.recipe import PythonRecipe
 class PyASN1Recipe(PythonRecipe):
     version = '0.1.8'
     url = 'https://pypi.python.org/packages/source/p/pyasn1/pyasn1-{version}.tar.gz'
-    depends = ['python2']
+    depends = [('python2', 'python3crystax')]
 
 
 recipe = PyASN1Recipe()

--- a/pythonforandroid/recipes/pyopenssl/__init__.py
+++ b/pythonforandroid/recipes/pyopenssl/__init__.py
@@ -5,7 +5,7 @@ from pythonforandroid.recipe import PythonRecipe
 class PyOpenSSLRecipe(PythonRecipe):
     version = '0.14'
     url = 'https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-{version}.tar.gz'
-    depends = ['openssl', 'python2', 'setuptools']
+    depends = [('python2', 'python3crystax'), 'openssl', 'setuptools']
     site_packages_name = 'OpenSSL'
 
     call_hostpython_via_targetpython = False

--- a/pythonforandroid/recipes/zope_interface/__init__.py
+++ b/pythonforandroid/recipes/zope_interface/__init__.py
@@ -10,7 +10,7 @@ class ZopeInterfaceRecipe(PythonRecipe):
     url = 'https://pypi.python.org/packages/source/z/zope.interface/zope.interface-{version}.tar.gz'
     site_packages_name = 'zope.interface'
 
-    depends = ['python2']
+    depends = [('python2', 'python3crystax')]
     patches = ['no_tests.patch']
 
     def prebuild_arch(self, arch):


### PR DESCRIPTION
Fix Twisted and Cryptography to not conflict with python3crystax

Note: Cryptography still does not successfully build, but at least it no longer complains about a conflict. https://paste.ubuntu.com/p/nMxXnP7tzH/