### PR TITLE
cryptography: add missing include flag [pyconfr18]

### DIFF
--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -1,4 +1,5 @@
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from os.path import join
 
 
 class CryptographyRecipe(CompiledComponentsPythonRecipe):
@@ -14,9 +15,11 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
         openssl_dir = r.get_build_dir(arch.arch)
         # Set linker to use the correct gcc
         env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
+        env['CFLAGS'] += ' -I' + join(openssl_dir, 'include')
         env['LDFLAGS'] += ' -L' + openssl_dir + \
                           ' -lssl' + r.version + \
                           ' -lcrypto' + r.version
+
         return env
 
 


### PR DESCRIPTION
an include has been mistakenly removed in
cbe9e8e019196c65d563c85052df8722847f0217 resulting in compilation error
(a header can't be found). This patch fixes this.