### PR TITLE
Add recipes for OpenAL support

### DIFF
--- a/pythonforandroid/recipes/libogg/__init__.py
+++ b/pythonforandroid/recipes/libogg/__init__.py
@@ -1,0 +1,26 @@
+from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.toolchain import current_directory, shprint
+from os.path import join
+import sh
+
+
+class OggRecipe(NDKRecipe):
+    version = '1.3.3'
+    url = 'http://downloads.xiph.org/releases/ogg/libogg-{version}.tar.gz'
+
+    generated_libraries = ['libogg.so']
+
+    def build_arch(self, arch):
+        with current_directory(self.get_build_dir(arch.arch)):
+            env = self.get_recipe_env(arch)
+            flags = [
+                '--with-sysroot=' + self.ctx.ndk_platform,
+                '--host=' + arch.toolchain_prefix,
+            ]
+            configure = sh.Command('./configure')
+            shprint(configure, *flags, _env=env)
+            shprint(sh.make, _env=env)
+            self.install_libs(arch, join('src', '.libs', 'libogg.so'))
+
+
+recipe = OggRecipe()

--- a/pythonforandroid/recipes/libvorbis/__init__.py
+++ b/pythonforandroid/recipes/libvorbis/__init__.py
@@ -1,0 +1,37 @@
+from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.toolchain import current_directory, shprint
+from os.path import join
+import sh
+
+
+class VorbisRecipe(NDKRecipe):
+    version = '1.3.6'
+    url = 'http://downloads.xiph.org/releases/vorbis/libvorbis-{version}.tar.gz'
+    opt_depends = ['libogg']
+
+    generated_libraries = ['libvorbis.so', 'libvorbisfile.so', 'libvorbisenc.so']
+
+    def get_recipe_env(self, arch=None):
+        env = super(VorbisRecipe, self).get_recipe_env(arch)
+        ogg = self.get_recipe('libogg', self.ctx)
+        env['CFLAGS'] += ' -I{}'.format(join(ogg.get_build_dir(arch.arch), 'include'))
+        return env
+
+    def build_arch(self, arch):
+        with current_directory(self.get_build_dir(arch.arch)):
+            env = self.get_recipe_env(arch)
+            flags = [
+                '--with-sysroot=' + self.ctx.ndk_platform,
+                '--host=' + arch.toolchain_prefix,
+            ]
+            configure = sh.Command('./configure')
+            shprint(configure, *flags, _env=env)
+            shprint(sh.make, _env=env)
+            self.install_libs(arch,
+                join('lib', '.libs', 'libvorbis.so'),
+                join('lib', '.libs', 'libvorbisfile.so'),
+                join('lib', '.libs', 'libvorbisenc.so')
+            )
+
+
+recipe = VorbisRecipe()

--- a/pythonforandroid/recipes/openal/__init__.py
+++ b/pythonforandroid/recipes/openal/__init__.py
@@ -1,0 +1,39 @@
+from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.toolchain import current_directory, shprint
+from os.path import join
+import os
+import sh
+
+
+class OpenALRecipe(NDKRecipe):
+    version = '1.18.2'
+    url = 'https://github.com/kcat/openal-soft/archive/openal-soft-{version}.tar.gz'
+
+    generated_libraries = ['libopenal.so']
+
+    def prebuild_arch(self, arch):
+        # we need to build native tools for host system architecture
+        with current_directory(join(self.get_build_dir(arch.arch), 'native-tools')):
+            shprint(sh.cmake, '.', _env=os.environ)
+            shprint(sh.make, _env=os.environ)
+
+    def build_arch(self, arch):
+        with current_directory(self.get_build_dir(arch.arch)):
+            env = self.get_recipe_env(arch)
+            cmake_args = [
+                '-DCMAKE_TOOLCHAIN_FILE={}'.format('XCompile-Android.txt'),
+                '-DHOST={}'.format(self.ctx.toolchain_prefix)
+            ]
+            if self.ctx.ndk == 'crystax':
+                # avoids a segfault in libcrystax when calling lrintf
+                cmake_args += ['-DHAVE_LRINTF=0']
+            shprint(
+                sh.cmake, '.',
+                *cmake_args,
+                _env=env
+            )
+            shprint(sh.make, _env=env)
+            self.install_libs(arch, 'libopenal.so')
+
+
+recipe = OpenALRecipe()

--- a/pythonforandroid/recipes/pyogg/__init__.py
+++ b/pythonforandroid/recipes/pyogg/__init__.py
@@ -1,0 +1,14 @@
+from pythonforandroid.recipe import PythonRecipe
+from os.path import join
+
+
+class PyOggRecipe(PythonRecipe):
+    version = '0.6.4a1'
+    url = 'https://files.pythonhosted.org/packages/source/p/pyogg/PyOgg-{version}.tar.gz'
+    depends = [('python2', 'python3crystax'), 'libogg', 'libvorbis', 'setuptools']
+    patches = [join('patches', 'fix-find-lib.patch')]
+
+    call_hostpython_via_targetpython = False
+
+
+recipe = PyOggRecipe()

--- a/pythonforandroid/recipes/pyogg/patches/fix-find-lib.patch
+++ b/pythonforandroid/recipes/pyogg/patches/fix-find-lib.patch
@@ -1,0 +1,13 @@
+diff --git a/pyogg/library_loader.py b/pyogg/library_loader.py
+index c2ba36c..383331a 100644
+--- a/pyogg/library_loader.py
++++ b/pyogg/library_loader.py
+@@ -54,7 +54,7 @@ def load_other(name, paths = None):
+                     except:
+                         pass
+     else:
+-        for path in [os.getcwd(), _here]:
++        for path in [os.path.join(os.environ['ANDROID_PRIVATE'], '..', 'lib')]:
+             for style in other_styles:
+                 candidate = os.path.join(path, style.format(name))
+                 if os.path.exists(candidate):

--- a/pythonforandroid/recipes/pyopenal/__init__.py
+++ b/pythonforandroid/recipes/pyopenal/__init__.py
@@ -1,0 +1,14 @@
+from pythonforandroid.recipe import PythonRecipe
+from os.path import join
+
+
+class PyOpenALRecipe(PythonRecipe):
+    version = '0.7.3a1'
+    url = 'https://files.pythonhosted.org/packages/source/p/pyopenal/PyOpenAL-{version}.tar.gz'
+    depends = [('python2', 'python3crystax'), 'openal', 'numpy', 'setuptools']
+    patches = [join('patches', 'fix-find-lib.patch')]
+
+    call_hostpython_via_targetpython = False
+
+
+recipe = PyOpenALRecipe()

--- a/pythonforandroid/recipes/pyopenal/patches/fix-find-lib.patch
+++ b/pythonforandroid/recipes/pyopenal/patches/fix-find-lib.patch
@@ -1,0 +1,13 @@
+diff --git a/openal/library_loader.py b/openal/library_loader.py
+index be2485c..e8c6cd2 100644
+--- a/openal/library_loader.py
++++ b/openal/library_loader.py
+@@ -56,7 +56,7 @@ class ExternalLibrary:
+                         except:
+                             pass
+         else:
+-            for path in [os.getcwd(), _here]:
++            for path in [os.path.join(os.environ['ANDROID_PRIVATE'], '..', 'lib')]:
+                 for style in ExternalLibrary.other_styles:
+                     candidate = os.path.join(path, style.format(name))
+                     if os.path.exists(candidate) and os.path.isfile(candidate):


### PR DESCRIPTION
This PR adds recipes for PyOpenAL, OpenAL Soft, PyOgg, libvorbis, and libogg.

Note: A working numpy recipe is needed. So for testing with python3, you also need to pull in #1343.