### PR TITLE
Fix segfault on hostpython2 when compiling for x86_64

### DIFF
--- a/pythonforandroid/recipes/hostpython2/__init__.py
+++ b/pythonforandroid/recipes/hostpython2/__init__.py
@@ -10,6 +10,7 @@ class Hostpython2Recipe(Recipe):
     version = '2.7.2'
     url = 'https://python.org/ftp/python/{version}/Python-{version}.tar.bz2'
     name = 'hostpython2'
+    patches = ['fix-segfault-pygchead.patch']
 
     conflicts = ['hostpython3']
 

--- a/pythonforandroid/recipes/hostpython2/fix-segfault-pygchead.patch
+++ b/pythonforandroid/recipes/hostpython2/fix-segfault-pygchead.patch
@@ -1,0 +1,12 @@
+diff -Naur Python-2.7.2.orig/Include/objimpl.h Python-2.7.2/Include/objimpl.h
+--- Python-2.7.2.orig/Include/objimpl.h	2011-06-11 17:46:23.000000000 +0200
++++ Python-2.7.2/Include/objimpl.h	2018-09-04 17:33:09.254654565 +0200
+@@ -255,7 +255,7 @@
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    long double dummy;  /* force worst-case alignment */
++    double dummy;  /* force worst-case alignment */
+ } PyGC_Head;
+ 
+ extern PyGC_Head *_PyGC_generation0;


### PR DESCRIPTION
This is a fixes for #1297 - on some platform, Python < 2.7.15 crashes due to a bug highlighted only with recent compilers.

This one liner came from https://github.com/python/cpython/commit/e348c8d154cf6342c79d627ebfe89dfe9de23817#diff-fb41bdaf12f733cf6ab8a82677d03adc that contains a extensive explaination about it. It could be done on Python 2 for ARM, but the bug isn't triggered at the moment.

I compiled a fresh app with this patch, it doesn't segfault during the compilation of hostpython2, and the app on Android runs.

(I talked about moving to Python 2.7.15, but it would take more time that just accepting this patch, as we would need to update hostpython2 and python2 recipes, and all cross compilation patches. Plus more testing as ssl module changed somewhere, unsure if we don't need more patching to make it work.)

Closes #1297