### PR TITLE
Fix LDSHARED and missing CFLAGS include path for python3crystax sources

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -112,8 +112,12 @@ class Arch(object):
         env['AR'] = '{}-ar'.format(command_prefix)
         env['RANLIB'] = '{}-ranlib'.format(command_prefix)
         env['LD'] = '{}-ld'.format(command_prefix)
-        # env['LDSHARED'] = join(self.ctx.root_dir, 'tools', 'liblink')
-        # env['LDSHARED'] = env['LD']
+        env['LDSHARED'] = env["CC"] + " -pthread -shared " +\
+            "-Wl,-O1 -Wl,-Bsymbolic-functions "
+        if self.ctx.python_recipe and self.ctx.python_recipe.from_crystax:
+            # For crystax python, we can't use the host python headers:
+            env["CFLAGS"] += ' -I{}/sources/python/{}/include/python/'.\
+                format(self.ctx.ndk_dir, self.ctx.python_recipe.version[0:3])
         env['STRIP'] = '{}-strip --strip-unneeded'.format(command_prefix)
         env['MAKE'] = 'make -j5'
         env['READELF'] = '{}-readelf'.format(command_prefix)


### PR DESCRIPTION
As proposed in #1360 this change fixes `env["LDSHARED"]` not being set which can confuse distutils / `python setup.py build_ext` to use the incorrect host compiler, and it adds the `-I` folder to the python3 crystax sources when using python 3 crystax. This should allow a lot of recipes to be cleaned up later which currently have the same repeated hacks to work around this. (Uncleaned recipes should just duplicate include paths which should do no harm, so this shouldn't require any recipes to be changed to be safely merged)

**Testing state**:
- tested with python3crystax *without kivy* (but with `Pillow` recipe)
- **not tested** with python 2
- **not tested** with other recipes