### PR TITLE
Use zip instead of tar.gz to obtain setuptools

### DIFF
--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -3,7 +3,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 class SetuptoolsRecipe(PythonRecipe):
     version = '18.3.1'
-    url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.tar.gz'
+    url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
 
     depends = [('python2', 'python3crystax')]
 


### PR DESCRIPTION
Newer releases of setuptools on pypi are only available as zip archives.

In order to support higher versions of setuptools, zip should be
preferred over tar.gz. Otherwise, installing e.g. setuptools==40.0.0
will fail.