### PR TITLE
Adds Python3 support to reportlab, pyrxp and preppy

### DIFF
--- a/pythonforandroid/recipes/preppy/__init__.py
+++ b/pythonforandroid/recipes/preppy/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class PreppyRecipe(PythonRecipe):
     version = '27b7085'
     url = 'https://bitbucket.org/rptlab/preppy/get/{version}.tar.gz'
-    depends = []
+    depends = [('python2', 'python3crystax')]
     patches = ['fix-setup.patch']
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/pyrxp/__init__.py
+++ b/pythonforandroid/recipes/pyrxp/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 class PyRXPURecipe(CompiledComponentsPythonRecipe):
     version = '2a02cecc87b9'
     url = 'https://bitbucket.org/rptlab/pyrxp/get/{version}.tar.gz'
-    depends = ['python2']
+    depends = [('python2', 'python3crystax')]
     patches = []
 
 

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -7,7 +7,7 @@ from pythonforandroid.logger import (info, shprint)
 class ReportLabRecipe(CompiledComponentsPythonRecipe):
     version = 'c088826211ca'
     url = 'https://bitbucket.org/rptlab/reportlab/get/{version}.tar.gz'
-    depends = ['python2', 'freetype']
+    depends = [('python2', 'python3crystax'), 'freetype']
 
     def prebuild_arch(self, arch):
         if not self.is_patched(arch):


### PR DESCRIPTION
Follow up for https://github.com/kivy/python-for-android/pull/1182
Squashed commit and also removed `pil` from the requirements list of the initial PR.
Edit:
Not tested, but well relatively safe change. In the worst case we have compilation error on Python3, but no regressions on Python2.