### PR TITLE
Sets default service pythonName, fixes #1049

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/src/org/renpy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/pygame/build/src/org/renpy/android/PythonActivity.java
@@ -351,6 +351,7 @@ public class PythonActivity extends Activity implements Runnable {
         String filesDirectory = PythonActivity.mActivity.mPath.getAbsolutePath();
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", filesDirectory);
+        serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", argument);
         serviceIntent.putExtra("pythonPath", argument + ":" + filesDirectory + "/lib");
         serviceIntent.putExtra("serviceTitle", serviceTitle);

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -350,6 +350,7 @@ public class PythonActivity extends SDLActivity {
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", app_root_dir);
         serviceIntent.putExtra("serviceEntrypoint", "service/main.pyo");
+        serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
         serviceIntent.putExtra("serviceTitle", serviceTitle);

--- a/pythonforandroid/bootstraps/webview/build/src/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/org/kivy/android/PythonActivity.java
@@ -405,6 +405,7 @@ public class PythonActivity extends Activity {
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", argument);
         serviceIntent.putExtra("serviceEntrypoint", "service/main.pyo");
+        serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", argument);
         serviceIntent.putExtra("pythonPath", argument + ":" + filesDirectory + "/lib");
         serviceIntent.putExtra("serviceTitle", serviceTitle);


### PR DESCRIPTION
In https://github.com/kivy/python-for-android/pull/609 `PYTHON_NAME` was
being used while potentially null (in the case of basic service folder
method), leading to segfault on `setenv()` call.