### PR TITLE
Fix jpeg build for newer NDKs

### DIFF
--- a/pythonforandroid/recipes/jpeg/Application.mk
+++ b/pythonforandroid/recipes/jpeg/Application.mk
@@ -1,3 +1,4 @@
 APP_OPTIM := release
 APP_ABI := all # or armeabi
 APP_MODULES := libjpeg
+APP_ALLOW_MISSING_DEPS := true


### PR DESCRIPTION
Otherwise it throws with an error message about cjpeg depending on undefined dependency cutils when using newer ndk (r15)