### PR TITLE
jpeg: use https: URL instead of git:

### DIFF
--- a/pythonforandroid/recipes/jpeg/__init__.py
+++ b/pythonforandroid/recipes/jpeg/__init__.py
@@ -8,7 +8,7 @@ import sh
 class JpegRecipe(NDKRecipe):
     name = 'jpeg'
     version = 'linaro-android'
-    url = 'git://git.linaro.org/people/tomgall/libjpeg-turbo/libjpeg-turbo.git'
+    url = 'git+https://git.linaro.org/people/tomgall/libjpeg-turbo/libjpeg-turbo'
 
     patches = ['build-static.patch']
 


### PR DESCRIPTION
This way download can work when non HTTP ports are blocked.