### PR TITLE
Linter fixes E111, E116, E122, E202, E225, E241...

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -36,7 +36,7 @@ class Arch(object):
         env['CFLAGS'] = ' '.join([
             '-DANDROID', '-mandroid', '-fomit-frame-pointer'
             ' -D__ANDROID_API__={}'.format(self.ctx._android_api),
-           ])
+            ])
         env['LDFLAGS'] = ' '
 
         sysroot = join(self.ctx._ndk_dir, 'sysroot')

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -378,7 +378,7 @@ main.py that loads it.''')
         url_scheme=url_scheme,
         private_version=str(time.time()))
 
-    ## gradle build templates
+    # gradle build templates
     render(
         'build.tmpl.gradle',
         'build.gradle',
@@ -388,7 +388,7 @@ main.py that loads it.''')
         android_api=android_api,
         build_tools_version=build_tools_version)
 
-    ## ant build templates
+    # ant build templates
     render(
         'build.tmpl.xml',
         'build.xml',
@@ -418,10 +418,10 @@ For this to work, Java and Ant need to be in your path, as does the
 tools directory of the Android SDK.
 ''')
 
+    # `required=True` for launcher, crashes in make_package
+    # if not mentioned (and the check is there anyway)
     ap.add_argument('--private', dest='private',
                     help='the dir of user files')
-                    # , required=True) for launcher, crashes in make_package
-                    # if not mentioned (and the check is there anyway)
     ap.add_argument('--package', dest='package',
                     help=('The name of the java package the project will be'
                           ' packaged under.'),
@@ -486,8 +486,8 @@ tools directory of the Android SDK.
     ap.add_argument('--depend', dest='depends', action='append',
                     help=('Add a external dependency '
                           '(eg: com.android.support:appcompat-v7:19.0.1)'))
-    ## The --sdk option has been removed, it is ignored in favour of
-    ## --android-api handled by toolchain.py
+    # The --sdk option has been removed, it is ignored in favour of
+    # --android-api handled by toolchain.py
     ap.add_argument('--sdk', dest='sdk_version', default=-1,
                     type=int, help=('Deprecated argument, does nothing'))
     ap.add_argument('--minsdk', dest='min_sdk_version',

--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -1,4 +1,3 @@
-
 from copy import deepcopy
 from itertools import product
 from sys import exit

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -548,8 +548,8 @@ class Recipe(with_metaclass(RecipeMeta)):
         if exists(base_dir):
             dirs.append(base_dir)
         if not dirs:
-             warning(('Attempted to clean build for {} but found no existing '
-                      'build dirs').format(self.name))
+            warning(('Attempted to clean build for {} but found no existing '
+                     'build dirs').format(self.name))
 
         for directory in dirs:
             if exists(directory):

--- a/pythonforandroid/recipes/android/src/android/__init__.py
+++ b/pythonforandroid/recipes/android/src/android/__init__.py
@@ -5,4 +5,4 @@ Android module
 '''
 
 # legacy import
-from android._android import *  # noqa: F401
+from android._android import *  # noqa: F401, F403

--- a/pythonforandroid/recipes/android/src/android/activity.py
+++ b/pythonforandroid/recipes/android/src/android/activity.py
@@ -5,7 +5,8 @@ _activity = autoclass(JAVA_NAMESPACE + '.PythonActivity').mActivity
 
 _callbacks = {
     'on_new_intent': [],
-    'on_activity_result': [] }
+    'on_activity_result': [],
+}
 
 
 class NewIntentListener(PythonJavaClass):

--- a/pythonforandroid/recipes/flask/__init__.py
+++ b/pythonforandroid/recipes/flask/__init__.py
@@ -3,9 +3,10 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class FlaskRecipe(PythonRecipe):
-    version = '0.10.1'  # The webserver of 'master' seems to fail
-                        # after a little while on Android, so use
-                        # 0.10.1 at least for now
+    # The webserver of 'master' seems to fail
+    # after a little while on Android, so use
+    # 0.10.1 at least for now
+    version = '0.10.1'
     url = 'https://github.com/pallets/flask/archive/{version}.zip'
 
     depends = [('python2', 'python3crystax'), 'setuptools', 'genericndkbuild']

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -40,8 +40,8 @@ class LibffiRecipe(Recipe):
                     '--host=' + arch.toolchain_prefix,
                     '--prefix=' + self.ctx.get_python_install_dir(),
                     '--enable-shared', _env=env)
-            #'--with-sysroot={}'.format(self.ctx.ndk_platform),
-            #'--target={}'.format(arch.toolchain_prefix),
+            # '--with-sysroot={}'.format(self.ctx.ndk_platform),
+            # '--target={}'.format(arch.toolchain_prefix),
 
             # ndk 15 introduces unified headers required --sysroot and
             # -isysroot for libraries and headers. libtool's head explodes

--- a/pythonforandroid/recipes/libgeos/__init__.py
+++ b/pythonforandroid/recipes/libgeos/__init__.py
@@ -6,7 +6,7 @@ from multiprocessing import cpu_count
 
 class LibgeosRecipe(Recipe):
     version = '3.5'
-    #url = 'http://download.osgeo.org/geos/geos-{version}.tar.bz2'
+    # url = 'http://download.osgeo.org/geos/geos-{version}.tar.bz2'
     url = 'https://github.com/libgeos/libgeos/archive/svn-{version}.zip'
     depends = ['python2']
 
@@ -23,7 +23,7 @@ class LibgeosRecipe(Recipe):
             bash = sh.Command('bash')
             print("If this fails make sure you have autoconf and libtool installed")
             shprint(bash, 'autogen.sh')  # Requires autoconf and libtool
-            shprint(bash, 'configure',  '--host=arm-linux-androideabi', '--enable-shared', '--prefix={}'.format(dst_dir), _env=env)
+            shprint(bash, 'configure', '--host=arm-linux-androideabi', '--enable-shared', '--prefix={}'.format(dst_dir), _env=env)
             shprint(sh.make, '-j', str(cpu_count()), _env=env)
             shprint(sh.make, 'install', _env=env)
             shutil.copyfile('{}/lib/libgeos_c.so'.format(dst_dir), join(self.ctx.get_libs_dir(arch.arch), 'libgeos_c.so'))

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -11,7 +11,7 @@ from multiprocessing import cpu_count
 class OpenCVRecipe(NDKRecipe):
     version = '2.4.10.1'
     url = 'https://github.com/Itseez/opencv/archive/{version}.zip'
-    #md5sum = '2ddfa98e867e6611254040df841186dc'
+    # md5sum = '2ddfa98e867e6611254040df841186dc'
     depends = ['numpy']
     patches = ['patches/p4a_build-2.4.10.1.patch']
     generated_libraries = ['cv2.so']

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -87,23 +87,23 @@ class Python2Recipe(TargetPythonRecipe):
             # TODO need to add a should_build that checks if optional
             # dependencies have changed (possibly in a generic way)
             if 'openssl' in self.ctx.recipe_build_order:
-                r = Recipe.get_recipe('openssl', self.ctx)
-                openssl_build_dir = r.get_build_dir(arch.arch)
+                recipe = Recipe.get_recipe('openssl', self.ctx)
+                openssl_build_dir = recipe.get_build_dir(arch.arch)
                 setuplocal = join('Modules', 'Setup.local')
                 shprint(sh.cp, join(self.get_recipe_dir(), 'Setup.local-ssl'), setuplocal)
                 shprint(sh.sed, '-i.backup', 's#^SSL=.*#SSL={}#'.format(openssl_build_dir), setuplocal)
-                env['OPENSSL_VERSION'] = r.version
+                env['OPENSSL_VERSION'] = recipe.version
 
             if 'sqlite3' in self.ctx.recipe_build_order:
                 # Include sqlite3 in python2 build
-                r = Recipe.get_recipe('sqlite3', self.ctx)
-                i = ' -I' + r.get_build_dir(arch.arch)
-                l = ' -L' + r.get_lib_dir(arch) + ' -lsqlite3'
+                recipe = Recipe.get_recipe('sqlite3', self.ctx)
+                include = ' -I' + recipe.get_build_dir(arch.arch)
+                lib = ' -L' + recipe.get_lib_dir(arch) + ' -lsqlite3'
                 # Insert or append to env
-                f = 'CPPFLAGS'
-                env[f] = env[f] + i if f in env else i
-                f = 'LDFLAGS'
-                env[f] = env[f] + l if f in env else l
+                flag = 'CPPFLAGS'
+                env[flag] = env[flag] + include if flag in env else include
+                flag = 'LDFLAGS'
+                env[flag] = env[flag] + lib if flag in env else lib
 
             # NDK has langinfo.h but doesn't define nl_langinfo()
             env['ac_cv_header_langinfo_h'] = 'no'

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -1,4 +1,5 @@
-import os, sh
+import os
+import sh
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 from pythonforandroid.util import (current_directory, ensure_dir)
 from pythonforandroid.logger import (info, shprint)

--- a/pythonforandroid/recipes/vlc/__init__.py
+++ b/pythonforandroid/recipes/vlc/__init__.py
@@ -65,8 +65,8 @@ class VlcRecipe(Recipe):
                 info("compiling vlc from sources")
                 debug("environment: {}".format(env))
                 if not isfile(join('bin', 'VLC-debug.apk')):
-                     shprint(sh.Command('./compile.sh'), _env=env,
-                             _tail=50, _critical=True)
+                    shprint(sh.Command('./compile.sh'), _env=env,
+                            _tail=50, _critical=True)
                 shprint(sh.Command('./compile-libvlc.sh'), _env=env,
                         _tail=50, _critical=True)
         shprint(sh.cp, '-a', aar, self.ctx.aars_dir)

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -398,7 +398,7 @@ class ToolchainCL(object):
             action='store_true',
             help='If passed, do not delete existing dists')
 
-        parser_clean_download_cache= add_parser(
+        parser_clean_download_cache = add_parser(
             subparsers,
             'clean_download_cache', aliases=['clean-download-cache'],
             help='Delete cached downloads for requirement builds',
@@ -584,8 +584,8 @@ class ToolchainCL(object):
                 print('{Fore.BLUE}{Style.BRIGHT}{recipe.name:<12} '
                       '{Style.RESET_ALL}{Fore.LIGHTBLUE_EX}'
                       '{version:<8}{Style.RESET_ALL}'.format(
-                        recipe=recipe, Fore=Out_Fore, Style=Out_Style,
-                        version=version))
+                            recipe=recipe, Fore=Out_Fore, Style=Out_Style,
+                            version=version))
                 print('    {Fore.GREEN}depends: {recipe.depends}'
                       '{Fore.RESET}'.format(recipe=recipe, Fore=Out_Fore))
                 if recipe.conflicts:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = flake8 pythonforandroid/ tests/
 
 [flake8]
 ignore =
-    E111, E116, E202, E121, E123, E124, E225, E126,
-    E226, E241, E265, E266,
-    E401, E402, E501, E502, E722, E741, F403,
-    F812, F841, F811, W292, W503
+    E123, E124, E126,
+    E226,
+    E402, E501, E722,
+    F812, F841, W503


### PR DESCRIPTION
  - E111 indentation is not a multiple of four
  - E116 unexpected indentation (comment)
  - E122 continuation line missing indentation or outdented
  - E202 whitespace before '}'
  - E225 missing whitespace around operator
  - E241 multiple spaces after ','
  - E265 block comment should start with '# '
  - E266 too many leading '#' for block comment
  - E401 multiple imports on one line
  - E741 ambiguous variable name
  - E502 the backslash is redundant between brackets
  - F403 unable to detect undefined names
  - F811 redefinition of unused name
  - W292 no newline at end of file