### PR TITLE
Fixes Python3.6 and enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ package_data = {'': ['*.tmpl',
 data_files = []
 
 
-install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2', 'six', 'enum34']
+install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2', 'six',
+    'enum34;python_version<"3.4"']
 if os.name != 'nt':
     install_reqs.append('sh>=1.10')
 


### PR DESCRIPTION
Module `enum34` should only be installed on Python < 3.4
Fixes host Python3 regression from ecd0bf6, the error was:
```
AttributeError: module 'enum' has no attribute 'IntFlag'
```