### PR TITLE
twisted: added a patch to disable incremental during setup [pyconfr18]

### DIFF
--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -6,9 +6,10 @@ class TwistedRecipe(CythonRecipe):
     url = 'https://github.com/twisted/twisted/archive/twisted-{version}.tar.gz'
 
     depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']
+    patches = ['incremental.patch']
 
     call_hostpython_via_targetpython = False
-    install_in_hostpython = True
+    install_in_hostpython = False
 
     def prebuild_arch(self, arch):
         super(TwistedRecipe, self).prebuild_arch(arch)

--- a/pythonforandroid/recipes/twisted/incremental.patch
+++ b/pythonforandroid/recipes/twisted/incremental.patch
@@ -1,0 +1,18 @@
+diff -Naur twisted-twisted-17.9.0/src/twisted/python/_setup.py twisted-twisted-17.9.0_patched/src/twisted/python/_setup.py
+--- twisted-twisted-17.9.0/src/twisted/python/_setup.py	2017-09-23 07:56:08.000000000 +0200
++++ twisted-twisted-17.9.0_patched/src/twisted/python/_setup.py	2018-10-05 11:06:23.305860722 +0200
+@@ -227,14 +227,11 @@
+         requirements = ["zope.interface >= 3.6.0"]
+ 
+     requirements.append("constantly >= 15.1")
+-    requirements.append("incremental >= 16.10.1")
+     requirements.append("Automat >= 0.3.0")
+     requirements.append("hyperlink >= 17.1.1")
+ 
+     arguments.update(dict(
+         packages=find_packages("src"),
+-        use_incremental=True,
+-        setup_requires=["incremental >= 16.10.1"],
+         install_requires=requirements,
+         entry_points={
+             'console_scripts': _CONSOLE_SCRIPTS


### PR DESCRIPTION
incremental is only used to get version, and it causes trouble during
installation as hostpython can't retrieve a https URL because it's
compiled without SSL support.

Also disabled install_in_hostpython which is not needed here.