### PR TITLE
fixed #1184 - now cython gets -L of NDK's libraries

### DIFF
--- a/pythonforandroid/recipes/cymunk/__init__.py
+++ b/pythonforandroid/recipes/cymunk/__init__.py
@@ -8,5 +8,26 @@ class CymunkRecipe(CythonRecipe):
 
     depends = [('python2', 'python3crystax')]
 
+    def get_recipe_env(self, arch):
+        """ 
+	    cython has problem with -lpython3.5m , hack to add -L to it
+
+	    roughly adapted from similar numpy (fix-numpy branch) dirty solution
+        """
+
+        env = super(CymunkRecipe, self).get_recipe_env(arch)
+        #: Hack add path L to crystax as a CFLAG
+
+	if 'python3crystax' not in self.ctx.recipe_build_order:
+	    return env
+
+        api_ver = self.ctx.android_api
+
+        flags = " -L{ctx.ndk_dir}/sources/python/3.5/libs/{arch}/"\
+                            .format(ctx=self.ctx, arch=arch.arch)
+        env['LDFLAGS'] += flags
+
+        return env
+
 
 recipe = CymunkRecipe()


### PR DESCRIPTION
I noticed that cython fails with error mentioned in #1184 , but workaround is to build kivy first, which copy libpython3.5m.so to .buildozer, and then add cython to requirements. 

Solution is, to add NDK path to -L path for compiler/linker. So I did it. 