### PR TITLE
Test Numpy on Python 2 / 3 on all architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,14 @@ env:
   # overrides requirements to skip `peewee` pure python module, see:
   # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
   - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
-  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --bootstrap sdl2 --requirements python2,numpy'
-  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk'
-  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,setuptools,android'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --bootstrap sdl2 --requirements python2,numpy --arch=armeabi-v7a'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --bootstrap sdl2 --requirements python2,numpy --arch=arm64-v8a'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --bootstrap sdl2 --requirements python2,numpy --arch=x86'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/android-ndk --bootstrap sdl2 --requirements python2,numpy --arch=x86_64'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,numpy,setuptools,android --arch=armeabi-v7a'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,numpy,setuptools,android --arch=arm64-v8a'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,numpy,setuptools,android --arch=x86'
+  - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir /opt/android/android-sdk --ndk-dir /opt/android/crystax-ndk --requirements python3crystax,numpy,setuptools,android --arch=x86_64'
 
 before_script:
   # we want to fail fast on tox errors without having to `docker build` first

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -175,7 +175,7 @@ class Archx86(Arch):
 
 class Archx86_64(Arch):
     arch = 'x86_64'
-    toolchain_prefix = 'x86'
+    toolchain_prefix = 'x86_64'
     command_prefix = 'x86_64-linux-android'
     platform_dir = 'arch-x86'
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -12,7 +12,7 @@ import sh
 from pythonforandroid.util import (ensure_dir, current_directory)
 from pythonforandroid.logger import (info, warning, error, info_notify,
                                      Err_Fore, info_main, shprint)
-from pythonforandroid.archs import ArchARM, ArchARMv7_a, ArchAarch_64, Archx86
+from pythonforandroid.archs import ArchARM, ArchARMv7_a, ArchAarch_64, Archx86, Archx86_64
 from pythonforandroid.recipe import Recipe
 
 DEFAULT_ANDROID_API = 15
@@ -463,6 +463,7 @@ class Context(object):
             ArchARM(self),
             ArchARMv7_a(self),
             Archx86(self),
+            Archx86_64(self),
             ArchAarch_64(self),
             )
 


### PR DESCRIPTION
I'm working on getting numpy built for Python 3.6 on `x86_64` and `arm64-v8a` ABIs, I just wanted to add and or check if this passes on CI in the meantime. 

The test matrix could probably be refactored to be a bit cleaner, I think it would be great if every build command were tested against every ABI.