### PR TITLE
Add Pillow Recipe

### DIFF
--- a/pythonforandroid/recipes/Pillow/__init__.py
+++ b/pythonforandroid/recipes/Pillow/__init__.py
@@ -1,0 +1,72 @@
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from pythonforandroid.toolchain import shprint
+from os.path import join, dirname
+import sh
+
+
+class PillowRecipe(CompiledComponentsPythonRecipe):
+
+    version = '5.2.0'
+    url = 'https://github.com/python-pillow/Pillow/archive/{version}.tar.gz'
+    site_packages_name = 'Pillow'
+    depends = [
+        ('python2', 'python3crystax'),
+        'png',
+        'jpeg',
+        'freetype',
+        'setuptools'
+    ]
+    patches = [
+        join('patches', 'fix-docstring.patch'),
+        join('patches', 'fix-setup.patch')
+    ]
+
+    call_hostpython_via_targetpython = False
+
+    def get_recipe_env(self, arch=None):
+        env = super(PillowRecipe, self).get_recipe_env(arch)
+        py_ver = self.ctx.python_recipe.version[0:3]
+
+        ndk_dir = self.ctx.ndk_platform
+        ndk_lib_dir = join(ndk_dir, 'usr', 'lib')
+        ndk_include_dir = (join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+            if py_ver == '2.7' else join(ndk_dir, 'usr', 'include'))
+
+        png = self.get_recipe('png', self.ctx)
+        png_lib_dir = png.get_lib_dir(arch)
+        png_jni_dir = png.get_jni_dir(arch)
+
+        jpeg = self.get_recipe('jpeg', self.ctx)
+        jpeg_lib_dir = jpeg.get_lib_dir(arch)
+        jpeg_jni_dir = jpeg.get_jni_dir(arch)
+
+        env['JPEG_ROOT'] = '{}|{}'.format(jpeg_lib_dir, jpeg_jni_dir)
+        env['ZLIB_ROOT'] = '{}|{}'.format(ndk_lib_dir, ndk_include_dir)
+
+        cflags = ' -nostdinc'
+        cflags += ' -I{} -L{}'.format(png_jni_dir, png_lib_dir)
+        cflags += ' -I{} -L{}'.format(jpeg_jni_dir, jpeg_lib_dir)
+        cflags += ' -I{} -L{}'.format(ndk_include_dir, ndk_lib_dir)
+
+        gcc_lib = (shprint(sh.gcc, '-print-libgcc-file-name')
+            .stdout.decode('utf-8').split('\n')[0])
+        gcc_include = join(dirname(gcc_lib), 'include')
+        cflags += ' -I{}'.format(gcc_include)
+
+        if self.ctx.ndk == 'crystax':
+            py_inc_dir = join(self.ctx.ndk_dir, 'sources', 'python', py_ver,
+                'include', 'python')
+            py_lib_dir = join(self.ctx.ndk_dir, 'sources', 'python', py_ver,
+                'libs', arch.arch)
+            cflags += ' -I{}'.format(py_inc_dir)
+            env['LDFLAGS'] += ' -L{} -lpython{}m'.format(py_lib_dir, py_ver)
+
+        env['LDFLAGS'] += ' {} -L{}'.format(env['CFLAGS'], self.ctx.libs_dir)
+        if cflags not in env['CFLAGS']:
+            env['CFLAGS'] += cflags
+        env['LDSHARED'] = '{} {}'.format(env['CC'],
+            '-pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions')
+        return env
+
+
+recipe = PillowRecipe()

--- a/pythonforandroid/recipes/Pillow/patches/fix-docstring.patch
+++ b/pythonforandroid/recipes/Pillow/patches/fix-docstring.patch
@@ -1,0 +1,13 @@
+diff --git a/src/PIL/__init__.py b/src/PIL/__init__.py
+index a07280e..6b9fe99 100644
+--- a/src/PIL/__init__.py
++++ b/src/PIL/__init__.py
+@@ -24,7 +24,7 @@ PILLOW_VERSION = __version__ = _version.__version__
+ 
+ del _version
+ 
+-__doc__ = __doc__.format(__version__)  # include version in docstring
++__doc__ = ''
+ 
+ 
+ _plugins = ['BlpImagePlugin',

--- a/pythonforandroid/recipes/Pillow/patches/fix-setup.patch
+++ b/pythonforandroid/recipes/Pillow/patches/fix-setup.patch
@@ -1,0 +1,148 @@
+diff --git a/setup.py b/setup.py
+index 761d552..4ddc598 100755
+--- a/setup.py
++++ b/setup.py
+@@ -136,12 +136,12 @@ except (ImportError, OSError):
+ 
+ NAME = 'Pillow'
+ PILLOW_VERSION = get_version()
+-JPEG_ROOT = None
++JPEG_ROOT = tuple(os.environ['JPEG_ROOT'].split('|')) if 'JPEG_ROOT' in os.environ else None
+ JPEG2K_ROOT = None
+-ZLIB_ROOT = None
++ZLIB_ROOT = tuple(os.environ['ZLIB_ROOT'].split('|')) if 'ZLIB_ROOT' in os.environ else None
+ IMAGEQUANT_ROOT = None
+ TIFF_ROOT = None
+-FREETYPE_ROOT = None
++FREETYPE_ROOT = tuple(os.environ['FREETYPE_ROOT'].split('|')) if 'FREETYPE_ROOT' in os.environ else None
+ LCMS_ROOT = None
+ 
+ 
+@@ -194,7 +194,7 @@ class pil_build_ext(build_ext):
+     ]
+ 
+     def initialize_options(self):
+-        self.disable_platform_guessing = None
++        self.disable_platform_guessing = True
+         build_ext.initialize_options(self)
+         for x in self.feature:
+             setattr(self, 'disable_%s' % x, None)
+@@ -466,61 +466,6 @@ class pil_build_ext(build_ext):
+                     feature.jpeg = "libjpeg"  # alternative name
+ 
+         feature.openjpeg_version = None
+-        if feature.want('jpeg2000'):
+-            _dbg('Looking for jpeg2000')
+-            best_version = None
+-            best_path = None
+-
+-            # Find the best version
+-            for directory in self.compiler.include_dirs:
+-                _dbg('Checking for openjpeg-#.# in %s', directory)
+-                try:
+-                    listdir = os.listdir(directory)
+-                except Exception:
+-                    # WindowsError, FileNotFoundError
+-                    continue
+-                for name in listdir:
+-                    if name.startswith('openjpeg-') and \
+-                        os.path.isfile(os.path.join(directory, name,
+-                                                    'openjpeg.h')):
+-                        _dbg('Found openjpeg.h in %s/%s', (directory, name))
+-                        version = tuple(int(x) for x in name[9:].split('.'))
+-                        if best_version is None or version > best_version:
+-                            best_version = version
+-                            best_path = os.path.join(directory, name)
+-                            _dbg('Best openjpeg version %s so far in %s',
+-                                 (best_version, best_path))
+-
+-            if best_version and _find_library_file(self, 'openjp2'):
+-                # Add the directory to the include path so we can include
+-                # <openjpeg.h> rather than having to cope with the versioned
+-                # include path
+-                # FIXME (melvyn-sopacua):
+-                # At this point it's possible that best_path is already in
+-                # self.compiler.include_dirs. Should investigate how that is
+-                # possible.
+-                _add_directory(self.compiler.include_dirs, best_path, 0)
+-                feature.jpeg2000 = 'openjp2'
+-                feature.openjpeg_version = '.'.join(str(x) for x in best_version)
+-
+-        if feature.want('imagequant'):
+-            _dbg('Looking for imagequant')
+-            if _find_include_file(self, 'libimagequant.h'):
+-                if _find_library_file(self, "imagequant"):
+-                    feature.imagequant = "imagequant"
+-                elif _find_library_file(self, "libimagequant"):
+-                    feature.imagequant = "libimagequant"
+-
+-        if feature.want('tiff'):
+-            _dbg('Looking for tiff')
+-            if _find_include_file(self, 'tiff.h'):
+-                if _find_library_file(self, "tiff"):
+-                    feature.tiff = "tiff"
+-                if sys.platform == "win32" and _find_library_file(self, "libtiff"):
+-                    feature.tiff = "libtiff"
+-                if (sys.platform == "darwin" and
+-                        _find_library_file(self, "libtiff")):
+-                    feature.tiff = "libtiff"
+ 
+         if feature.want('freetype'):
+             _dbg('Looking for freetype')
+@@ -546,36 +491,6 @@ class pil_build_ext(build_ext):
+                     if subdir:
+                         _add_directory(self.compiler.include_dirs, subdir, 0)
+ 
+-        if feature.want('lcms'):
+-            _dbg('Looking for lcms')
+-            if _find_include_file(self, "lcms2.h"):
+-                if _find_library_file(self, "lcms2"):
+-                    feature.lcms = "lcms2"
+-                elif _find_library_file(self, "lcms2_static"):
+-                    # alternate Windows name.
+-                    feature.lcms = "lcms2_static"
+-
+-        if feature.want('webp'):
+-            _dbg('Looking for webp')
+-            if (_find_include_file(self, "webp/encode.h") and
+-                    _find_include_file(self, "webp/decode.h")):
+-                # In Google's precompiled zip it is call "libwebp":
+-                if _find_library_file(self, "webp"):
+-                    feature.webp = "webp"
+-                elif _find_library_file(self, "libwebp"):
+-                    feature.webp = "libwebp"
+-
+-        if feature.want('webpmux'):
+-            _dbg('Looking for webpmux')
+-            if (_find_include_file(self, "webp/mux.h") and
+-                    _find_include_file(self, "webp/demux.h")):
+-                if (_find_library_file(self, "webpmux") and
+-                        _find_library_file(self, "webpdemux")):
+-                    feature.webpmux = "webpmux"
+-                if (_find_library_file(self, "libwebpmux") and
+-                        _find_library_file(self, "libwebpdemux")):
+-                    feature.webpmux = "libwebpmux"
+-
+         for f in feature:
+             if not getattr(feature, f) and feature.require(f):
+                 if f in ('jpeg', 'zlib'):
+@@ -612,8 +527,6 @@ class pil_build_ext(build_ext):
+             defs.append(("HAVE_LIBTIFF", None))
+         if sys.platform == "win32":
+             libs.extend(["kernel32", "user32", "gdi32"])
+-        if struct.unpack("h", "\0\1".encode('ascii'))[0] == 1:
+-            defs.append(("WORDS_BIGENDIAN", None))
+ 
+         if sys.platform == "win32" and not (PLATFORM_PYPY or PLATFORM_MINGW):
+             defs.append(("PILLOW_VERSION", '"\\"%s\\""' % PILLOW_VERSION))
+@@ -658,10 +571,6 @@ class pil_build_ext(build_ext):
+                                   define_macros=defs))
+ 
+         tk_libs = ['psapi'] if sys.platform == 'win32' else []
+-        exts.append(Extension("PIL._imagingtk",
+-                              ["src/_imagingtk.c", "src/Tk/tkImaging.c"],
+-                              include_dirs=['src/Tk'],
+-                              libraries=tk_libs))
+ 
+         exts.append(Extension("PIL._imagingmath", ["src/_imagingmath.c"]))
+         exts.append(Extension("PIL._imagingmorph", ["src/_imagingmorph.c"]))

--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class SetuptoolsRecipe(PythonRecipe):
-    version = '18.3.1'
+    version = '40.0.0'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
 
     depends = [('python2', 'python3crystax')]


### PR DESCRIPTION
This patch adds a new recipe for Pillow. There already is a recipe for PIL, but PIL does not support python3.

This new recipe should work with `python3crystax` as well as with `python2`. However, with `python2`, there are the following issues:

- The existing recipe for `setuptools` provides an older version of `setuptools`, which is too old for Pillow. This can be circumvented by specifying `setuptools==40.0.0` when building an APK. I am not sure if it is possible to specify a minimum version for dependencies inside recipes.
- There seems to be an issue with the `jpeg` recipe which requires `libcutils`. I resolved it locally by removing `libcutils` from  `pythonforandroid/recipes/jpeg/build-static.patch`.

With `python3crystax`, there should be no issues.

This PR addresses #1114 and #1326.