### PR TITLE
Fix for Mac OS version bug

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -350,7 +350,8 @@ main.py that loads it.''')
     sdk_dir = sdk_dir[8:]
 
     # Try to build with the newest available build tools
-    build_tools_versions = listdir(join(sdk_dir, 'build-tools'))
+    ignored = {".DS_Store", ".ds_store"}
+    build_tools_versions = [x for x in listdir(join(sdk_dir, 'build-tools')) if x not in ignored]
     build_tools_versions = sorted(build_tools_versions,
                                   key=LooseVersion)
     build_tools_version = build_tools_versions[-1]


### PR DESCRIPTION
ignores .DS_Store files while comparing build-tools versions

