### PR TITLE
Proof of concept for Python 3 without CrystaX, plus API 27 support

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -133,6 +133,8 @@ class Arch(object):
         if self.ctx.python_recipe and self.ctx.python_recipe.from_crystax:
             env['CRYSTAX_PYTHON_VERSION'] = self.ctx.python_recipe.version
 
+        env['TARGET_ANDROID_API'] = str(self.ctx.ndk_target_api)
+
         return env
 
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -245,7 +245,7 @@ class Bootstrap(object):
 
     def strip_libraries(self, arch):
         info('Stripping libraries')
-        if self.ctx.python_recipe.from_crystax:
+        if self.ctx.python_recipe.from_crystax or True:
             info('Python was loaded from CrystaX, skipping strip')
             return
         env = arch.get_env()

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -1,6 +1,7 @@
 from pythonforandroid.toolchain import (
     Bootstrap, shprint, current_directory, info, info_main)
 from pythonforandroid.util import ensure_dir
+from pythonforandroid.recipe import Recipe
 from os.path import join, exists, curdir, abspath
 from os import walk
 import glob
@@ -13,7 +14,7 @@ EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 class SDL2GradleBootstrap(Bootstrap):
     name = 'sdl2_gradle'
 
-    recipe_depends = ['sdl2', ('python2', 'python3crystax')]
+    recipe_depends = ['sdl2', ('python2', 'python3crystax', 'python3')]
 
     def run_distribute(self):
         info_main("# Creating Android project ({})".format(self.name))
@@ -39,8 +40,8 @@ class SDL2GradleBootstrap(Bootstrap):
         with current_directory(self.dist_dir):
             info("Copying Python distribution")
 
-            if not exists("private") and not from_crystax:
-                ensure_dir("private")
+            # if not exists("private") and not from_crystax:
+            #     ensure_dir("private")
             if not exists("crystax_python") and from_crystax:
                 ensure_dir(crystax_python_dir)
 
@@ -52,84 +53,113 @@ class SDL2GradleBootstrap(Bootstrap):
                             _tail=10, _filterout="^Listing")
                 except sh.ErrorReturnCode:
                     pass
-                if not exists('python-install'):
-                    shprint(
-                        sh.cp, '-a', python_install_dir, './python-install')
+                # if not exists('python-install'):
+                #     shprint(
+                #         sh.cp, '-a', python_install_dir, './python-install')
 
             self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
             self.distribute_javaclasses(self.ctx.javaclass_dir,
                                         dest_dir=join("src", "main", "java"))
 
-            if not from_crystax:
-                info("Filling private directory")
-                if not exists(join("private", "lib")):
-                    info("private/lib does not exist, making")
-                    shprint(sh.cp, "-a",
-                            join("python-install", "lib"), "private")
-                shprint(sh.mkdir, "-p",
-                        join("private", "include", "python2.7"))
+            # if not from_crystax:
+            #     info("Filling private directory")
+            #     if not exists(join("private", "lib")):
+            #         info("private/lib does not exist, making")
+            #         shprint(sh.cp, "-a",
+            #                 join("python-install", "lib"), "private")
+            #     shprint(sh.mkdir, "-p",
+            #             join("private", "include", "python2.7"))
 
-                libpymodules_fn = join("libs", arch.arch, "libpymodules.so")
-                if exists(libpymodules_fn):
-                    shprint(sh.mv, libpymodules_fn, 'private/')
-                shprint(sh.cp,
-                        join('python-install', 'include',
-                             'python2.7', 'pyconfig.h'),
-                        join('private', 'include', 'python2.7/'))
+            #     libpymodules_fn = join("libs", arch.arch, "libpymodules.so")
+            #     if exists(libpymodules_fn):
+            #         shprint(sh.mv, libpymodules_fn, 'private/')
+            #     shprint(sh.cp,
+            #             join('python-install', 'include',
+            #                  'python2.7', 'pyconfig.h'),
+            #             join('private', 'include', 'python2.7/'))
 
-                info('Removing some unwanted files')
-                shprint(sh.rm, '-f', join('private', 'lib', 'libpython2.7.so'))
-                shprint(sh.rm, '-rf', join('private', 'lib', 'pkgconfig'))
+            #     info('Removing some unwanted files')
+            #     shprint(sh.rm, '-f', join('private', 'lib', 'libpython2.7.so'))
+            #     shprint(sh.rm, '-rf', join('private', 'lib', 'pkgconfig'))
 
-                libdir = join(self.dist_dir, 'private', 'lib', 'python2.7')
-                site_packages_dir = join(libdir, 'site-packages')
-                with current_directory(libdir):
-                    removes = []
-                    for dirname, root, filenames in walk("."):
-                        for filename in filenames:
-                            for suffix in EXCLUDE_EXTS:
-                                if filename.endswith(suffix):
-                                    removes.append(filename)
-                    shprint(sh.rm, '-f', *removes)
+            #     libdir = join(self.dist_dir, 'private', 'lib', 'python2.7')
+            #     site_packages_dir = join(libdir, 'site-packages')
+            #     with current_directory(libdir):
+            #         removes = []
+            #         for dirname, root, filenames in walk("."):
+            #             for filename in filenames:
+            #                 for suffix in EXCLUDE_EXTS:
+            #                     if filename.endswith(suffix):
+            #                         removes.append(filename)
+            #         shprint(sh.rm, '-f', *removes)
 
-                    info('Deleting some other stuff not used on android')
-                    # To quote the original distribute.sh, 'well...'
-                    shprint(sh.rm, '-rf', 'lib2to3')
-                    shprint(sh.rm, '-rf', 'idlelib')
-                    for filename in glob.glob('config/libpython*.a'):
-                        shprint(sh.rm, '-f', filename)
-                    shprint(sh.rm, '-rf', 'config/python.o')
+            #         info('Deleting some other stuff not used on android')
+            #         # To quote the original distribute.sh, 'well...'
+            #         shprint(sh.rm, '-rf', 'lib2to3')
+            #         shprint(sh.rm, '-rf', 'idlelib')
+            #         for filename in glob.glob('config/libpython*.a'):
+            #             shprint(sh.rm, '-f', filename)
+            #         shprint(sh.rm, '-rf', 'config/python.o')
 
-            else:  # Python *is* loaded from crystax
-                ndk_dir = self.ctx.ndk_dir
-                py_recipe = self.ctx.python_recipe
-                python_dir = join(ndk_dir, 'sources', 'python',
-                                  py_recipe.version, 'libs', arch.arch)
-                shprint(sh.cp, '-r', join(python_dir,
-                                          'stdlib.zip'), crystax_python_dir)
-                shprint(sh.cp, '-r', join(python_dir,
-                                          'modules'), crystax_python_dir)
-                shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
-                        join(crystax_python_dir, 'site-packages'))
+            # else:  # Python *is* loaded from crystax
+            #     ndk_dir = self.ctx.ndk_dir
+            #     py_recipe = self.ctx.python_recipe
+            #     python_dir = join(ndk_dir, 'sources', 'python',
+            #                       py_recipe.version, 'libs', arch.arch)
+            #     shprint(sh.cp, '-r', join(python_dir,
+            #                               'stdlib.zip'), crystax_python_dir)
+            #     shprint(sh.cp, '-r', join(python_dir,
+            #                               'modules'), crystax_python_dir)
+            #     shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
+            #             join(crystax_python_dir, 'site-packages'))
 
-                info('Renaming .so files to reflect cross-compile')
-                site_packages_dir = join(crystax_python_dir, "site-packages")
-                find_ret = shprint(
-                    sh.find, site_packages_dir, '-iname', '*.so')
-                filenames = find_ret.stdout.decode('utf-8').split('\n')[:-1]
-                for filename in filenames:
-                    parts = filename.split('.')
-                    if len(parts) <= 2:
-                        continue
-                    shprint(sh.mv, filename, filename.split('.')[0] + '.so')
-                site_packages_dir = join(abspath(curdir),
-                                         site_packages_dir)
+            #     info('Renaming .so files to reflect cross-compile')
+            #     site_packages_dir = join(crystax_python_dir, "site-packages")
+            #     find_ret = shprint(
+            #         sh.find, site_packages_dir, '-iname', '*.so')
+            #     filenames = find_ret.stdout.decode('utf-8').split('\n')[:-1]
+            #     for filename in filenames:
+            #         parts = filename.split('.')
+            #         if len(parts) <= 2:
+            #             continue
+            #         shprint(sh.mv, filename, filename.split('.')[0] + '.so')
+            #     site_packages_dir = join(abspath(curdir),
+            #                              site_packages_dir)
+            # if 'sqlite3' not in self.ctx.recipe_build_order:
+            #     with open('blacklist.txt', 'a') as fileh:
+            #         fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
+
+            ndk_dir = self.ctx.ndk_dir
+            py_recipe = self.ctx.python_recipe
+            shprint(sh.cp, '-r', '/home/sandy/crystax_python', 'crystax_python')
+            shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
+                    join(crystax_python_dir, 'site-packages'))
+
+            python3_build_dir = join(Recipe.get_recipe('python3', self.ctx).get_build_dir(arch.arch),
+                                     'Android', 'build',
+                                     'python3.7-android-{}-armv7'.format(self.ctx.android_api))
+            shprint(sh.cp, join(python3_build_dir, 'libpython3.7m.so'), 'libs/{}'.format(arch.arch))
+            shprint(sh.cp, join(python3_build_dir, 'libpython3.7m.so.1.0'), 'libs/{}'.format(arch.arch))
+
+            info('Renaming .so files to reflect cross-compile')
+            site_packages_dir = join(crystax_python_dir, "site-packages")
+            find_ret = shprint(
+                sh.find, site_packages_dir, '-iname', '*.so')
+            filenames = find_ret.stdout.decode('utf-8').split('\n')[:-1]
+            for filename in filenames:
+                parts = filename.split('.')
+                if len(parts) <= 2:
+                    continue
+                shprint(sh.mv, filename, filename.split('.')[0] + '.so')
+            site_packages_dir = join(abspath(curdir),
+                                        site_packages_dir)
+
             if 'sqlite3' not in self.ctx.recipe_build_order:
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
         self.strip_libraries(arch)
-        self.fry_eggs(site_packages_dir)
+        # self.fry_eggs(site_packages_dir)
         super(SDL2GradleBootstrap, self).run_distribute()
 
 

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -137,7 +137,7 @@ class SDL2GradleBootstrap(Bootstrap):
 
             python3_build_dir = join(Recipe.get_recipe('python3', self.ctx).get_build_dir(arch.arch),
                                      'Android', 'build',
-                                     'python3.7-android-{}-armv7'.format(self.ctx.android_api))
+                                     'python3.7-android-{}-armv7'.format(self.ctx.ndk_target_api))
             shprint(sh.cp, join(python3_build_dir, 'libpython3.7m.so'), 'libs/{}'.format(arch.arch))
             shprint(sh.cp, join(python3_build_dir, 'libpython3.7m.so.1.0'), 'libs/{}'.format(arch.arch))
 

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -410,7 +410,7 @@ main.py that loads it.''')
 
 def parse_args(args=None):
     global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
-    default_android_api = 12
+    default_android_api = 19
     import argparse
     ap = argparse.ArgumentParser(description='''\
 Package a Python application for Android.

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -410,7 +410,7 @@ main.py that loads it.''')
 
 def parse_args(args=None):
     global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
-    default_android_api = 19
+    default_android_api = 21
     import argparse
     ap = argparse.ArgumentParser(description='''\
 Package a Python application for Android.

--- a/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
@@ -5,3 +5,4 @@
 
 # APP_ABI := armeabi armeabi-v7a x86
 APP_ABI := $(ARCH)
+APP_PLATFORM := android-21

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -12,13 +12,18 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include
 LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 	start.c
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS)
+# LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS)
+
+LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Include -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7 -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7
+
+
+# LOCAL_CFLAGS += -I/home/sandy/.local/share/python-for-android/build/bootstrap_builds/sdl2_gradle-python3/jni/src/../../../../other_builds/python3/armeabi-v7a/python3/Android/build/python3.7-android-24-armv7
 
 LOCAL_SHARED_LIBRARIES := SDL2 python_shared
 
-LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS)
+LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS) -lpython3.7m
 
-LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
+LOCAL_LDFLAGS += $(APPLICATION_ADDITIONAL_LDFLAGS) -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -14,7 +14,7 @@ LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 
 # LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS)
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Include -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7 -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7
+LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Include -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-$(TARGET_ANDROID_API)-armv7 -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-$(TARGET_ANDROID_API)-armv7
 
 
 # LOCAL_CFLAGS += -I/home/sandy/.local/share/python-for-android/build/bootstrap_builds/sdl2_gradle-python3/jni/src/../../../../other_builds/python3/armeabi-v7a/python3/Android/build/python3.7-android-24-armv7
@@ -23,7 +23,7 @@ LOCAL_SHARED_LIBRARIES := SDL2 python_shared
 
 LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS) -lpython3.7m
 
-LOCAL_LDFLAGS += $(APPLICATION_ADDITIONAL_LDFLAGS) -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-23-armv7
+LOCAL_LDFLAGS += $(APPLICATION_ADDITIONAL_LDFLAGS) -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Android/build/python3.7-android-$(TARGET_ANDROID_API)-armv7
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
@@ -112,8 +112,16 @@ int main(int argc, char *argv[]) {
   char crystax_python_dir[256];
   snprintf(crystax_python_dir, 256,
            "%s/crystax_python", getenv("ANDROID_UNPACK"));
+  char stdlib[256];
+  snprintf(stdlib, 256,
+           "%s/crystax_python/stdlib.zip", getenv("ANDROID_UNPACK"));
   if (dir_exists(crystax_python_dir)) {
     LOGP("crystax_python exists");
+    if (file_exists(stdlib)) {
+        LOGP("stdlib.zip exists");
+    } else {
+        LOGP("no stdlib.zip exists");
+    }
     char paths[256];
     snprintf(paths, 256,
              "%s/stdlib.zip:%s/modules",
@@ -137,13 +145,13 @@ int main(int argc, char *argv[]) {
     LOGP("crystax_python does not exist");
   }
 
+  LOGP("Calling Py_Initialize");
   Py_Initialize();
+  LOGP("Py_Initialize returned successfully");
 
 #if PY_MAJOR_VERSION < 3
   PySys_SetArgv(argc, argv);
 #endif
-
-  LOGP("Initialized python");
 
   /* ensure threads will work.
    */

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -67,8 +67,8 @@ public class PythonUtil {
                 // load, and it has failed, give a more
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
-                if (lib.startsWith("python3.6") && !foundPython) {
-                    throw new java.lang.RuntimeException("Could not load any libpythonXXX.so");
+                if (lib.startsWith("python3.7m") && !foundPython) {
+                    throw new java.lang.RuntimeException("Could not load libpython3.7m.so");
                 } else if (lib.startsWith("python")) {
                     continue;
                 } else {

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -45,6 +45,7 @@ public class PythonUtil {
         addLibraryIfExists(libsList, "crypto.*", libsDir);
         libsList.add("python2.7");
         libsList.add("python3.5m");
+        libsList.add("python3.7m");
         libsList.add("main");
         return libsList;
     }

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -106,6 +106,8 @@ class Context(object):
         ensure_dir(join(self.build_dir, 'bootstrap_builds'))
         ensure_dir(join(self.build_dir, 'other_builds'))
 
+    ndk_target_api = 21
+
     @property
     def android_api(self):
         '''The Android API being targeted.'''

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -780,7 +780,7 @@ class PythonRecipe(Recipe):
                 env['PYTHON_ROOT'] = Recipe.get_recipe('python3', self.ctx).get_build_dir(arch.arch)
                 print('python root is', env['PYTHON_ROOT'])
                 env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/Include'
-                env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/Android/build/python3.7-android-23-armv7/' + \
+                env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/Android/build/python3.7-android-{}-armv7/'.format(self.ctx.ndk_target_api) + \
                                   ' -lpython{}m'.format(
                                       python_short_version)
                 del env['PYTHON_ROOT']

--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -9,7 +9,7 @@ class PyjniusRecipe(CythonRecipe):
     version = 'master'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
-    depends = [('python2', 'python3crystax'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']
+    depends = [('python2', 'python3crystax', 'python3'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']
     site_packages_name = 'jnius'
 
     patches = [('sdl2_jnienv_getter.patch', will_build('sdl2')),

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,0 +1,71 @@
+from pythonforandroid.recipe import TargetPythonRecipe, Recipe
+from pythonforandroid.toolchain import shprint, current_directory, info
+from pythonforandroid.patching import (is_darwin, is_api_gt,
+                                       check_all, is_api_lt, is_ndk)
+from os.path import exists, join, realpath
+import sh
+
+
+class Python3Recipe(TargetPythonRecipe):
+    version = "3.7"
+    url = 'https://github.com/inclement/cpython/archive/bpo-30386.zip'
+    name = 'python3'
+
+    depends = []
+    conflicts = ['python3crystax', 'python2']
+    # opt_depends = ['openssl', 'sqlite3']
+
+    from_crystax = False
+
+    def build_arch(self, arch):
+
+        # If already built, don't build again
+        if not exists(join(self.get_build_dir(arch.arch), 'Android', 'build', 'python3.7-android-23-armv7', 'libpython3.7m.so')):
+            self.do_python_build(arch)
+
+        # if not exists(self.ctx.get_python_install_dir()):
+        #     shprint(sh.cp, '-a', join(self.get_build_dir(arch.arch), 'python-install'),
+        #             self.ctx.get_python_install_dir())
+
+        # # This should be safe to run every time
+        # info('Copying hostpython binary to targetpython folder')
+        # shprint(sh.cp, self.ctx.hostpython,
+        #         join(self.ctx.get_python_install_dir(), 'bin', 'python.host'))
+        # self.ctx.hostpython = join(self.ctx.get_python_install_dir(), 'bin', 'python.host')
+
+        # if not exists(join(self.ctx.get_libs_dir(arch.arch), 'libpython2.7.so')):
+        #     shprint(sh.cp, join(self.get_build_dir(arch.arch), 'libpython2.7.so'), self.ctx.get_libs_dir(arch.arch))
+        # Instead of using a locally built hostpython, we use the
+        # user's Python for now. They must have the right version
+        # available. Using e.g. pyenv makes this easy.
+        self.ctx.hostpython = 'python{}'.format(self.version)
+
+        recipe_dir = self.get_build_dir(arch.arch)
+        shprint(sh.cp,
+                join(recipe_dir, 'Android', 'build',
+                     'python3.7-android-{}-armv7'.format(self.ctx.android_api),
+                     'pyconfig.h'),
+                join(recipe_dir, 'Include'))
+                
+
+
+    def do_python_build(self, arch):
+
+        import os
+        env = os.environ
+
+        env.update({'ANDROID_NDK_ROOT': self.ctx.ndk_dir,
+                    'ANDROID_API': str(self.ctx.android_api),
+                    'ANDROID_ARCH': 'armv7'})
+
+        with current_directory(join(self.get_build_dir(arch.arch), 'Android')):
+            com = sh.Command('./makesetup')
+            # import ipdb
+            # ipdb.set_trace()
+            shprint(com, _env=env)
+
+            shprint(sh.make, 'build', _env=env)
+        
+
+
+recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -20,7 +20,7 @@ class Python3Recipe(TargetPythonRecipe):
     def build_arch(self, arch):
 
         # If already built, don't build again
-        if not exists(join(self.get_build_dir(arch.arch), 'Android', 'build', 'python3.7-android-23-armv7', 'libpython3.7m.so')):
+        if not exists(join(self.get_build_dir(arch.arch), 'Android', 'build', 'python3.7-android-{}-armv7'.format(self.ctx.ndk_target_api), 'libpython3.7m.so')):
             self.do_python_build(arch)
 
         # if not exists(self.ctx.get_python_install_dir()):
@@ -43,7 +43,7 @@ class Python3Recipe(TargetPythonRecipe):
         recipe_dir = self.get_build_dir(arch.arch)
         shprint(sh.cp,
                 join(recipe_dir, 'Android', 'build',
-                     'python3.7-android-{}-armv7'.format(self.ctx.android_api),
+                     'python3.7-android-{}-armv7'.format(self.ctx.ndk_target_api),
                      'pyconfig.h'),
                 join(recipe_dir, 'Include'))
                 
@@ -55,7 +55,7 @@ class Python3Recipe(TargetPythonRecipe):
         env = os.environ
 
         env.update({'ANDROID_NDK_ROOT': self.ctx.ndk_dir,
-                    'ANDROID_API': str(self.ctx.android_api),
+                    'ANDROID_API': str(self.ctx.ndk_target_api),
                     'ANDROID_ARCH': 'armv7'})
 
         with current_directory(join(self.get_build_dir(arch.arch), 'Android')):

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -10,7 +10,7 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
 
     dir_name = 'SDL'
 
-    depends = [('python2', 'python3crystax'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
+    depends = [('python2', 'python3crystax', 'python3'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
     conflicts = ['sdl', 'pygame', 'pygame_bootstrap_components']
 
     patches = ['add_nativeSetEnv.patch']

--- a/pythonforandroid/recipes/six/__init__.py
+++ b/pythonforandroid/recipes/six/__init__.py
@@ -5,7 +5,7 @@ from pythonforandroid.recipe import PythonRecipe
 class SixRecipe(PythonRecipe):
     version = '1.9.0'
     url = 'https://pypi.python.org/packages/source/s/six/six-{version}.tar.gz'
-    depends = [('python2', 'python3crystax')]
+    depends = [('python2', 'python3crystax', 'python3')]
 
 
 recipe = SixRecipe()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -747,12 +747,14 @@ class ToolchainCL(object):
                 env['P4A_RELEASE_KEYALIAS_PASSWD'] = args.keystorepw
 
         build = imp.load_source('build', join(dist.dist_dir, 'build.py'))
+        print('now')
         with current_directory(dist.dist_dir):
             self.hook("before_apk_build")
             os.environ["ANDROID_API"] = str(self.ctx.android_api)
             build_args = build.parse_args(args.unknown_args)
             self.hook("after_apk_build")
             self.hook("before_apk_assemble")
+            print('foo')
 
             build_type = ctx.java_build_tool
             if build_type == 'auto':

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python3crystax',
+                   'requirements': 'sdl2,pyjnius,kivy,python3crystax==3.6',
                    'android-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python3',

--- a/testapps/testapp/main.py
+++ b/testapps/testapp/main.py
@@ -11,6 +11,8 @@ print('contents of this dir', os.listdir('./'))
 import sys
 print('pythonpath is', sys.path)
 
+print('python version is', sys.version)
+
 import kivy
 print('imported kivy')
 print('file is', kivy.__file__)
@@ -58,6 +60,14 @@ ScrollView:
             text_size: self.size[0], None
             markup: True
             text: '[b]Kivy[/b] on [b]SDL2[/b] on [b]Android[/b]!'
+            halign: 'center'
+        Label:
+            height: self.texture_size[1]
+            size_hint_y: None
+            font_size: 100
+            text_size: self.size[0], None
+            markup: True
+            text: 'Built [b]without CrystaX[/b]'
             halign: 'center'
         Label:
             height: self.texture_size[1]


### PR DESCRIPTION
This PR is most of the work necessary to let p4a build and use Python 3 with the normal Google NDK, using the build process submitted to CPython at https://github.com/python/cpython/pull/1629 (bpo-30386).

This isn't intended for merging: it's super hacky and mostly just a test to see if it could work, plus I'm not sure if the PR I'm using is the most up to date. However, it *does* work, and I'll now move to fix up a proper version. Even in the worst case that these types of changes never get updated or land in Python, it's more than enough to support p4a in the foreseeable future, and already far more understandable than the old hacky Python 2 method.

I also got this working with API 27 for good measure. This involved a few further hacks to the Python build, which aren't yet in this PR, but shouldn't be important for other recipes. As far as I can tell that worked okay, if I upload the APK to the Play store it doesn't give a warning about the API version so it seems happy with what I did. The important thing here is: the target SDK version must be 27 or higher, the compile SDK version may be lower than that (but doesn't really matter right now), the min SDK version must be at least 21 for this Python version (I think), and finally the NDK target version controlled by APP_PLATFORM must have a *low* value, ideally equal to the min SDK. This NDK setting is not currently controlled by python-for-android, which I now realise is an omission that probably led to a range of build issues for different people.

I know various people have been interested in aspects of this, please let me know if you have any questions. I'll update this if I achieve anything interesting, and also fix up all the work to properly add the features.