### PR TITLE
Enables unit tests in tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq python-tox
+  - sudo apt-get install -qq python2.7 python3
+  - sudo pip install tox>=2.0
 
 env:
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk'

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,3 @@
-
 from pythonforandroid.build import Context
 from pythonforandroid.graph import get_recipe_order_and_bootstrap
 from pythonforandroid.bootstrap import Bootstrap
@@ -18,14 +17,12 @@ valid_combinations = list(product(name_sets, bootstraps))
 valid_combinations.extend(
     [(['python3crystax'], Bootstrap.get_bootstrap('sdl2', ctx)),
      (['kivy', 'python3crystax'], Bootstrap.get_bootstrap('sdl2', ctx))])
+invalid_combinations = [[['python2', 'python3crystax'], None]]
 
 
 @pytest.mark.parametrize('names,bootstrap', valid_combinations)
 def test_valid_recipe_order_and_bootstrap(names, bootstrap):
     get_recipe_order_and_bootstrap(ctx, names, bootstrap)
-
-invalid_combinations = [[['python2', 'python3crystax'], None],
-                        [['python3'], Bootstrap.get_bootstrap('pygame', ctx)]]
 
 
 @pytest.mark.parametrize('names,bootstrap', invalid_combinations)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = pep8
-# no setup.py to be ran
-skipsdist = True
+envlist = pep8,py27,py3
+
+[testenv]
+deps = pytest
+commands = pytest tests/
 
 [testenv:pep8]
 deps = flake8
-commands = flake8 pythonforandroid/
+commands = flake8 pythonforandroid/ tests/
 
 [flake8]
 ignore =


### PR DESCRIPTION
Unit tests should be also ran in Continous Integration for both Python2
and Python3.
Also fixes `invalid_combinations` list as `python3` recipe was removed
in a19e884.