### PR TITLE
Adds issue template with basic required info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+The issue tracker is a tool to address bugs.
+Please use the #kivy IRC channel on freenode or Stack Overflow for
+support questions, more information at https://github.com/kivy/python-for-android#support
+
+Before opening a new issue, make sure you do the following:
+    * check that your issue isn't already filed: https://github.com/kivy/python-for-android/issues
+    * prepare a short, runnable example that reproduces the issue
+    * make sure to have `log_level = 2` in your `buildozer.spec`
+    * reproduce the problem with the latest development version (`p4a.branch = master`)
+    * double-check that the issue is indeed a bug and not a support request
+    * please use backticks to format code or logs
+-->
+
+### Versions
+
+* Python:
+* OS:
+* Kivy:
+* Cython:
+
+### Description
+
+// REPLACE ME: What are you trying to get done, what has happened, what went wrong, and what did you expect?
+
+### buildozer.spec
+
+Command:
+```sh
+// REPLACE ME: buildozer command ran? e.g. buildozer android debug
+```
+
+Spec file:
+```
+// REPLACE ME: Paste your buildozer.spec file here
+```
+
+### Logs
+
+```
+// REPLACE ME: Paste the build ouput containing the error
+```


### PR DESCRIPTION
The same way we did on buildozer project (https://github.com/kivy/buildozer/pull/688).
See what it looks like on my fork:
https://github.com/AndreMiras/python-for-android/issues/new