### PR TITLE
Defaults to latest kivy==1.10.1 release, fixes #1328

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -6,13 +6,11 @@ import glob
 
 
 class KivyRecipe(CythonRecipe):
-    version = '1.10.0'
+    version = '1.10.1'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 
     depends = [('sdl2', 'pygame'), 'pyjnius']
-
-    # patches = ['setargv.patch']
 
     def cythonize_build(self, env, build_dir='.'):
         super(KivyRecipe, self).cythonize_build(env, build_dir=build_dir)


### PR DESCRIPTION
Kivy 1.10.1 was released recently. This minor change makes sure p4a picks up the latest stable kivy version by default.
Fixes #1328 and may also fix #1219 and https://github.com/kivy/buildozer/issues/697