### PR TITLE
Added code style exception for android module * import

### DIFF
--- a/pythonforandroid/recipes/android/src/android/__init__.py
+++ b/pythonforandroid/recipes/android/src/android/__init__.py
@@ -5,4 +5,4 @@ Android module
 '''
 
 # legacy import
-from android._android import *
+from android._android import *  # noqa: F401


### PR DESCRIPTION
It would be better to add explicit imports, but fixing the tests is fine for now. The android module is mostly legacy stuff that would be better restructured entirely if it were actively developed.