### PR TITLE
Python 3 recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ env:
     - ANDROID_NDK_HOME=/opt/android/android-ndk
     - CRYSTAX_NDK_HOME=/opt/android/crystax-ndk
   matrix:
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME'
     # overrides requirements to skip `peewee` pure python module, see:
     # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements python2,numpy'
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3crystax.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $CRYSTAX_NDK_HOME --requirements python3crystax,setuptools,android,sdl2,pyjnius,kivy'
+    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME'
     # builds only the recipes that moved
     - COMMAND='. venv/bin/activate && ./ci/rebuild_updated_recipes.py'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements python2,numpy'
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $CRYSTAX_NDK_HOME --requirements python3crystax,setuptools,android,sdl2,pyjnius,kivy'
+    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3crystax.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $CRYSTAX_NDK_HOME --requirements python3crystax,setuptools,android,sdl2,pyjnius,kivy'
     # builds only the recipes that moved
     - COMMAND='. venv/bin/activate && ./ci/rebuild_updated_recipes.py'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements python2,numpy'
     - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3crystax.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $CRYSTAX_NDK_HOME --requirements python3crystax,setuptools,android,sdl2,pyjnius,kivy'
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME'
     # builds only the recipes that moved
     - COMMAND='. venv/bin/activate && ./ci/rebuild_updated_recipes.py'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN mkdir --parents "${ANDROID_SDK_HOME}/.android/" && \
 	echo '### User Sources for Android SDK Manager' > "${ANDROID_SDK_HOME}/.android/repositories.cfg"
 RUN yes | "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" --licenses
 RUN "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "platforms;android-19" && \
+    "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "platforms;android-27" && \
     "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "build-tools;26.0.2" && \
     chmod +x "${ANDROID_SDK_HOME}/tools/bin/avdmanager"
 

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -17,16 +17,23 @@ This option builds Python 2.7.2 for your selected Android
 architecture. There are no special requirements, all the building is
 done locally.
 
-The python2 build is also the way python-for-android originally
-worked, even in the old toolchain.
-
 
 python3
 ~~~~~~~
 
-.. warning::
-   Python3 support is experimental, and some of these details
-   may change as it is improved and fully stabilised.
+Python3 is supported in two ways. The default method uses CPython 3.7+
+and works with any recent version of the Android NDK.
+
+Select Python 3 by adding it to your requirements,
+e.g. ``--requirements=python3``.
+
+
+CrystaX python3
+###############
+
+.. warning:: python-for-android originally supported Python 3 using the CrystaX
+             NDK. This support is now being phased out as CrystaX is no longer
+             actively developed.
 
 .. note:: You must manually download the `CrystaX NDK
    <https://www.crystax.net/android/ndk>`__ and tell
@@ -41,11 +48,6 @@ Google's official NDK which includes many improvements. You
 *must* use the CrystaX NDK 10.3.0 or higher when building with
 python3. You can get it `here
 <https://www.crystax.net/en/download>`__.
-
-The python3crystax build is handled quite differently to python2 so
-there may be bugs or surprising behaviours. If you come across any,
-feel free to `open an issue
-<https://github.com/kivy/python-for-android>`__.
 
 .. _bootstrap_build_options:
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -114,15 +114,17 @@ Then, you can edit your ``~/.bashrc`` or other favorite shell to include new env
     # Adjust the paths!
     export ANDROIDSDK="$HOME/Documents/android-sdk-21"
     export ANDROIDNDK="$HOME/Documents/android-ndk-r10e"
-    export ANDROIDAPI="19"  # Target API version of your application
+    export ANDROIDAPI="26"  # Target API version of your application
+    export NDKAPI="19"  # Minimum supported API version of your application
     export ANDROIDNDKVER="r10e"  # Version of the NDK you installed
 
 You have the possibility to configure on any command the PATH to the SDK, NDK and Android API using:
 
-- :code:`--sdk_dir PATH` as an equivalent of `$ANDROIDSDK`
-- :code:`--ndk_dir PATH` as an equivalent of `$ANDROIDNDK`
-- :code:`--android_api VERSION` as an equivalent of `$ANDROIDAPI`
-- :code:`--ndk_version VERSION` as an equivalent of `$ANDROIDNDKVER`
+- :code:`--sdk-dir PATH` as an equivalent of `$ANDROIDSDK`
+- :code:`--ndk-dir PATH` as an equivalent of `$ANDROIDNDK`
+- :code:`--android-api VERSION` as an equivalent of `$ANDROIDAPI`
+- :code:`--ndk-api VERSION` as an equivalent of `$NDKAPI`
+- :code:`--ndk-version VERSION` as an equivalent of `$ANDROIDNDKVER`
 
 
 Usage

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -133,7 +133,7 @@ class Arch(object):
         env['PATH'] = environ['PATH']
 
         env['ARCH'] = self.arch
-        env['NDK_API'] = str(self.ctx.ndk_api)
+        env['NDK_API'] = 'android-{}'.format(str(self.ctx.ndk_api))
 
         if self.ctx.python_recipe and self.ctx.python_recipe.from_crystax:
             env['CRYSTAX_PYTHON_VERSION'] = self.ctx.python_recipe.version

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -133,6 +133,7 @@ class Arch(object):
         env['PATH'] = environ['PATH']
 
         env['ARCH'] = self.arch
+        env['NDK_API'] = str(self.ctx.ndk_api)
 
         if self.ctx.python_recipe and self.ctx.python_recipe.from_crystax:
             env['CRYSTAX_PYTHON_VERSION'] = self.ctx.python_recipe.version

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -35,7 +35,7 @@ class Arch(object):
 
         env['CFLAGS'] = ' '.join([
             '-DANDROID', '-mandroid', '-fomit-frame-pointer'
-            ' -D__ANDROID_API__={}'.format(self.ctx._android_api),
+            ' -D__ANDROID_API__={}'.format(self.ctx.ndk_api),
             ])
         env['LDFLAGS'] = ' '
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -106,15 +106,14 @@ class Bootstrap(object):
         ensure_dir(self.dist_dir)
 
     def run_distribute(self):
-        # print('Default bootstrap being used doesn\'t know how '
-        #       'to distribute...failing.')
-        # exit(1)
+        # TODO: Move this to Distribution.save_info
         with current_directory(self.dist_dir):
             info('Saving distribution info')
             with open('dist_info.json', 'w') as fileh:
                 json.dump({'dist_name': self.ctx.dist_name,
                            'bootstrap': self.ctx.bootstrap.name,
                            'archs': [arch.arch for arch in self.ctx.archs],
+                           'ndk_api': self.ctx.ndk_api,
                            'recipes': self.ctx.recipe_build_order + self.ctx.python_modules},
                           fileh)
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -254,9 +254,15 @@ class Bootstrap(object):
             warning('Can\'t find strip in PATH...')
             return
         strip = sh.Command(strip)
-        filens = shprint(sh.find, join(self.dist_dir, 'private'),
-                         join(self.dist_dir, 'libs'),
-                         '-iname', '*.so', _env=env).stdout.decode('utf-8')
+
+        if self.ctx.python_recipe.name == 'python2':
+            filens = shprint(sh.find, join(self.dist_dir, 'private'),
+                            join(self.dist_dir, 'libs'),
+                            '-iname', '*.so', _env=env).stdout.decode('utf-8')
+        else:
+            filens = shprint(sh.find, join(self.dist_dir, '_python_bundle', '_python_bundle', 'modules'),
+                            join(self.dist_dir, 'libs'),
+                            '-iname', '*.so', _env=env).stdout.decode('utf-8')
         logger.info('Stripping libraries in private dir')
         for filen in filens.split('\n'):
             try:

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -2,7 +2,6 @@ from os.path import (join, dirname, isdir, splitext, basename)
 from os import listdir
 import sh
 import glob
-import json
 import importlib
 
 from pythonforandroid.logger import (warning, shprint, info, logger,
@@ -246,12 +245,12 @@ class Bootstrap(object):
 
         if self.ctx.python_recipe.name == 'python2':
             filens = shprint(sh.find, join(self.dist_dir, 'private'),
-                            join(self.dist_dir, 'libs'),
-                            '-iname', '*.so', _env=env).stdout.decode('utf-8')
+                             join(self.dist_dir, 'libs'),
+                             '-iname', '*.so', _env=env).stdout.decode('utf-8')
         else:
             filens = shprint(sh.find, join(self.dist_dir, '_python_bundle', '_python_bundle', 'modules'),
-                            join(self.dist_dir, 'libs'),
-                            '-iname', '*.so', _env=env).stdout.decode('utf-8')
+                             join(self.dist_dir, 'libs'),
+                             '-iname', '*.so', _env=env).stdout.decode('utf-8')
         logger.info('Stripping libraries in private dir')
         for filen in filens.split('\n'):
             try:

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -107,15 +107,7 @@ class Bootstrap(object):
 
     def run_distribute(self):
         # TODO: Move this to Distribution.save_info
-        with current_directory(self.dist_dir):
-            info('Saving distribution info')
-            with open('dist_info.json', 'w') as fileh:
-                json.dump({'dist_name': self.ctx.dist_name,
-                           'bootstrap': self.ctx.bootstrap.name,
-                           'archs': [arch.arch for arch in self.ctx.archs],
-                           'ndk_api': self.ctx.ndk_api,
-                           'recipes': self.ctx.recipe_build_order + self.ctx.python_modules},
-                          fileh)
+        self.distribution.save_info(self.dist_dir)
 
     @classmethod
     def list_bootstraps(cls):

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -102,11 +102,9 @@ class Bootstrap(object):
                 fileh.write('target=android-{}'.format(self.ctx.android_api))
 
     def prepare_dist_dir(self, name):
-        # self.dist_dir = self.get_dist_dir(name)
         ensure_dir(self.dist_dir)
 
     def run_distribute(self):
-        # TODO: Move this to Distribution.save_info
         self.distribution.save_info(self.dist_dir)
 
     @classmethod

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -107,53 +107,8 @@ class SDL2GradleBootstrap(Bootstrap):
                     shprint(sh.rm, '-rf', 'config/python.o')
 
             elif self.ctx.python_recipe.name == 'python3':
-                ndk_dir = self.ctx.ndk_dir
-                py_recipe = self.ctx.python_recipe
-
-                ## Build the python bundle:
-
-                # Bundle compiled python modules to a folder
-                modules_dir = join(python_bundle_dir, 'modules')
-                ensure_dir(modules_dir)
-                
-                modules_build_dir = join(
-                    self.ctx.python_recipe.get_build_dir(arch.arch),
-                    'android-build',
-                    'build',
-                    'lib.linux-arm-3.7')
-                module_filens = (glob.glob(join(modules_build_dir, '*.so')) +
-                                 glob.glob(join(modules_build_dir, '*.py')))
-                for filen in module_filens:
-                    shprint(sh.cp, filen, modules_dir)
-
-                # zip up the standard library
-                stdlib_zip = join(self.dist_dir, python_bundle_dir, 'stdlib.zip')
-                with current_directory(
-                        join(self.ctx.python_recipe.get_build_dir(arch.arch),
-                             'Lib')):
-                    shprint(sh.zip, '-r', stdlib_zip, *os.listdir())
-                    
-                # copy the site-packages into place
-                shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
-                        join(python_bundle_dir, 'site-packages'))
-
-                # copy the python .so files into place
-                python_build_dir = join(py_recipe.get_build_dir(arch.arch),
-                                        'android-build')
-                shprint(sh.cp, join(python_build_dir, 'libpython3.7m.so'),
-                        'libs/{}'.format(arch.arch))
-                shprint(sh.cp, join(python_build_dir, 'libpython3.7m.so.1.0'),
-                        'libs/{}'.format(arch.arch))
-                
-                info('Renaming .so files to reflect cross-compile')
-                site_packages_dir = join(python_bundle_dir, 'site-packages')
-                py_so_files = shprint(sh.find, site_packages_dir, '-iname', '*.so')
-                filens = py_so_files.stdout.decode('utf-8').split('\n')[:-1]
-                for filen in filens:
-                    parts = filen.split('.')
-                    if len(parts) <= 2:
-                        continue
-                    shprint(sh.mv, filen, parts[0] + '.so')
+                self.ctx.python_recipe.create_python_bundle(
+                    join(self.dist_dir, python_bundle_dir), arch)
                 
             elif self.ctx.python_recipe.from_crystax:  # Python *is* loaded from crystax
                 ndk_dir = self.ctx.ndk_dir

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -61,7 +61,7 @@ class SDL2GradleBootstrap(Bootstrap):
                 python_bundle_dir = 'private'
             ensure_dir(python_bundle_dir)
 
-            self.ctx.python_recipe.create_python_bundle(
+            site_packages_dir = self.ctx.python_recipe.create_python_bundle(
                 join(self.dist_dir, python_bundle_dir), arch)
                 # TODO: Also set site_packages_dir again so fry_eggs can work
 
@@ -70,7 +70,7 @@ class SDL2GradleBootstrap(Bootstrap):
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
         self.strip_libraries(arch)
-        # self.fry_eggs(site_packages_dir)  # TODO uncomment this and make it work with python3
+        self.fry_eggs(site_packages_dir)  # TODO uncomment this and make it work with python3
         super(SDL2GradleBootstrap, self).run_distribute()
 
 

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -4,11 +4,7 @@ from pythonforandroid.util import ensure_dir
 from os.path import join, exists, curdir, abspath
 from os import walk
 import os
-import glob
 import sh
-
-
-EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 
 
 class SDL2GradleBootstrap(Bootstrap):

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -110,30 +110,11 @@ class SDL2GradleBootstrap(Bootstrap):
                 self.ctx.python_recipe.create_python_bundle(
                     join(self.dist_dir, python_bundle_dir), arch)
                 
-            elif self.ctx.python_recipe.from_crystax:  # Python *is* loaded from crystax
-                ndk_dir = self.ctx.ndk_dir
-                py_recipe = self.ctx.python_recipe
-                python_dir = join(ndk_dir, 'sources', 'python',
-                                  py_recipe.version, 'libs', arch.arch)
-                shprint(sh.cp, '-r', join(python_dir,
-                                          'stdlib.zip'), crystax_python_dir)
-                shprint(sh.cp, '-r', join(python_dir,
-                                          'modules'), crystax_python_dir)
-                shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
-                        join(crystax_python_dir, 'site-packages'))
+            elif self.ctx.python_recipe.from_crystax:
+                self.ctx.python_recipe.create_python_bundle(
+                    join(self.dist_dir, python_bundle_dir), arch)
+                # TODO: Also set site_packages_dir again so fry_eggs can work
 
-                info('Renaming .so files to reflect cross-compile')
-                site_packages_dir = join(crystax_python_dir, "site-packages")
-                find_ret = shprint(
-                    sh.find, site_packages_dir, '-iname', '*.so')
-                filenames = find_ret.stdout.decode('utf-8').split('\n')[:-1]
-                for filename in filenames:
-                    parts = filename.split('.')
-                    if len(parts) <= 2:
-                        continue
-                    shprint(sh.mv, filename, filename.split('.')[0] + '.so')
-                site_packages_dir = join(abspath(curdir),
-                                         site_packages_dir)
             if 'sqlite3' not in self.ctx.recipe_build_order:
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -22,9 +22,6 @@ class SDL2GradleBootstrap(Bootstrap):
         arch = self.ctx.archs[0]
         python_install_dir = self.ctx.get_python_install_dir()
         from_crystax = self.ctx.python_recipe.from_crystax
-        crystax_python_dir = join("crystax_python", "crystax_python")
-
-        python_bundle_dir = join('_python_bundle', '_python_bundle')
 
         if len(self.ctx.archs) > 1:
             raise ValueError("SDL2/gradle support only one arch")
@@ -43,13 +40,6 @@ class SDL2GradleBootstrap(Bootstrap):
         with current_directory(self.dist_dir):
             info("Copying Python distribution")
 
-            if 'python2' in self.ctx.recipe_build_order:
-                ensure_dir("private")
-            elif not exists("crystax_python") and from_crystax:
-                ensure_dir(crystax_python_dir)
-            elif 'python3' in self.ctx.recipe_build_order:
-                ensure_dir(python_bundle_dir)
-
             hostpython = sh.Command(self.ctx.hostpython)
             if self.ctx.python_recipe.name == 'python2':
                 try:
@@ -66,53 +56,14 @@ class SDL2GradleBootstrap(Bootstrap):
             self.distribute_javaclasses(self.ctx.javaclass_dir,
                                         dest_dir=join("src", "main", "java"))
 
-            if self.ctx.python_recipe.name == 'python2':
-                info("Filling private directory")
-                if not exists(join("private", "lib")):
-                    info("private/lib does not exist, making")
-                    shprint(sh.cp, "-a",
-                            join("python-install", "lib"), "private")
-                shprint(sh.mkdir, "-p",
-                        join("private", "include", "python2.7"))
+            python_bundle_dir = join('_python_bundle', '_python_bundle')
+            if 'python2' in self.ctx.recipe_build_order:
+                # Python 2 is a special case with its own packaging location
+                python_bundle_dir = 'private'
+            ensure_dir(python_bundle_dir)
 
-                libpymodules_fn = join("libs", arch.arch, "libpymodules.so")
-                if exists(libpymodules_fn):
-                    shprint(sh.mv, libpymodules_fn, 'private/')
-                shprint(sh.cp,
-                        join('python-install', 'include',
-                             'python2.7', 'pyconfig.h'),
-                        join('private', 'include', 'python2.7/'))
-
-                info('Removing some unwanted files')
-                shprint(sh.rm, '-f', join('private', 'lib', 'libpython2.7.so'))
-                shprint(sh.rm, '-rf', join('private', 'lib', 'pkgconfig'))
-
-                libdir = join(self.dist_dir, 'private', 'lib', 'python2.7')
-                site_packages_dir = join(libdir, 'site-packages')
-                with current_directory(libdir):
-                    removes = []
-                    for dirname, root, filenames in walk("."):
-                        for filename in filenames:
-                            for suffix in EXCLUDE_EXTS:
-                                if filename.endswith(suffix):
-                                    removes.append(filename)
-                    shprint(sh.rm, '-f', *removes)
-
-                    info('Deleting some other stuff not used on android')
-                    # To quote the original distribute.sh, 'well...'
-                    shprint(sh.rm, '-rf', 'lib2to3')
-                    shprint(sh.rm, '-rf', 'idlelib')
-                    for filename in glob.glob('config/libpython*.a'):
-                        shprint(sh.rm, '-f', filename)
-                    shprint(sh.rm, '-rf', 'config/python.o')
-
-            elif self.ctx.python_recipe.name == 'python3':
-                self.ctx.python_recipe.create_python_bundle(
-                    join(self.dist_dir, python_bundle_dir), arch)
-                
-            elif self.ctx.python_recipe.from_crystax:
-                self.ctx.python_recipe.create_python_bundle(
-                    join(self.dist_dir, python_bundle_dir), arch)
+            self.ctx.python_recipe.create_python_bundle(
+                join(self.dist_dir, python_bundle_dir), arch)
                 # TODO: Also set site_packages_dir again so fry_eggs can work
 
             if 'sqlite3' not in self.ctx.recipe_build_order:

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -36,7 +36,6 @@ class SDL2GradleBootstrap(Bootstrap):
             with open('local.properties', 'w') as fileh:
                 fileh.write('sdk.dir={}'.format(self.ctx.sdk_dir))
 
-        # TODO: Move the packaged python building to the python recipes
         with current_directory(self.dist_dir):
             info("Copying Python distribution")
 

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -119,6 +119,7 @@ class SDL2GradleBootstrap(Bootstrap):
                 modules_build_dir = join(
                     self.ctx.python_recipe.get_build_dir(arch.arch),
                     'android-build',
+                    'build',
                     'lib.linux-arm-3.7')
                 module_filens = (glob.glob(join(modules_build_dir, '*.so')) +
                                  glob.glob(join(modules_build_dir, '*.py')))

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -63,14 +63,13 @@ class SDL2GradleBootstrap(Bootstrap):
 
             site_packages_dir = self.ctx.python_recipe.create_python_bundle(
                 join(self.dist_dir, python_bundle_dir), arch)
-                # TODO: Also set site_packages_dir again so fry_eggs can work
 
             if 'sqlite3' not in self.ctx.recipe_build_order:
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
         self.strip_libraries(arch)
-        self.fry_eggs(site_packages_dir)  # TODO uncomment this and make it work with python3
+        self.fry_eggs(site_packages_dir)
         super(SDL2GradleBootstrap, self).run_distribute()
 
 

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -13,7 +13,7 @@ EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 class SDL2GradleBootstrap(Bootstrap):
     name = 'sdl2_gradle'
 
-    recipe_depends = ['sdl2', ('python2', 'python3crystax')]
+    recipe_depends = ['sdl2', ('python2', 'python3', 'python3crystax')]
 
     def run_distribute(self):
         info_main("# Creating Android project ({})".format(self.name))

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -1,9 +1,7 @@
 from pythonforandroid.toolchain import (
     Bootstrap, shprint, current_directory, info, info_main)
 from pythonforandroid.util import ensure_dir
-from os.path import join, exists, curdir, abspath
-from os import walk
-import os
+from os.path import join, exists
 import sh
 
 

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -409,7 +409,7 @@ main.py that loads it.''')
 
 def parse_args(args=None):
     global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
-    default_android_api = 12
+    default_android_api = 21
     import argparse
     ap = argparse.ArgumentParser(description='''\
 Package a Python application for Android.

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -125,7 +125,7 @@ def make_python_zip():
 
     if not exists('private'):
         print('No compiled python is present to zip, skipping.')
-        print('this should only be the case if you are using the CrystaX python')
+        print('this should only be the case if you are using the CrystaX python or python3')
         return
 
     global python_files
@@ -243,6 +243,8 @@ main.py that loads it.''')
         tar_dirs.append('private')
     if exists('crystax_python'):
         tar_dirs.append('crystax_python')
+    if exists('_python_bundle'):
+        tar_dirs.append('_python_bundle')
 
     if args.private:
         make_tar('src/main/assets/private.mp3', tar_dirs, args.ignore_path)

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -544,18 +544,16 @@ tools directory of the Android SDK.
 
     if ndk_api != args.min_sdk_version:
         print(('WARNING: --minsdk argument does not match the api that is '
-                'compiled against. Only proceed if you know what you are '
-                'doing, otherwise use --minsdk={} or recompile against api '
-                '{}').format(ndk_api, args.min_sdk_version))
+               'compiled against. Only proceed if you know what you are '
+               'doing, otherwise use --minsdk={} or recompile against api '
+               '{}').format(ndk_api, args.min_sdk_version))
         if not args.allow_minsdk_ndkapi_mismatch:
             print('You must pass --allow-minsdk-ndkapi-mismatch to build '
-                    'with --minsdk different to the target NDK api from the '
-                    'build step')
+                  'with --minsdk different to the target NDK api from the '
+                  'build step')
             exit(1)
         else:
             print('Proceeding with --minsdk not matching build target api')
-            
-
 
     if args.sdk_version != -1:
         print('WARNING: Received a --sdk argument, but this argument is '

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -242,7 +242,7 @@ main.py that loads it.''')
     tar_dirs = [args.private]
     for python_bundle_dir in ('private', 'crystax_python', '_python_bundle'):
         if exists(python_bundle_dir):
-            tar_dirs.append(python_bundle_Dir)
+            tar_dirs.append(python_bundle_dir)
 
     if args.private:
         make_tar('src/main/assets/private.mp3', tar_dirs, args.ignore_path)

--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -240,12 +240,9 @@ main.py that loads it.''')
 
     # Package up the private data (public not supported).
     tar_dirs = [args.private]
-    if exists('private'):
-        tar_dirs.append('private')
-    if exists('crystax_python'):
-        tar_dirs.append('crystax_python')
-    if exists('_python_bundle'):
-        tar_dirs.append('_python_bundle')
+    for python_bundle_dir in ('private', 'crystax_python', '_python_bundle'):
+        if exists(python_bundle_dir):
+            tar_dirs.append(python_bundle_Dir)
 
     if args.private:
         make_tar('src/main/assets/private.mp3', tar_dirs, args.ignore_path)
@@ -413,14 +410,14 @@ main.py that loads it.''')
 def parse_args(args=None):
     global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
 
-    # Get the default minsdk, equal to the NDK API that this dist it built against
+    # Get the default minsdk, equal to the NDK API that this dist is built against
     with open('dist_info.json', 'r') as fileh:
         info = json.load(fileh)
         if 'ndk_api' not in info:
-            print('Failed to read ndk_api from dist info')
-            default_android_api = 12  # The old default before ndk_api was introduced
+            print('WARNING: Failed to read ndk_api from dist info, defaulting to 12')
+            default_min_api = 12  # The old default before ndk_api was introduced
         else:
-            default_android_api = info['ndk_api']
+            default_min_api = info['ndk_api']
             ndk_api = info['ndk_api']
 
     import argparse
@@ -504,9 +501,9 @@ tools directory of the Android SDK.
     ap.add_argument('--sdk', dest='sdk_version', default=-1,
                     type=int, help=('Deprecated argument, does nothing'))
     ap.add_argument('--minsdk', dest='min_sdk_version',
-                    default=default_android_api, type=int,
+                    default=default_min_api, type=int,
                     help=('Minimum Android SDK version that the app supports. '
-                          'Defaults to {}.'.format(default_android_api)))
+                          'Defaults to {}.'.format(default_min_api)))
     ap.add_argument('--allow-minsdk-ndkapi-mismatch', default=False,
                     action='store_true',
                     help=('Allow the --minsdk argument to be different from '

--- a/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
@@ -5,4 +5,4 @@
 
 # APP_ABI := armeabi armeabi-v7a x86
 APP_ABI := $(ARCH)
-APP_PLATFORM := android-21
+APP_PLATFORM := $(NDK_API)

--- a/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/Application.mk
@@ -5,3 +5,4 @@
 
 # APP_ABI := armeabi armeabi-v7a x86
 APP_ABI := $(ARCH)
+APP_PLATFORM := android-21

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -12,13 +12,13 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include
 LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 	start.c
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS) -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Include -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/android-build
+LOCAL_CFLAGS += -I$(PYTHON_INCLUDE_ROOT) $(EXTRA_CFLAGS)
 
 LOCAL_SHARED_LIBRARIES := SDL2 python_shared
 
-LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS) -lpython3.7m
+LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS)
 
-LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS) -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/android-build
+LOCAL_LDFLAGS += -L$(PYTHON_LINK_ROOT) $(APPLICATION_ADDITIONAL_LDFLAGS)
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/Android.mk
@@ -12,13 +12,13 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include
 LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
 	start.c
 
-LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS)
+LOCAL_CFLAGS += -I$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/include/python2.7 $(EXTRA_CFLAGS) -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/Include -I$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/android-build
 
 LOCAL_SHARED_LIBRARIES := SDL2 python_shared
 
-LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS)
+LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog $(EXTRA_LDLIBS) -lpython3.7m
 
-LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS)
+LOCAL_LDFLAGS += -L$(LOCAL_PATH)/../../../../other_builds/$(PYTHON2_NAME)/$(ARCH)/python2/python-install/lib $(APPLICATION_ADDITIONAL_LDFLAGS) -L$(LOCAL_PATH)/../../../../other_builds/python3/$(ARCH)/python3/android-build
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
@@ -123,8 +123,6 @@ int main(int argc, char *argv[]) {
         snprintf(paths, 256,
                 "%s/stdlib.zip:%s/modules",
                 crystax_python_dir, crystax_python_dir);
-        LOGP("calculated paths to be...");
-        LOGP(paths);
     }
 
     if (dir_exists(python_bundle_dir)) {
@@ -132,9 +130,10 @@ int main(int argc, char *argv[]) {
         snprintf(paths, 256,
                 "%s/stdlib.zip:%s/modules",
                 python_bundle_dir, python_bundle_dir);
-        LOGP("calculated paths to be...");
-        LOGP(paths);
     }
+
+    LOGP("calculated paths to be...");
+    LOGP(paths);
 
 
     #if PY_MAJOR_VERSION >= 3
@@ -148,7 +147,10 @@ int main(int argc, char *argv[]) {
 
         LOGP("set wchar paths...");
   } else {
-      LOGP("crystax_python does not exist");
+      // We do not expect to see crystax_python any more, so no point
+      // reminding the user about it. If it does exist, we'll have
+      // logged it earlier.
+      LOGP("_python_bundle does not exist");
   }
 
   Py_Initialize();

--- a/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
+++ b/pythonforandroid/bootstraps/sdl2/build/jni/src/start.c
@@ -76,10 +76,9 @@ int main(int argc, char *argv[]) {
   int ret = 0;
   FILE *fd;
 
-  /* AND: Several filepaths are hardcoded here, these must be made
-     configurable */
-  /* AND: P4A uses env vars...not sure what's best */
-  LOGP("Initialize Python for Android");
+  setenv("P4A_BOOTSTRAP", "SDL2", 1);  // env var to identify p4a to applications
+
+  LOGP("Initializing Python for Android");
   env_argument = getenv("ANDROID_ARGUMENT");
   setenv("ANDROID_APP_PATH", env_argument, 1);
   env_entrypoint = getenv("ANDROID_ENTRYPOINT");
@@ -109,32 +108,47 @@ int main(int argc, char *argv[]) {
 
   LOGP("Preparing to initialize python");
 
+  // Set up the python path
+  char paths[256];
+
   char crystax_python_dir[256];
   snprintf(crystax_python_dir, 256,
            "%s/crystax_python", getenv("ANDROID_UNPACK"));
-  if (dir_exists(crystax_python_dir)) {
-    LOGP("crystax_python exists");
-    char paths[256];
-    snprintf(paths, 256,
-             "%s/stdlib.zip:%s/modules",
-             crystax_python_dir, crystax_python_dir);
-    /* snprintf(paths, 256, "%s/stdlib.zip:%s/modules", env_argument,
-     * env_argument); */
-    LOGP("calculated paths to be...");
-    LOGP(paths);
+  char python_bundle_dir[256];
+  snprintf(python_bundle_dir, 256,
+           "%s/_python_bundle", getenv("ANDROID_UNPACK"));
+  if (dir_exists(crystax_python_dir) || dir_exists(python_bundle_dir)) {
+    if (dir_exists(crystax_python_dir)) {
+        LOGP("crystax_python exists");
+        snprintf(paths, 256,
+                "%s/stdlib.zip:%s/modules",
+                crystax_python_dir, crystax_python_dir);
+        LOGP("calculated paths to be...");
+        LOGP(paths);
+    }
 
-#if PY_MAJOR_VERSION >= 3
-    wchar_t *wchar_paths = Py_DecodeLocale(paths, NULL);
-    Py_SetPath(wchar_paths);
-#else
-    char *wchar_paths = paths;
-    LOGP("Can't Py_SetPath in python2, so crystax python2 doesn't work yet");
-    exit(1);
-#endif
+    if (dir_exists(python_bundle_dir)) {
+        LOGP("_python_bundle dir exists");
+        snprintf(paths, 256,
+                "%s/stdlib.zip:%s/modules",
+                python_bundle_dir, python_bundle_dir);
+        LOGP("calculated paths to be...");
+        LOGP(paths);
+    }
 
-    LOGP("set wchar paths...");
+
+    #if PY_MAJOR_VERSION >= 3
+        wchar_t *wchar_paths = Py_DecodeLocale(paths, NULL);
+        Py_SetPath(wchar_paths);
+    #else
+        char *wchar_paths = paths;
+        LOGP("Can't Py_SetPath in python2, so crystax python2 doesn't work yet");
+        exit(1);
+    #endif
+
+        LOGP("set wchar paths...");
   } else {
-    LOGP("crystax_python does not exist");
+      LOGP("crystax_python does not exist");
   }
 
   Py_Initialize();
@@ -174,11 +188,24 @@ int main(int argc, char *argv[]) {
                        "    argument ]\n");
   }
 
+  char add_site_packages_dir[256];
   if (dir_exists(crystax_python_dir)) {
-    char add_site_packages_dir[256];
     snprintf(add_site_packages_dir, 256,
              "sys.path.append('%s/site-packages')",
              crystax_python_dir);
+
+    PyRun_SimpleString("import sys\n"
+                       "sys.argv = ['notaninterpreterreally']\n"
+                       "from os.path import realpath, join, dirname");
+    PyRun_SimpleString(add_site_packages_dir);
+    /* "sys.path.append(join(dirname(realpath(__file__)), 'site-packages'))") */
+    PyRun_SimpleString("sys.path = ['.'] + sys.path");
+  }
+
+  if (dir_exists(python_bundle_dir)) {
+    snprintf(add_site_packages_dir, 256,
+             "sys.path.append('%s/site-packages')",
+             python_bundle_dir);
 
     PyRun_SimpleString("import sys\n"
                        "sys.argv = ['notaninterpreterreally']\n"
@@ -317,6 +344,7 @@ JNIEXPORT void JNICALL Java_org_kivy_android_PythonService_nativeStart(
   setenv("PYTHONHOME", python_home, 1);
   setenv("PYTHONPATH", python_path, 1);
   setenv("PYTHON_SERVICE_ARGUMENT", arg, 1);
+  setenv("P4A_BOOTSTRAP", "SDL2", 1);
 
   char *argv[] = {"."};
   /* ANDROID_ARGUMENT points to service subdir,

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -45,6 +45,8 @@ public class PythonUtil {
         addLibraryIfExists(libsList, "crypto.*", libsDir);
         libsList.add("python2.7");
         libsList.add("python3.5m");
+        libsList.add("python3.6m");
+        libsList.add("python3.7m");
         libsList.add("main");
         return libsList;
     }
@@ -66,7 +68,7 @@ public class PythonUtil {
                 // load, and it has failed, give a more
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
-                if (lib.startsWith("python3.6") && !foundPython) {
+                if (lib.startsWith("python3.7") && !foundPython) {
                     throw new java.lang.RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -509,14 +509,13 @@ class Context(object):
         '''Returns the location of site-packages in the python-install build
         dir.
         '''
+        if self.python_recipe.name == 'python2':
+            return join(self.get_python_install_dir(),
+                        'lib', 'python2.7', 'site-packages')
 
-        # This needs to be replaced with something more general in
-        # order to support multiple python versions and/or multiple
-        # archs.
-        if self.python_recipe.from_crystax:
-            return self.get_python_install_dir()
-        return join(self.get_python_install_dir(),
-                    'lib', 'python2.7', 'site-packages')
+        # Only python2 is a special case, other python recipes use the
+        # python install dir
+        return self.get_python_install_dir()
 
     def get_libs_dir(self, arch):
         '''The libs dir for a given arch.'''
@@ -621,7 +620,9 @@ def run_pymodules_install(ctx, modules):
 
     venv = sh.Command(ctx.virtualenv)
     with current_directory(join(ctx.build_dir)):
-        shprint(venv, '--python=python2.7', 'venv')
+        shprint(venv,
+                '--python=python{}'.format(ctx.python_recipe.major_minor_version_string()),
+                'venv')
 
         info('Creating a requirements.txt file for the Python modules')
         with open('requirements.txt', 'w') as fileh:

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -355,7 +355,7 @@ class Context(object):
         if not self.ccache:
             info('ccache is missing, the build will not be optimized in the '
                  'future.')
-        for cython_fn in ("cython2", "cython-2.7", "cython"):
+        for cython_fn in ("cython", "cython3", "cython2", "cython-2.7"):
             cython = sh.which(cython_fn)
             if cython:
                 self.cython = cython

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -340,6 +340,12 @@ class Context(object):
         self.ndk_ver = ndk_ver
 
         self.ndk_api = user_ndk_api
+        if self.ndk_api > self.android_api:
+            error('Target NDK API is {}, higher than the target Android API {}.'.format(
+                self.ndk_api, self.android_api))
+            error('The NDK API is a minimum supported API number and must be lower '
+                  'than the target Android API')
+            exit(1)
 
         info('Using {} NDK {}'.format(self.ndk.capitalize(), self.ndk_ver))
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -17,6 +17,8 @@ from pythonforandroid.recipe import Recipe
 
 DEFAULT_ANDROID_API = 15
 
+DEFAULT_NDK_API = 21
+
 
 class Context(object):
     '''A build context. If anything will be built, an instance this class
@@ -352,7 +354,23 @@ class Context(object):
                     'set it with `--ndk-version=...`.')
         self.ndk_ver = ndk_ver
 
-        self.ndk_api = user_ndk_api
+        ndk_api = None
+        if user_ndk_api:
+            ndk_api = user_ndk_api
+            if ndk_api is not None:
+                info('Getting NDK API version (i.e. minimum supported API) from user argument')
+        if ndk_api is None:
+            ndk_api = environ.get('NDKAPI', None)
+            if ndk_api is not None:
+                info('Found Android API target in $NDKAPI')
+        if ndk_api is None:
+            ndk_api = min(self.android_api, DEFAULT_NDK_API)
+            warning('NDK API target was not set manually, using '
+                    'the default of {} = min(android-api={}, default ndk-api={})'.format(
+                        ndk_api, self.android_api, DEFAULT_NDK_API))
+        ndk_api = int(ndk_api)
+        self.ndk_api = ndk_api
+
         if self.ndk_api > self.android_api:
             error('Target NDK API is {}, higher than the target Android API {}.'.format(
                 self.ndk_api, self.android_api))

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -231,13 +231,11 @@ class Context(object):
         android_api = None
         if user_android_api:
             android_api = user_android_api
-            if android_api is not None:
-                info('Getting Android API version from user argument')
-        if android_api is None:
-            android_api = environ.get('ANDROIDAPI', None)
-            if android_api is not None:
-                info('Found Android API target in $ANDROIDAPI')
-        if android_api is None:
+            info('Getting Android API version from user argument')
+        elif 'ANDROIDAPI' in environ:
+            android_api = environ['ANDROIDAPI']
+            info('Found Android API target in $ANDROIDAPI')
+        else:
             info('Android API target was not set manually, using '
                  'the default of {}'.format(DEFAULT_ANDROID_API))
             android_api = DEFAULT_ANDROID_API
@@ -357,11 +355,10 @@ class Context(object):
         if user_ndk_api:
             ndk_api = user_ndk_api
             info('Getting NDK API version (i.e. minimum supported API) from user argument')
-        if ndk_api is None:
+        elif 'NDKAPI' in environ:
             ndk_api = environ.get('NDKAPI', None)
-            if ndk_api is not None:
-                info('Found Android API target in $NDKAPI')
-        if ndk_api is None:
+            info('Found Android API target in $NDKAPI')
+        else:
             ndk_api = min(self.android_api, DEFAULT_NDK_API)
             warning('NDK API target was not set manually, using '
                     'the default of {} = min(android-api={}, default ndk-api={})'.format(

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -280,8 +280,7 @@ class Context(object):
         ndk_dir = None
         if user_ndk_dir:
             ndk_dir = user_ndk_dir
-            if ndk_dir is not None:
-                info('Getting NDK dir from from user argument')
+            info('Getting NDK dir from from user argument')
         if ndk_dir is None:  # The old P4A-specific dir
             ndk_dir = environ.get('ANDROIDNDK', None)
             if ndk_dir is not None:
@@ -357,8 +356,7 @@ class Context(object):
         ndk_api = None
         if user_ndk_api:
             ndk_api = user_ndk_api
-            if ndk_api is not None:
-                info('Getting NDK API version (i.e. minimum supported API) from user argument')
+            info('Getting NDK API version (i.e. minimum supported API) from user argument')
         if ndk_api is None:
             ndk_api = environ.get('NDKAPI', None)
             if ndk_api is not None:

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -627,7 +627,7 @@ def run_pymodules_install(ctx, modules):
     venv = sh.Command(ctx.virtualenv)
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '--python=python{}'.format(ctx.python_recipe.major_minor_version_string()),
+                '--python=python{}'.format(ctx.python_recipe.major_minor_version_string),
                 'venv')
 
         info('Creating a requirements.txt file for the Python modules')

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -125,6 +125,19 @@ class Context(object):
         self._android_api = value
 
     @property
+    def ndk_api(self):
+        '''The API number compile against'''
+        if self._ndk_api is None:
+            raise ValueError('Tried to access ndk_api_api but it has not '
+                             'been set - this should not happen, something '
+                             'went wrong!')
+        return self._ndk_api
+
+    @ndk_api.setter
+    def ndk_api(self, value):
+        self._ndk_api = value
+
+    @property
     def ndk_ver(self):
         '''The version of the NDK being used for compilation.'''
         if self._ndk_ver is None:
@@ -461,6 +474,7 @@ class Context(object):
         self._sdk_dir = None
         self._ndk_dir = None
         self._android_api = None
+        self._ndk_api = None
         self._ndk_ver = None
         self.ndk = None
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -163,8 +163,12 @@ class Context(object):
     def ndk_dir(self, value):
         self._ndk_dir = value
 
-    def prepare_build_environment(self, user_sdk_dir, user_ndk_dir,
-                                  user_android_api, user_ndk_ver):
+    def prepare_build_environment(self,
+                                  user_sdk_dir,
+                                  user_ndk_dir,
+                                  user_android_api,
+                                  user_ndk_ver,
+                                  user_ndk_api):
         '''Checks that build dependencies exist and sets internal variables
         for the Android SDK etc.
 
@@ -334,6 +338,8 @@ class Context(object):
                     'won\'t cause any problems, but if necessary you can'
                     'set it with `--ndk-version=...`.')
         self.ndk_ver = ndk_ver
+
+        self.ndk_api = user_ndk_api
 
         info('Using {} NDK {}'.format(self.ndk.capitalize(), self.ndk_ver))
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -381,7 +381,7 @@ class Context(object):
         self.ndk_platform = join(
             self.ndk_dir,
             'platforms',
-            'android-{}'.format(self.android_api),
+            'android-{}'.format(self.ndk_api),
             platform_dir)
         if not exists(self.ndk_platform):
             warning('ndk_platform doesn\'t exist: {}'.format(

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -182,29 +182,19 @@ class Distribution(object):
                 dists.append(dist)
         return dists
 
-    # def save_info(self):
-    #     '''
-    #     Save information about the distribution in its dist_dir.
-    #     '''
-    #     with current_directory(self.dist_dir):
-    #         info('Saving distribution info')
-    #         with open('dist_info.json', 'w') as fileh:
-    #             json.dump({'dist_name': self.name,
-    #                        'archs': [arch.arch for arch in self.ctx.archs],
-    #                        'ndk_api': self.ctx.ndk_api,
-    #                        'recipes': self.ctx.recipe_build_order},
-    #                       fileh)
-
-    # def load_info(self):
-    #     '''Load information about the dist from the info file that p4a
-    #     automatically creates.'''
-    #     with current_directory(self.dist_dir):
-    #         filen = 'dist_info.json'
-    #         if not exists(filen):
-    #             return None
-    #         with open('dist_info.json', 'r') as fileh:
-    #             dist_info = json.load(fileh)
-    #     return dist_info
+    def save_info(self, dirn):
+        '''
+        Save information about the distribution in its dist_dir.
+        '''
+        with current_directory(dirn):
+            info('Saving distribution info')
+            with open('dist_info.json', 'w') as fileh:
+                json.dump({'dist_name': self.ctx.dist_name,
+                           'bootstrap': self.ctx.bootstrap.name,
+                           'archs': [arch.arch for arch in self.ctx.archs],
+                           'ndk_api': self.ctx.ndk_api,
+                           'recipes': self.ctx.recipe_build_order + self.ctx.python_modules},
+                          fileh)
 
 
 def pretty_log_dists(dists, log_func=info):

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -182,28 +182,29 @@ class Distribution(object):
                 dists.append(dist)
         return dists
 
-    def save_info(self):
-        '''
-        Save information about the distribution in its dist_dir.
-        '''
-        with current_directory(self.dist_dir):
-            info('Saving distribution info')
-            with open('dist_info.json', 'w') as fileh:
-                json.dump({'dist_name': self.name,
-                           'archs': [arch.arch for arch in self.ctx.archs],
-                           'recipes': self.ctx.recipe_build_order},
-                          fileh)
+    # def save_info(self):
+    #     '''
+    #     Save information about the distribution in its dist_dir.
+    #     '''
+    #     with current_directory(self.dist_dir):
+    #         info('Saving distribution info')
+    #         with open('dist_info.json', 'w') as fileh:
+    #             json.dump({'dist_name': self.name,
+    #                        'archs': [arch.arch for arch in self.ctx.archs],
+    #                        'ndk_api': self.ctx.ndk_api,
+    #                        'recipes': self.ctx.recipe_build_order},
+    #                       fileh)
 
-    def load_info(self):
-        '''Load information about the dist from the info file that p4a
-        automatically creates.'''
-        with current_directory(self.dist_dir):
-            filen = 'dist_info.json'
-            if not exists(filen):
-                return None
-            with open('dist_info.json', 'r') as fileh:
-                dist_info = json.load(fileh)
-        return dist_info
+    # def load_info(self):
+    #     '''Load information about the dist from the info file that p4a
+    #     automatically creates.'''
+    #     with current_directory(self.dist_dir):
+    #         filen = 'dist_info.json'
+    #         if not exists(filen):
+    #             return None
+    #         with open('dist_info.json', 'r') as fileh:
+    #             dist_info = json.load(fileh)
+    #     return dist_info
 
 
 def pretty_log_dists(dists, log_func=info):

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -3,7 +3,7 @@ import glob
 import json
 
 from pythonforandroid.logger import (info, info_notify, warning,
-                                     Err_Style, Err_Fore)
+                                     Err_Style, Err_Fore, error)
 from pythonforandroid.util import current_directory
 
 
@@ -21,6 +21,7 @@ class Distribution(object):
     needs_build = False  # Whether the dist needs compiling
     url = None
     dist_dir = None  # Where the dist dir ultimately is. Should not be None.
+    ndk_api = None
 
     archs = []
     '''The arch targets that the dist is built for.'''
@@ -42,6 +43,7 @@ class Distribution(object):
 
     @classmethod
     def get_distribution(cls, ctx, name=None, recipes=[],
+                         ndk_api=None,
                          force_build=False,
                          extra_dist_dirs=[],
                          require_perfect_match=False):
@@ -76,13 +78,19 @@ class Distribution(object):
 
         possible_dists = existing_dists
 
+        name_match_dist = None
+
         # 0) Check if a dist with that name already exists
         if name is not None and name:
             possible_dists = [d for d in possible_dists if d.name == name]
+            if possible_dists:
+                name_match_dist = possible_dists[0]
 
         # 1) Check if any existing dists meet the requirements
         _possible_dists = []
         for dist in possible_dists:
+            if ndk_api is not None and dist.ndk_api != ndk_api:
+                continue
             for recipe in recipes:
                 if recipe not in dist.recipes:
                     break
@@ -97,9 +105,11 @@ class Distribution(object):
         else:
             info('No existing dists meet the given requirements!')
 
-        # If any dist has perfect recipes, return it
+        # If any dist has perfect recipes and ndk API, return it
         for dist in possible_dists:
             if force_build:
+                continue
+            if ndk_api is not None and dist.ndk_api != ndk_api:
                 continue
             if (set(dist.recipes) == set(recipes) or
                 (set(recipes).issubset(set(dist.recipes)) and
@@ -110,33 +120,21 @@ class Distribution(object):
 
         assert len(possible_dists) < 2
 
-        if not name and possible_dists:
-            info('Asked for dist with name {} with recipes ({}), but a dist '
-                 'with this name already exists and has incompatible recipes '
-                 '({})'.format(name, ', '.join(recipes),
-                               ', '.join(possible_dists[0].recipes)))
-            info('No compatible dist found, so exiting.')
+        # If there was a name match but we didn't already choose it,
+        # then the existing dist is incompatible with the requested
+        # configuration and the build cannot continue
+        if name_match_dist is not None:
+            error('Asked for dist with name {name} with recipes ({req_recipes}) and '
+                  'NDK API {req_ndk_api}, but a dist '
+                  'with this name already exists and has either incompatible recipes '
+                  '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
+                      name=name,
+                      req_ndk_api=ndk_api,
+                      dist_ndk_api=name_match_dist.ndk_api,
+                      req_recipes=', '.join(recipes),
+                      dist_recipes=', '.join(name_match_dist.recipes)))
+            error('No compatible dist found, so exiting.')
             exit(1)
-
-        # # 2) Check if any downloadable dists meet the requirements
-
-        # online_dists = [('testsdl2', ['hostpython2', 'sdl2_image',
-        #                               'sdl2_mixer', 'sdl2_ttf',
-        #                               'python2', 'sdl2',
-        #                               'pyjniussdl2', 'kivysdl2'],
-        #                  'https://github.com/inclement/sdl2-example-dist/archive/master.zip'),
-        #                  ]
-        # _possible_dists = []
-        # for dist_name, dist_recipes, dist_url in online_dists:
-        #     for recipe in recipes:
-        #         if recipe not in dist_recipes:
-        #             break
-        #     else:
-        #         dist = Distribution(ctx)
-        #         dist.name = dist_name
-        #         dist.url = dist_url
-        #         _possible_dists.append(dist)
-        # # if _possible_dists
 
         # If we got this far, we need to build a new dist
         dist = Distribution(ctx)
@@ -152,6 +150,7 @@ class Distribution(object):
         dist.name = name
         dist.dist_dir = join(ctx.dist_dir, dist.name)
         dist.recipes = recipes
+        dist.ndk_api = ctx.ndk_api
 
         return dist
 
@@ -179,6 +178,7 @@ class Distribution(object):
                 dist.recipes = dist_info['recipes']
                 if 'archs' in dist_info:
                     dist.archs = dist_info['archs']
+                dist.ndk_api = dist_info['ndk_api']
                 dists.append(dist)
         return dists
 
@@ -200,10 +200,12 @@ class Distribution(object):
 def pretty_log_dists(dists, log_func=info):
     infos = []
     for dist in dists:
-        infos.append('{Fore.GREEN}{Style.BRIGHT}{name}{Style.RESET_ALL}: '
+        ndk_api = 'unknown' if dist.ndk_api is None else dist.ndk_api
+        infos.append('{Fore.GREEN}{Style.BRIGHT}{name}{Style.RESET_ALL}: min API {ndk_api}, '
                      'includes recipes ({Fore.GREEN}{recipes}'
                      '{Style.RESET_ALL}), built for archs ({Fore.BLUE}'
                      '{archs}{Style.RESET_ALL})'.format(
+                         ndk_api=ndk_api,
                          name=dist.name, recipes=', '.join(dist.recipes),
                          archs=', '.join(dist.archs) if dist.archs else 'UNKNOWN',
                          Fore=Err_Fore, Style=Err_Style))

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -277,7 +277,8 @@ class Recipe(with_metaclass(RecipeMeta)):
         alternative or optional dependencies are being built.
         '''
         dir_name = self.get_dir_name()
-        return join(self.ctx.build_dir, 'other_builds', dir_name, arch)
+        return join(self.ctx.build_dir, 'other_builds',
+                    dir_name, '{}__ndk_target_{}'.format(arch, self.ctx.ndk_api))
 
     def get_dir_name(self):
         choices = self.check_recipe_choices()
@@ -1084,7 +1085,6 @@ class CythonRecipe(PythonRecipe):
 
         return env
 
-
 class TargetPythonRecipe(Recipe):
     '''Class for target python recipes. Sets ctx.python_recipe to point to
     itself, so as to know later what kind of Python was built or used.'''
@@ -1104,6 +1104,13 @@ class TargetPythonRecipe(Recipe):
                   'using the CrystaX NDK. Exiting.'.format(self.name))
             exit(1)
         self.ctx.python_recipe = self
+
+    def include_root(self, arch):
+        '''The root directory from which to include headers.'''
+        raise NotImplementedError('Not implemented in TargetPythonRecipe')
+
+    def link_root(self):
+        raise NotImplementedError('Not implemented in TargetPythonRecipe')
 
     # @property
     # def ctx(self):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -20,8 +20,6 @@ from pythonforandroid.logger import (logger, info, warning, error, debug, shprin
 from pythonforandroid.util import (urlretrieve, current_directory, ensure_dir)
 
 # this import is necessary to keep imp.load_source from complaining :)
-
-
 if PY2:
     import imp
     import_recipe = imp.load_source
@@ -167,20 +165,6 @@ class Recipe(with_metaclass(RecipeMeta)):
                         shprint(sh.git, 'submodule', 'update', '--recursive')
             return target
 
-    # def get_archive_rootdir(self, filename):
-    #     if filename.endswith(".tgz") or filename.endswith(".tar.gz") or \
-    #         filename.endswith(".tbz2") or filename.endswith(".tar.bz2"):
-    #         archive = tarfile.open(filename)
-    #         root = archive.next().path.split("/")
-    #         return root[0]
-    #     elif filename.endswith(".zip"):
-    #         with zipfile.ZipFile(filename) as zf:
-    #             return dirname(zf.namelist()[0])
-    #     else:
-    #         print("Error: cannot detect root directory")
-    #         print("Unrecognized extension for {}".format(filename))
-    #         raise Exception()
-
     def apply_patch(self, filename, arch):
         """
         Apply a patch from the current recipe directory into the current
@@ -206,41 +190,11 @@ class Recipe(with_metaclass(RecipeMeta)):
         with open(dest, "ab") as fd:
             fd.write(data)
 
-    # def has_marker(self, marker):
-    #     """
-    #     Return True if the current build directory has the marker set
-    #     """
-    #     return exists(join(self.build_dir, ".{}".format(marker)))
-
-    # def set_marker(self, marker):
-    #     """
-    #     Set a marker info the current build directory
-    #     """
-    #     with open(join(self.build_dir, ".{}".format(marker)), "w") as fd:
-    #         fd.write("ok")
-
-    # def delete_marker(self, marker):
-    #     """
-    #     Delete a specific marker
-    #     """
-    #     try:
-    #         unlink(join(self.build_dir, ".{}".format(marker)))
-    #     except:
-    #         pass
-
     @property
     def name(self):
         '''The name of the recipe, the same as the folder containing it.'''
         modname = self.__class__.__module__
         return modname.split(".", 2)[-1]
-
-    # @property
-    # def archive_fn(self):
-    #     bfn = basename(self.url.format(version=self.version))
-    #     fn = "{}/{}-{}".format(
-    #         self.ctx.cache_dir,
-    #         self.name, bfn)
-    #     return fn
 
     @property
     def filtered_archs(self):
@@ -1095,7 +1049,7 @@ class TargetPythonRecipe(Recipe):
 
     def prebuild_arch(self, arch):
         super(TargetPythonRecipe, self).prebuild_arch(arch)
-        if self.from_crystax and self.ctx.ndk != 'crystax':
+        if elf.from_crystax and self.ctx.ndk != 'crystax':
             error('The {} recipe can only be built when '
                   'using the CrystaX NDK. Exiting.'.format(self.name))
             exit(1)

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1,4 +1,4 @@
-from os.path import basename, dirname, exists, isdir, isfile, join, realpath
+from os.path import basename, dirname, exists, isdir, isfile, join, realpath, split
 import importlib
 import glob
 from shutil import rmtree
@@ -1124,6 +1124,20 @@ class TargetPythonRecipe(Recipe):
         place.
         """
         raise NotImplementedError('{} does not implement create_python_bundle'.format(self))
+
+    def reduce_object_file_names(self, dirn):
+        """Recursively renames all files named XXX.cpython-...-linux-gnu.so"
+        to "XXX.so", i.e. removing the erroneous architecture name
+        coming from the local system.
+        """
+        py_so_files = shprint(sh.find, dirn, '-iname', '*.so')
+        filens = py_so_files.stdout.decode('utf-8').split('\n')[:-1]
+        for filen in filens:
+            file_dirname, file_basename = split(filen)
+            parts = file_basename.split('.')
+            if len(parts) <= 2:
+                continue
+            shprint(sh.mv, filen, join(file_dirname, parts[0] + '.so'))
 
 
 def md5sum(filen):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1112,14 +1112,18 @@ class TargetPythonRecipe(Recipe):
     def link_root(self):
         raise NotImplementedError('Not implemented in TargetPythonRecipe')
 
-    # @property
-    # def ctx(self):
-    #     return self._ctx
+    @property
+    def major_minor_version_string(self):
+        from distutils.version import LooseVersion
+        return '.'.join([str(v) for v in LooseVersion(self.version).version[:2]])
 
-    # @ctx.setter
-    # def ctx(self, ctx):
-    #     self._ctx = ctx
-    #     ctx.python_recipe = self
+    def create_python_bundle(self, dirn, arch):
+        """
+        Create a packaged python bundle in the target directory, by
+        copying all the modules and standard library to the right
+        place.
+        """
+        raise NotImplementedError('{} does not implement create_python_bundle'.format(self))
 
 
 def md5sum(filen):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -952,7 +952,7 @@ class CythonRecipe(PythonRecipe):
     def __init__(self, *args, **kwargs):
         super(CythonRecipe, self).__init__(*args, **kwargs)
         depends = self.depends
-        depends.append(('python2', 'python3crystax'))
+        depends.append(('python2', 'python3', 'python3crystax'))
         depends = list(set(depends))
         self.depends = depends
 

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1035,6 +1035,7 @@ class CythonRecipe(PythonRecipe):
 
         return env
 
+
 class TargetPythonRecipe(Recipe):
     '''Class for target python recipes. Sets ctx.python_recipe to point to
     itself, so as to know later what kind of Python was built or used.'''

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -789,14 +789,10 @@ class PythonRecipe(Recipe):
                     join(ndk_dir_python, 'libs', arch.arch))
                 env['LDFLAGS'] += ' -lpython{}m'.format(python_short_version)
             elif 'python3' in self.ctx.recipe_build_order:
-                # TODO: Make the recipe env get these details from the
-                # python recipe instead of hardcoding
-                env['PYTHON_ROOT'] = Recipe.get_recipe('python3', self.ctx).get_build_dir(arch.arch)
-                env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/Include'
-                env['LDFLAGS'] += (
-                    ' -L' +
-                    join(env['PYTHON_ROOT'], 'android-build') +
-                    ' -lpython3.7m')
+                env['CFLAGS'] += ' -I{}'.format(self.ctx.python_recipe.include_root(arch.arch))
+                env['LDFLAGS'] += ' -L{} -lpython{}m'.format(
+                    self.ctx.python_recipe.link_root(arch.arch),
+                    self.ctx.python_recipe.major_minor_version_string)
 
             hppath = []
             hppath.append(join(dirname(self.hostpython_location), 'Lib'))

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -712,6 +712,13 @@ class PythonRecipe(Recipe):
     setup_extra_args = []
     '''List of extra arugments to pass to setup.py'''
 
+    def __init__(self, *args, **kwargs):
+        super(PythonRecipe, self).__init__(*args, **kwargs)
+        depends = self.depends
+        depends.append(('python2', 'python3', 'python3crystax'))
+        depends = list(set(depends))
+        self.depends = depends
+
     def clean_build(self, arch=None):
         super(PythonRecipe, self).clean_build(arch=arch)
         name = self.folder_name

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1049,7 +1049,7 @@ class TargetPythonRecipe(Recipe):
 
     def prebuild_arch(self, arch):
         super(TargetPythonRecipe, self).prebuild_arch(arch)
-        if elf.from_crystax and self.ctx.ndk != 'crystax':
+        if self.from_crystax and self.ctx.ndk != 'crystax':
             error('The {} recipe can only be built when '
                   'using the CrystaX NDK. Exiting.'.format(self.name))
             exit(1)

--- a/pythonforandroid/recipes/android/__init__.py
+++ b/pythonforandroid/recipes/android/__init__.py
@@ -13,7 +13,8 @@ class AndroidRecipe(IncludedFilesBehaviour, CythonRecipe):
 
     src_filename = 'src'
 
-    depends = [('pygame', 'sdl2', 'genericndkbuild'), ('python2', 'python3crystax')]
+    depends = [('pygame', 'sdl2', 'genericndkbuild'),
+               ('python2', 'python3crystax', 'python3')]
 
     config_env = {}
 

--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -332,7 +332,7 @@ class AndroidBrowser(object):
         return open_url(url)
     
 import webbrowser
-webbrowser.register('android', AndroidBrowser, None, -1)
+webbrowser.register('android', AndroidBrowser)
 
 cdef extern void android_start_service(char *, char *, char *)
 def start_service(title=None, description=None, arg=None):

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -6,8 +6,8 @@ import sh
 
 
 class Hostpython3Recipe(Recipe):
-    version = 'bpo-30386'
-    url = 'https://github.com/inclement/cpython/archive/{version}.zip'
+    version = '3.7.0'
+    url = 'https://www.python.org/ftp/python/3.7.0/Python-{version}.tgz'
     name = 'hostpython3'
 
     conflicts = ['hostpython2']

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -10,7 +10,7 @@ class Hostpython3Recipe(Recipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'hostpython3'
 
-    conflicts = ['hostpython2']
+    conflicts = ['hostpython2', 'hostpython3crystax']
 
     def get_build_container_dir(self, arch=None):
         choices = self.check_recipe_choices()

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -30,9 +30,6 @@ class Hostpython3Recipe(Recipe):
 
         if not exists(join(build_dir, 'python')):
             with current_directory(recipe_build_dir):
-                env = {}  # The command line environment we will use
-
-
                 # Configure the build
                 with current_directory(build_dir):
                     if not exists('config.status'):
@@ -40,8 +37,6 @@ class Hostpython3Recipe(Recipe):
 
                 # Create the Setup file. This copying from Setup.dist
                 # seems to be the normal and expected procedure.
-                assert exists(join(build_dir, 'Modules')), (
-                    'Expected dir {} does not exist'.format(join(build_dir, 'Modules')))
                 shprint(sh.cp, join('Modules', 'Setup.dist'), join(build_dir, 'Modules', 'Setup'))
 
                 result = shprint(sh.make, '-C', build_dir)
@@ -49,6 +44,5 @@ class Hostpython3Recipe(Recipe):
             info('Skipping hostpython3 build as it has already been completed')
 
         self.ctx.hostpython = join(build_dir, 'python')
-        self.ctx.hostpgen = '/usr/bin/false'  # is this actually used for anything?
 
 recipe = Hostpython3Recipe()

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -1,0 +1,53 @@
+from pythonforandroid.toolchain import Recipe, shprint, info, warning
+from pythonforandroid.util import ensure_dir, current_directory
+from os.path import join, exists
+import os
+import sh
+
+
+class Hostpython3Recipe(Recipe):
+    version = 'bpo-30386'
+    url = 'https://github.com/inclement/cpython/archive/{version}.zip'
+    name = 'hostpython3'
+
+    conflicts = ['hostpython2']
+
+    def get_build_container_dir(self, arch=None):
+        choices = self.check_recipe_choices()
+        dir_name = '-'.join([self.name] + choices)
+        return join(self.ctx.build_dir, 'other_builds', dir_name, 'desktop')
+
+    def get_build_dir(self, arch=None):
+        # Unlike other recipes, the hostpython build dir doesn't depend on the target arch
+        return join(self.get_build_container_dir(), self.name)
+
+    def build_arch(self, arch):
+        recipe_build_dir = self.get_build_dir(arch.arch)
+        with current_directory(recipe_build_dir):
+            # Create a subdirectory to actually perform the build
+            build_dir = join(recipe_build_dir, 'native-build')
+            ensure_dir(build_dir)
+
+            env = {}  # The command line environment we will use
+
+
+            # Configure the build
+            with current_directory(build_dir):
+                if not exists('config.status'):
+                    shprint(sh.Command(join(recipe_build_dir, 'configure')))
+
+            # Create the Setup file. This copying from Setup.dist
+            # seems to be the normal and expected procedure.
+            assert exists(join(build_dir, 'Modules')), (
+                'Expected dir {} does not exist'.format(join(build_dir, 'Modules')))
+            shprint(sh.cp, join('Modules', 'Setup.dist'), join(build_dir, 'Modules', 'Setup'))
+
+            result = shprint(sh.make, '-C', build_dir)
+
+        self.ctx.hostpython = join(build_dir, 'python')
+        self.ctx.hostpgen = '/usr/bin/false'  # is this actually used for anything?
+
+        print('result is', result)
+        exit(1)
+
+recipe = Hostpython3Recipe()

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -1,7 +1,6 @@
-from pythonforandroid.toolchain import Recipe, shprint, info, warning
+from pythonforandroid.toolchain import Recipe, shprint, info
 from pythonforandroid.util import ensure_dir, current_directory
 from os.path import join, exists
-import os
 import sh
 
 
@@ -44,5 +43,6 @@ class Hostpython3Recipe(Recipe):
             info('Skipping hostpython3 build as it has already been completed')
 
         self.ctx.hostpython = join(build_dir, 'python')
+
 
 recipe = Hostpython3Recipe()

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -6,7 +6,7 @@ import sh
 
 
 class Hostpython3Recipe(Recipe):
-    version = '3.7.0'
+    version = '3.7.1'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'hostpython3'
 

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -23,31 +23,32 @@ class Hostpython3Recipe(Recipe):
 
     def build_arch(self, arch):
         recipe_build_dir = self.get_build_dir(arch.arch)
-        with current_directory(recipe_build_dir):
-            # Create a subdirectory to actually perform the build
-            build_dir = join(recipe_build_dir, 'native-build')
-            ensure_dir(build_dir)
 
-            env = {}  # The command line environment we will use
+        # Create a subdirectory to actually perform the build
+        build_dir = join(recipe_build_dir, 'native-build')
+        ensure_dir(build_dir)
+
+        if not exists(join(build_dir, 'python')):
+            with current_directory(recipe_build_dir):
+                env = {}  # The command line environment we will use
 
 
-            # Configure the build
-            with current_directory(build_dir):
-                if not exists('config.status'):
-                    shprint(sh.Command(join(recipe_build_dir, 'configure')))
+                # Configure the build
+                with current_directory(build_dir):
+                    if not exists('config.status'):
+                        shprint(sh.Command(join(recipe_build_dir, 'configure')))
 
-            # Create the Setup file. This copying from Setup.dist
-            # seems to be the normal and expected procedure.
-            assert exists(join(build_dir, 'Modules')), (
-                'Expected dir {} does not exist'.format(join(build_dir, 'Modules')))
-            shprint(sh.cp, join('Modules', 'Setup.dist'), join(build_dir, 'Modules', 'Setup'))
+                # Create the Setup file. This copying from Setup.dist
+                # seems to be the normal and expected procedure.
+                assert exists(join(build_dir, 'Modules')), (
+                    'Expected dir {} does not exist'.format(join(build_dir, 'Modules')))
+                shprint(sh.cp, join('Modules', 'Setup.dist'), join(build_dir, 'Modules', 'Setup'))
 
-            result = shprint(sh.make, '-C', build_dir)
+                result = shprint(sh.make, '-C', build_dir)
+        else:
+            info('Skipping hostpython3 build as it has already been completed')
 
         self.ctx.hostpython = join(build_dir, 'python')
         self.ctx.hostpgen = '/usr/bin/false'  # is this actually used for anything?
-
-        print('result is', result)
-        exit(1)
 
 recipe = Hostpython3Recipe()

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -7,7 +7,7 @@ import sh
 
 class Hostpython3Recipe(Recipe):
     version = '3.7.0'
-    url = 'https://www.python.org/ftp/python/3.7.0/Python-{version}.tgz'
+    url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'hostpython3'
 
     conflicts = ['hostpython2']

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -3,6 +3,8 @@ from pythonforandroid.util import ensure_dir, current_directory
 from os.path import join, exists
 import sh
 
+BUILD_SUBDIR = 'native-build'
+
 
 class Hostpython3Recipe(Recipe):
     version = '3.7.1'
@@ -20,11 +22,14 @@ class Hostpython3Recipe(Recipe):
         # Unlike other recipes, the hostpython build dir doesn't depend on the target arch
         return join(self.get_build_container_dir(), self.name)
 
+    def get_path_to_python(self):
+        return join(self.get_build_dir(), BUILD_SUBDIR)
+
     def build_arch(self, arch):
         recipe_build_dir = self.get_build_dir(arch.arch)
 
         # Create a subdirectory to actually perform the build
-        build_dir = join(recipe_build_dir, 'native-build')
+        build_dir = join(recipe_build_dir, BUILD_SUBDIR)
         ensure_dir(build_dir)
 
         if not exists(join(build_dir, 'python')):

--- a/pythonforandroid/recipes/hostpython3crystax/__init__.py
+++ b/pythonforandroid/recipes/hostpython3crystax/__init__.py
@@ -3,7 +3,7 @@ from os.path import join
 import sh
 
 
-class Hostpython3Recipe(Recipe):
+class Hostpython3CrystaXRecipe(Recipe):
     version = 'auto'  # the version is taken from the python3crystax recipe
     name = 'hostpython3crystax'
 
@@ -41,4 +41,4 @@ class Hostpython3Recipe(Recipe):
         shprint(sh.ln, '-sf', system_python, link_dest)
 
 
-recipe = Hostpython3Recipe()
+recipe = Hostpython3CrystaXRecipe()

--- a/pythonforandroid/recipes/hostpython3crystax/__init__.py
+++ b/pythonforandroid/recipes/hostpython3crystax/__init__.py
@@ -27,7 +27,6 @@ class Hostpython3Recipe(Recipe):
         Creates expected build and symlinks system Python version.
         """
         self.ctx.hostpython = '/usr/bin/false'
-        self.ctx.hostpgen = '/usr/bin/false'
         # creates the sub buildir (used by other recipes)
         # https://github.com/kivy/python-for-android/issues/1154
         sub_build_dir = join(self.get_build_dir(), 'build')

--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -9,7 +9,7 @@ class PyjniusRecipe(CythonRecipe):
     version = '1.1.3'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
-    depends = [('python2', 'python3crystax'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']
+    depends = [('python2', 'python3', 'python3crystax'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']
     site_packages_name = 'jnius'
 
     patches = [('sdl2_jnienv_getter.patch', will_build('sdl2')),

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -9,6 +9,7 @@ import sh
 
 EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 
+
 class Python2Recipe(TargetPythonRecipe):
     version = "2.7.2"
     url = 'https://python.org/ftp/python/{version}/Python-{version}.tar.bz2'
@@ -187,7 +188,7 @@ class Python2Recipe(TargetPythonRecipe):
             shprint(sh.mv, libpymodules_fn, dirn)
         shprint(sh.cp,
                 join('python-install', 'include',
-                        'python2.7', 'pyconfig.h'),
+                     'python2.7', 'pyconfig.h'),
                 join(dirn, 'include', 'python2.7/'))
 
         info('Removing some unwanted files')
@@ -219,5 +220,6 @@ class Python2Recipe(TargetPythonRecipe):
 
     def link_root(self, arch_name):
         return join(self.get_build_dir(arch_name), 'python-install', 'lib')
+
 
 recipe = Python2Recipe()

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -9,7 +9,6 @@ import sh
 
 EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 
-
 class Python2Recipe(TargetPythonRecipe):
     version = "2.7.2"
     url = 'https://python.org/ftp/python/{version}/Python-{version}.tar.bz2'

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -3,7 +3,11 @@ from pythonforandroid.toolchain import shprint, current_directory, info
 from pythonforandroid.patching import (is_darwin, is_api_gt,
                                        check_all, is_api_lt, is_ndk)
 from os.path import exists, join, realpath
+from os import walk
+import glob
 import sh
+
+EXCLUDE_EXTS = (".py", ".pyc", ".so.o", ".so.a", ".so.libs", ".pyx")
 
 
 class Python2Recipe(TargetPythonRecipe):

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -170,5 +170,44 @@ class Python2Recipe(TargetPythonRecipe):
         # print('python2 build done, exiting for debug')
         # exit(1)
 
+    def create_python_bundle(self, dirn, arch):
+        info("Filling private directory")
+        if not exists(join(dirn, "lib")):
+            info("lib dir does not exist, making")
+            shprint(sh.cp, "-a",
+                    join("python-install", "lib"), dirn)
+        shprint(sh.mkdir, "-p",
+                join(dirn, "include", "python2.7"))
+
+        libpymodules_fn = join("libs", arch.arch, "libpymodules.so")
+        if exists(libpymodules_fn):
+            shprint(sh.mv, libpymodules_fn, dirn)
+        shprint(sh.cp,
+                join('python-install', 'include',
+                        'python2.7', 'pyconfig.h'),
+                join(dirn, 'include', 'python2.7/'))
+
+        info('Removing some unwanted files')
+        shprint(sh.rm, '-f', join(dirn, 'lib', 'libpython2.7.so'))
+        shprint(sh.rm, '-rf', join(dirn, 'lib', 'pkgconfig'))
+
+        libdir = join(dirn, 'lib', 'python2.7')
+        site_packages_dir = join(libdir, 'site-packages')
+        with current_directory(libdir):
+            removes = []
+            for dirname, root, filenames in walk("."):
+                for filename in filenames:
+                    for suffix in EXCLUDE_EXTS:
+                        if filename.endswith(suffix):
+                            removes.append(filename)
+            shprint(sh.rm, '-f', *removes)
+
+            info('Deleting some other stuff not used on android')
+            # To quote the original distribute.sh, 'well...'
+            shprint(sh.rm, '-rf', 'lib2to3')
+            shprint(sh.rm, '-rf', 'idlelib')
+            for filename in glob.glob('config/libpython*.a'):
+                shprint(sh.rm, '-f', filename)
+            shprint(sh.rm, '-rf', 'config/python.o')
 
 recipe = Python2Recipe()

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -210,6 +210,8 @@ class Python2Recipe(TargetPythonRecipe):
                 shprint(sh.rm, '-f', filename)
             shprint(sh.rm, '-rf', 'config/python.o')
 
+        return site_packages_dir
+
     def include_root(self, arch_name):
         return join(self.get_build_dir(arch_name), 'python-install', 'include', 'python2.7')
 

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -210,4 +210,10 @@ class Python2Recipe(TargetPythonRecipe):
                 shprint(sh.rm, '-f', filename)
             shprint(sh.rm, '-rf', 'config/python.o')
 
+    def include_root(self, arch_name):
+        return join(self.get_build_dir(arch_name), 'python-install', 'include', 'python2.7')
+
+    def link_root(self, arch_name):
+        return join(self.get_build_dir(arch_name), 'python-install', 'lib')
+
 recipe = Python2Recipe()

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -209,8 +209,7 @@ class Python2Recipe(TargetPythonRecipe):
             # To quote the original distribute.sh, 'well...'
             shprint(sh.rm, '-rf', 'lib2to3')
             shprint(sh.rm, '-rf', 'idlelib')
-            for filename in glob.glob('config/libpython*.a'):
-                shprint(sh.rm, '-f', filename)
+            shprint(sh.rm, '-f', *glob.glob('config/libpython*.a'))
             shprint(sh.rm, '-rf', 'config/python.o')
 
         return site_packages_dir

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -106,14 +106,5 @@ class Python3Recipe(TargetPythonRecipe):
             ipdb.set_trace()
 
             shprint(sh.make, 'all', _env=env)
-
-            exit(1)
             
-
-        #     if not exists('config.status'):
-                
-
-        #     shprint(sh.make, '-C', build_dir)
-            
-
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -10,8 +10,8 @@ import sh
 
 
 class Python3Recipe(TargetPythonRecipe):
-    version = 'bpo-30386'
-    url = 'https://github.com/inclement/cpython/archive/{version}.zip'
+    version = '3.7.0'
+    url = 'https://www.python.org/ftp/python/3.7.0/Python-{version}.tgz'
     name = 'python3'
 
     depends = ['hostpython3']

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -11,7 +11,7 @@ import sh
 
 
 class Python3Recipe(TargetPythonRecipe):
-    version = '3.7.0'
+    version = '3.7.1'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -187,5 +187,7 @@ class Python3Recipe(TargetPythonRecipe):
         info('Renaming .so files to reflect cross-compile')
         self.reduce_object_file_names(join(dirn, 'site-packages'))
 
+        return join(dirn, 'site-packages')
+
 
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -80,11 +80,6 @@ class Python3Recipe(TargetPythonRecipe):
 
             env['SYSROOT'] = sysroot
 
-            print('CPPflags', env['CPPFLAGS'])
-            print('LDFLAGS', env['LDFLAGS'])
-
-            print('LD is', env['LD'])
-
             if not exists('config.status'):
                 shprint(sh.Command(join(recipe_build_dir, 'configure')),
                         *(' '.join(('--host={android_host}',
@@ -102,9 +97,11 @@ class Python3Recipe(TargetPythonRecipe):
                                         prefix=sys_prefix,
                                         exec_prefix=sys_exec_prefix)).split(' '), _env=env)
 
-            import ipdb
-            ipdb.set_trace()
+            if not exists('python'):
+                shprint(sh.make, 'all', _env=env)
 
-            shprint(sh.make, 'all', _env=env)
+            # TODO: Look into passing the path to pyconfig.h in a
+            # better way, although this is probably acceptable
+            sh.cp('pyconfig.h', join(recipe_build_dir, 'Include'))
             
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -11,7 +11,7 @@ import sh
 
 class Python3Recipe(TargetPythonRecipe):
     version = '3.7.0'
-    url = 'https://www.python.org/ftp/python/3.7.0/Python-{version}.tgz'
+    url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
     depends = ['hostpython3']

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.patching import (is_darwin, is_api_gt,
                                        check_all, is_api_lt, is_ndk)
 from pythonforandroid.logger import logger
 from pythonforandroid.util import ensure_dir
-from os.path import exists, join, realpath, split
+from os.path import exists, join, realpath
 from os import environ, listdir
 import glob
 import sh
@@ -154,14 +154,7 @@ class Python3Recipe(TargetPythonRecipe):
                 'libs/{}'.format(arch.arch))
 
         info('Renaming .so files to reflect cross-compile')
-        site_packages_dir = join(dirn, 'site-packages')
-        py_so_files = shprint(sh.find, site_packages_dir, '-iname', '*.so')
-        filens = py_so_files.stdout.decode('utf-8').split('\n')[:-1]
-        for filen in filens:
-            file_dirname, file_basename = split(filen)
-            parts = file_basename.split('.')
-            if len(parts) <= 2:
-                continue
-            shprint(sh.mv, filen, join(file_dirname, parts[0] + '.so'))
-            
+        self.reduce_object_file_names(join(dirn, 'site-packages'))
+
+
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,0 +1,18 @@
+from pythonforandroid.recipe import TargetPythonRecipe, Recipe
+from pythonforandroid.toolchain import shprint, current_directory, info
+from pythonforandroid.patching import (is_darwin, is_api_gt,
+                                       check_all, is_api_lt, is_ndk)
+from os.path import exists, join, realpath
+import sh
+
+
+class Python3Recipe(TargetPythonRecipe):
+    version = 'bpo-30386'
+    url = 'https://github.com/inclement/cpython/archive/{version}.zip'
+    name = 'python3'
+
+    depends = ['hostpython3']
+    conflicts = ['python3crystax', 'python2']
+    opt_depends = ['openssl', 'sqlite3']
+
+recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -103,5 +103,13 @@ class Python3Recipe(TargetPythonRecipe):
             # TODO: Look into passing the path to pyconfig.h in a
             # better way, although this is probably acceptable
             sh.cp('pyconfig.h', join(recipe_build_dir, 'Include'))
+
+    def include_root(self, arch_name):
+        return join(self.get_build_dir(arch_name),
+                    'Include')
+
+    def link_root(self, arch_name):
+        return join(self.get_build_dir(arch_name),
+                    'android-build')
             
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,14 +1,11 @@
-from pythonforandroid.recipe import TargetPythonRecipe, Recipe
+from pythonforandroid.recipe import TargetPythonRecipe
 from pythonforandroid.toolchain import shprint, current_directory
-from pythonforandroid.patching import (is_darwin, is_api_gt,
-                                       check_all, is_api_lt, is_ndk)
 from pythonforandroid.logger import logger, info
 from pythonforandroid.util import ensure_dir, walk_valid_filens
-from os.path import exists, join, realpath, dirname
-from os import environ, listdir, walk
+from os.path import exists, join, dirname
+from os import environ
 import glob
 import sh
-
 
 STDLIB_DIR_BLACKLIST = {
     '__pycache__',
@@ -46,7 +43,7 @@ class Python3Recipe(TargetPythonRecipe):
 
     def build_arch(self, arch):
         recipe_build_dir = self.get_build_dir(arch.arch)
-        
+
         # Create a subdirectory to actually perform the build
         build_dir = join(recipe_build_dir, 'android-build')
         ensure_dir(build_dir)

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -2,7 +2,9 @@ from pythonforandroid.recipe import TargetPythonRecipe, Recipe
 from pythonforandroid.toolchain import shprint, current_directory, info
 from pythonforandroid.patching import (is_darwin, is_api_gt,
                                        check_all, is_api_lt, is_ndk)
+from pythonforandroid.util import ensure_dir
 from os.path import exists, join, realpath
+from os import environ
 import sh
 
 
@@ -13,6 +15,82 @@ class Python3Recipe(TargetPythonRecipe):
 
     depends = ['hostpython3']
     conflicts = ['python3crystax', 'python2']
-    opt_depends = ['openssl', 'sqlite3']
+    # opt_depends = ['openssl', 'sqlite3']
+
+    def build_arch(self, arch):
+        recipe_build_dir = self.get_build_dir(arch.arch)
+        
+        # Create a subdirectory to actually perform the build
+        build_dir = join(recipe_build_dir, 'android-build')
+        ensure_dir(build_dir)
+
+        # TODO: Get these dynamically, like bpo-30386 does
+        sys_prefix = '/usr/local'
+        sys_exec_prefix = '/usr/local'
+
+        # Skipping "Ensure that nl_langinfo is broken" from the original bpo-30386
+
+        with current_directory(build_dir):
+            env = environ.copy()
+
+
+            # TODO: Get this information from p4a's arch system
+            android_host = 'arm-linux-androideabi'
+            android_build = sh.Command(join(recipe_build_dir, 'config.guess'))().stdout.strip().decode('utf-8')
+            platform_dir = join(self.ctx.ndk_dir, 'platforms', 'android-19', 'arch-arm')
+            toolchain = '{android_host}-4.9'.format(android_host=android_host)
+            toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
+            CC = '{clang} -target {target} -gcc-toolchain {toolchain}'.format(
+                clang=join(self.ctx.ndk_dir, 'toolchains', 'llvm', 'prebuilt', 'linux-x86_64', 'bin', 'clang'),
+                target='armv7-none-linux-androideabi',
+                toolchain=toolchain)
+
+            AR = join(toolchain, 'bin', android_host) + '-ar'
+            LD = join(toolchain, 'bin', android_host) + '-ld'
+            RANLIB = join(toolchain, 'bin', android_host) + '-ranlib'
+            READELF = join(toolchain, 'bin', android_host) + '-readelf'
+            STRIP = join(toolchain, 'bin', android_host) + '-strip --strip-debug --strip-unneeded'
+
+            env['CC'] = CC
+            env['AR'] = AR
+            env['LD'] = LD
+            env['RANLIB'] = RANLIB
+            env['READELF'] = READELF
+            env['STRIP'] = STRIP
+
+            ndk_flags = '--sysroot={ndk_sysroot} -D__ANDROID_API__=19 -isystem {ndk_android_host}'.format(
+                ndk_sysroot=join(self.ctx.ndk_dir, 'sysroot'),
+                ndk_android_host=join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include', android_host))
+            sysroot = join(self.ctx.ndk_dir, 'platforms', 'android-19', 'arch-arm')
+            env['CFLAGS'] = env.get('CFLAGS', '') + ' ' + ndk_flags
+            env['CPPFLAGS'] = env.get('CPPFLAGS', '') + ' ' + ndk_flags
+            env['LDFLAGS'] = env.get('LDFLAGS', '') + ' --sysroot={} -march=armv7-a -Wl,--fix-cortex-a8'.format(sysroot)
+
+            print('CPPflags', env['CPPFLAGS'])
+            print('LDFLAGS', env['LDFLAGS'])
+
+            print('LD is', env['LD'])
+
+            shprint(sh.Command(join(recipe_build_dir, 'configure')),
+                    *(' '.join(('--host={android_host}',
+                                '--build={android_build}',
+                                '--enable-shared',
+                                '--disable-ipv6',
+                                'ac_cv_file__dev_ptmx=yes',
+                                'ac_cv_file__dev_ptc=no',
+                                '--without-ensurepip',
+                                'ac_cv_little_endian_double=yes',
+                                '--prefix={prefix}',
+                                '--exec-prefix={exec_prefix}')).format(
+                                    android_host=android_host,
+                                    android_build=android_build,
+                                    prefix=sys_prefix,
+                                    exec_prefix=sys_exec_prefix)).split(' '), _env=env)
+
+        #     if not exists('config.status'):
+                
+
+        #     shprint(sh.make, '-C', build_dir)
+            
 
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -83,6 +83,10 @@ class Python3Recipe(TargetPythonRecipe):
             env['READELF'] = READELF
             env['STRIP'] = STRIP
 
+            env['PATH'] = '{hostpython_dir}:{old_path}'.format(
+                hostpython_dir=self.get_recipe('hostpython3', self.ctx).get_path_to_python(),
+                old_path=env['PATH'])
+
             ndk_flags = ('--sysroot={ndk_sysroot} -D__ANDROID_API__={android_api} '
                          '-isystem {ndk_android_host}').format(
                              ndk_sysroot=join(self.ctx.ndk_dir, 'sysroot'),

--- a/pythonforandroid/recipes/python3crystax/__init__.py
+++ b/pythonforandroid/recipes/python3crystax/__init__.py
@@ -73,5 +73,20 @@ class Python3Recipe(TargetPythonRecipe):
         # available. Using e.g. pyenv makes this easy.
         self.ctx.hostpython = 'python{}'.format(self.version)
 
+    def create_python_bundle(self, dirn, arch):
+        ndk_dir = self.ctx.ndk_dir
+        py_recipe = self.ctx.python_recipe
+        python_dir = join(ndk_dir, 'sources', 'python',
+                            py_recipe.version, 'libs', arch.arch)
+        shprint(sh.cp, '-r', join(python_dir,
+                                    'stdlib.zip'), dirn)
+        shprint(sh.cp, '-r', join(python_dir,
+                                    'modules'), dirn)
+        shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
+                join(dirn, 'site-packages'))
+
+        info('Renaming .so files to reflect cross-compile')
+        self.reduce_object_file_names(self, join(dirn, "site-packages"))
+
 
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3crystax/__init__.py
+++ b/pythonforandroid/recipes/python3crystax/__init__.py
@@ -22,7 +22,7 @@ class Python3CrystaXRecipe(TargetPythonRecipe):
     from_crystax = True
 
     def get_dir_name(self):
-        name = super(Python3Recipe, self).get_dir_name()
+        name = super(Python3CrystaXRecipe, self).get_dir_name()
         name += '-version{}'.format(self.version)
         return name
 
@@ -77,11 +77,11 @@ class Python3CrystaXRecipe(TargetPythonRecipe):
         ndk_dir = self.ctx.ndk_dir
         py_recipe = self.ctx.python_recipe
         python_dir = join(ndk_dir, 'sources', 'python',
-                            py_recipe.version, 'libs', arch.arch)
+                          py_recipe.version, 'libs', arch.arch)
         shprint(sh.cp, '-r', join(python_dir,
-                                    'stdlib.zip'), dirn)
+                                  'stdlib.zip'), dirn)
         shprint(sh.cp, '-r', join(python_dir,
-                                    'modules'), dirn)
+                                  'modules'), dirn)
         shprint(sh.cp, '-r', self.ctx.get_python_install_dir(),
                 join(dirn, 'site-packages'))
 
@@ -97,5 +97,6 @@ class Python3CrystaXRecipe(TargetPythonRecipe):
     def link_root(self, arch_name):
         return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string,
                     'libs', arch_name)
+
 
 recipe = Python3CrystaXRecipe()

--- a/pythonforandroid/recipes/python3crystax/__init__.py
+++ b/pythonforandroid/recipes/python3crystax/__init__.py
@@ -11,7 +11,7 @@ prebuilt_download_locations = {
             'releases/download/0.1/crystax_python_3.6_armeabi_armeabi-v7a.tar.gz')}
 
 
-class Python3Recipe(TargetPythonRecipe):
+class Python3CrystaXRecipe(TargetPythonRecipe):
     version = '3.6'
     url = ''
     name = 'python3crystax'
@@ -86,16 +86,16 @@ class Python3Recipe(TargetPythonRecipe):
                 join(dirn, 'site-packages'))
 
         info('Renaming .so files to reflect cross-compile')
-        self.reduce_object_file_names(self, join(dirn, "site-packages"))
+        self.reduce_object_file_names(join(dirn, "site-packages"))
 
         return join(dirn, 'site-packages')
 
     def include_root(self, arch_name):
-        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string(),
+        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string,
                     'include', 'python')
 
     def link_root(self, arch_name):
-        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string(),
+        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string,
                     'libs', arch_name)
 
-recipe = Python3Recipe()
+recipe = Python3CrystaXRecipe()

--- a/pythonforandroid/recipes/python3crystax/__init__.py
+++ b/pythonforandroid/recipes/python3crystax/__init__.py
@@ -88,5 +88,12 @@ class Python3Recipe(TargetPythonRecipe):
         info('Renaming .so files to reflect cross-compile')
         self.reduce_object_file_names(self, join(dirn, "site-packages"))
 
+    def include_root(self, arch_name):
+        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string(),
+                    'include', 'python')
+
+    def link_root(self, arch_name):
+        return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string(),
+                    'libs', arch_name)
 
 recipe = Python3Recipe()

--- a/pythonforandroid/recipes/python3crystax/__init__.py
+++ b/pythonforandroid/recipes/python3crystax/__init__.py
@@ -88,6 +88,8 @@ class Python3Recipe(TargetPythonRecipe):
         info('Renaming .so files to reflect cross-compile')
         self.reduce_object_file_names(self, join(dirn, "site-packages"))
 
+        return join(dirn, 'site-packages')
+
     def include_root(self, arch_name):
         return join(self.ctx.ndk_dir, 'sources', 'python', self.major_minor_version_string(),
                     'include', 'python')

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -29,7 +29,8 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
             env['EXTRA_LDLIBS'] = ' -lpython2.7'
 
         if 'python3' in self.ctx.recipe_build_order:
-            env['EXTRA_LDLIBS'] = ' -lpython3.7m'  # TODO: don't hardcode the python version
+            env['EXTRA_LDLIBS'] = ' -lpython{}m'.format(
+                self.ctx.python_recipe.major_minor_version_string)
 
         env['APP_ALLOW_MISSING_DEPS'] = 'true'
         return env

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -20,7 +20,6 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
 
         py2 = self.get_recipe('python2', arch.ctx)
         env['PYTHON2_NAME'] = py2.get_dir_name()
-        py3 = self.get_recipe('python3', arch.ctx)
 
         env['PYTHON_INCLUDE_ROOT'] = self.ctx.python_recipe.include_root(arch.arch)
         env['PYTHON_LINK_ROOT'] = self.ctx.python_recipe.link_root(arch.arch)

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -10,7 +10,7 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
 
     dir_name = 'SDL'
 
-    depends = [('python2', 'python3crystax'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
+    depends = [('python2', 'python3', 'python3crystax'), 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
     conflicts = ['sdl', 'pygame', 'pygame_bootstrap_components']
 
     patches = ['add_nativeSetEnv.patch']

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -17,10 +17,19 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
 
     def get_recipe_env(self, arch=None):
         env = super(LibSDL2Recipe, self).get_recipe_env(arch)
+
         py2 = self.get_recipe('python2', arch.ctx)
         env['PYTHON2_NAME'] = py2.get_dir_name()
+        py3 = self.get_recipe('python3', arch.ctx)
+
+        env['PYTHON_INCLUDE_ROOT'] = self.ctx.python_recipe.include_root(arch.arch)
+        env['PYTHON_LINK_ROOT'] = self.ctx.python_recipe.link_root(arch.arch)
+
         if 'python2' in self.ctx.recipe_build_order:
             env['EXTRA_LDLIBS'] = ' -lpython2.7'
+
+        if 'python3' in self.ctx.recipe_build_order:
+            env['EXTRA_LDLIBS'] = ' -lpython3.7m'  # TODO: don't hardcode the python version
 
         env['APP_ALLOW_MISSING_DEPS'] = 'true'
         return env

--- a/pythonforandroid/recipes/six/__init__.py
+++ b/pythonforandroid/recipes/six/__init__.py
@@ -5,6 +5,7 @@ from pythonforandroid.recipe import PythonRecipe
 class SixRecipe(PythonRecipe):
     version = '1.9.0'
     url = 'https://pypi.python.org/packages/source/s/six/six-{version}.tar.gz'
+    depends = [('python2', 'python3', 'python3crystax')]
 
 
 recipe = SixRecipe()

--- a/pythonforandroid/recipes/six/__init__.py
+++ b/pythonforandroid/recipes/six/__init__.py
@@ -5,7 +5,6 @@ from pythonforandroid.recipe import PythonRecipe
 class SixRecipe(PythonRecipe):
     version = '1.9.0'
     url = 'https://pypi.python.org/packages/source/s/six/six-{version}.tar.gz'
-    depends = [('python2', 'python3crystax')]
 
 
 recipe = SixRecipe()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -137,7 +137,8 @@ def require_prebuilt_dist(func):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
-                                      user_ndk_ver=self.ndk_version)
+                                      user_ndk_ver=self.ndk_version,
+                                      user_ndk_api=self.ndk_api)
         dist = self._dist
         if dist.needs_build:
             info_notify('No dist exists that meets your requirements, '
@@ -257,8 +258,14 @@ class ToolchainCL(object):
             help=('The version of the Android NDK. This is optional: '
                   'we try to work it out automatically from the ndk_dir.'))
         generic_parser.add_argument(
-            '--symlink-java-src', '--symlink_java_src', action='store_true',
-            dest='symlink_java_src', default=False,
+            '--ndk-api', type=int, default=21,
+            help=('The Android API level to compile against. This should be your '
+                  '*minimal supported* API, not normally the same as your --android-api.'))
+        generic_parser.add_argument(
+            '--symlink-java-src', '--symlink_java_src',
+            action='store_true',
+            dest='symlink_java_src',
+            default=False,
             help=('If True, symlinks the java src folder during build and dist '
                   'creation. This is useful for development only, it could also'
                   ' cause weird problems.'))
@@ -520,6 +527,7 @@ class ToolchainCL(object):
         self.ndk_dir = args.ndk_dir
         self.android_api = args.android_api
         self.ndk_version = args.ndk_version
+        self.ndk_api = args.ndk_api
         self.ctx.symlink_java_src = args.symlink_java_src
         self.ctx.java_build_tool = args.java_build_tool
 
@@ -928,7 +936,8 @@ class ToolchainCL(object):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
-                                      user_ndk_ver=self.ndk_version)
+                                      user_ndk_ver=self.ndk_version,
+                                      user_ndk_api=self.ndk_api)
         android = sh.Command(join(ctx.sdk_dir, 'tools', args.tool))
         output = android(
             *args.unknown_args, _iter=True, _out_bufsize=1, _err_to_out=True)
@@ -955,7 +964,8 @@ class ToolchainCL(object):
         ctx.prepare_build_environment(user_sdk_dir=self.sdk_dir,
                                       user_ndk_dir=self.ndk_dir,
                                       user_android_api=self.android_api,
-                                      user_ndk_ver=self.ndk_version)
+                                      user_ndk_ver=self.ndk_version,
+                                      user_ndk_api=self.ndk_api)
         if platform in ('win32', 'cygwin'):
             adb = sh.Command(join(ctx.sdk_dir, 'platform-tools', 'adb.exe'))
         else:

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -259,7 +259,7 @@ class ToolchainCL(object):
             help=('The version of the Android NDK. This is optional: '
                   'we try to work it out automatically from the ndk_dir.'))
         generic_parser.add_argument(
-            '--ndk-api', type=int, default=21,
+            '--ndk-api', type=int, default=0,
             help=('The Android API level to compile against. This should be your '
                   '*minimal supported* API, not normally the same as your --android-api.'))
         generic_parser.add_argument(

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -8,6 +8,7 @@ This module defines the entry point for command line and programmatic use.
 
 from __future__ import print_function
 from pythonforandroid import __version__
+from pythonforandroid.build import DEFAULT_NDK_API, DEFAULT_ANDROID_API
 
 
 def check_python_dependencies():
@@ -252,8 +253,13 @@ class ToolchainCL(object):
             '--ndk-dir', '--ndk_dir', dest='ndk_dir', default='',
             help='The filepath where the Android NDK is installed')
         generic_parser.add_argument(
-            '--android-api', '--android_api', dest='android_api', default=0,
-            type=int, help='The Android API level to build against.')
+            '--android-api',
+            '--android_api',
+            dest='android_api',
+            default=0,
+            type=int,
+            help=('The Android API level to build against defaults to {} if '
+                  'not specified.').format(DEFAULT_ANDROID_API))
         generic_parser.add_argument(
             '--ndk-version', '--ndk_version', dest='ndk_version', default='',
             help=('The version of the Android NDK. This is optional: '
@@ -261,7 +267,8 @@ class ToolchainCL(object):
         generic_parser.add_argument(
             '--ndk-api', type=int, default=0,
             help=('The Android API level to compile against. This should be your '
-                  '*minimal supported* API, not normally the same as your --android-api.'))
+                  '*minimal supported* API, not normally the same as your --android-api. '
+                  'Defaults to min(ANDROID_API, {}) if not specified.').format(DEFAULT_NDK_API))
         generic_parser.add_argument(
             '--symlink-java-src', '--symlink_java_src',
             action='store_true',

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -155,6 +155,7 @@ def dist_from_args(ctx, args):
     return Distribution.get_distribution(
         ctx,
         name=args.dist_name,
+        ndk_api=args.ndk_api,
         recipes=split_argument_list(args.requirements),
         require_perfect_match=args.require_perfect_match)
 

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -126,6 +126,7 @@ def which(program, path_env):
 
     return None
 
+
 def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
     """Recursively walks all the files and directories in ``dirn``,
     ignoring directories that match any pattern in ``invalid_dirns``
@@ -138,7 +139,7 @@ def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
 
     File and directory paths are evaluated as full paths relative to ``dirn``.
 
-    """ 
+    """
 
     for dirn, subdirs, filens in walk(base_dir):
 

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -1,10 +1,11 @@
 import contextlib
-from os.path import exists
-from os import getcwd, chdir, makedirs
+from os.path import exists, join
+from os import getcwd, chdir, makedirs, walk
 import io
 import json
 import shutil
 import sys
+from fnmatch import fnmatch
 from tempfile import mkdtemp
 try:
     from urllib.request import FancyURLopener
@@ -124,3 +125,33 @@ def which(program, path_env):
                 return exe_file
 
     return None
+
+def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
+    """Recursively walks all the files and directories in ``dirn``,
+    ignoring directories that match any pattern in ``invalid_dirns``
+    and files that patch any pattern in ``invalid_filens``.
+
+    ``invalid_dirns`` and ``invalid_filens`` should both be lists of
+    strings to match. ``invalid_dir_patterns`` expects a list of
+    invalid directory names, while ``invalid_file_patterns`` expects a
+    list of glob patterns compared against the full filepath.
+
+    File and directory paths are evaluated as full paths relative to ``dirn``.
+
+    """ 
+
+    return_filens = []
+    for dirn, subdirs, filens in walk(base_dir):
+
+        # Remove invalid subdirs so that they will not be walked
+        for i in reversed(range(len(subdirs))):
+            subdir = subdirs[i]
+            if subdir in invalid_dir_names:
+                subdirs.pop(i)
+
+        for filen in filens:
+            for pattern in invalid_file_patterns:
+                if fnmatch(filen, pattern):
+                    break
+            else:
+                yield join(dirn, filen)

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -140,7 +140,6 @@ def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
 
     """ 
 
-    return_filens = []
     for dirn, subdirs, filens in walk(base_dir):
 
         # Remove invalid subdirs so that they will not be walked

--- a/testapps/setup_testapp_python2.py
+++ b/testapps/setup_testapp_python2.py
@@ -2,9 +2,10 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {
+options = {'apk': {'debug': None,
                    'requirements': 'sdl2,pyjnius,kivy,python2',
                    'android-api': 19,
+                   'ndk-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python2',
                    'ndk-version': '10.3.2',

--- a/testapps/setup_testapp_python2.py
+++ b/testapps/setup_testapp_python2.py
@@ -2,8 +2,7 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python2',
+options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python2',
                    'android-api': 19,
                    'ndk-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',

--- a/testapps/setup_testapp_python2_sqlite_openssl.py
+++ b/testapps/setup_testapp_python2_sqlite_openssl.py
@@ -2,9 +2,9 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {#'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python2,openssl,requests,peewee,sqlite3',
+options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python2,openssl,requests,peewee,sqlite3',
                    'android-api': 19,
+                   'ndk-api': 19,
                    'ndk-dir': '/home/sandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python2_sqlite_openssl',
                    'ndk-version': '10.3.2',

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3',
                    'android-api': 27,
-                   'ndk-api': 19,
+                   'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_googlendk',
                    'ndk-version': '10.3.2',
                    'arch': 'armeabi-v7a',

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3',
-                   'android-api': 26,
+                   'android-api': 27,
                    'ndk-api': 19,
                    'dist-name': 'bdisttest_python3_googlendk',
                    'ndk-version': '10.3.2',

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -6,7 +6,7 @@ options = {'apk': {'debug': None,
                    'requirements': 'sdl2,pyjnius,kivy,python3',
                    'android-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
-                   'dist-name': 'bdisttest_python3',
+                   'dist-name': 'bdisttest_python3_googlendk',
                    'ndk-version': '10.3.2',
                    'arch': 'armeabi-v7a',
                    'permission': 'VIBRATE',
@@ -20,7 +20,7 @@ packages = find_packages()
 print('packages are', packages)
 
 setup(
-    name='testapp_python3',
+    name='testapp_python3_googlendk',
     version='1.1',
     description='p4a setup.py test',
     author='Alexander Taylor',

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -2,10 +2,9 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python3',
-                   'android-api': 19,
-                   'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
+options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3',
+                   'android-api': 26,
+                   'ndk-api': 19,
                    'dist-name': 'bdisttest_python3_googlendk',
                    'ndk-version': '10.3.2',
                    'arch': 'armeabi-v7a',

--- a/testapps/setup_testapp_python3crystax.py
+++ b/testapps/setup_testapp_python3crystax.py
@@ -5,6 +5,7 @@ from setuptools import find_packages
 options = {'apk': {'debug': None,
                    'requirements': 'sdl2,pyjnius,kivy,python3crystax',
                    'android-api': 19,
+                   'ndk-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python3',
                    'ndk-version': '10.3.2',

--- a/testapps/setup_testapp_python3crystax.py
+++ b/testapps/setup_testapp_python3crystax.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python3',
+                   'requirements': 'sdl2,pyjnius,kivy,python3crystax',
                    'android-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python3',

--- a/testapps/setup_testapp_python3crystax.py
+++ b/testapps/setup_testapp_python3crystax.py
@@ -2,8 +2,7 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python3crystax',
+options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3crystax',
                    'android-api': 19,
                    'ndk-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',

--- a/tests/recipes/test_reportlab.py
+++ b/tests/recipes/test_reportlab.py
@@ -16,6 +16,8 @@ class TestReportLabRecipe(unittest.TestCase):
         Setups recipe and context.
         """
         self.context = Context()
+        self.context.ndk_api = 21
+        self.context.android_api = 27
         self.arch = ArchARMv7_a(self.context)
         self.recipe = Recipe.get_recipe('reportlab', self.context)
         self.recipe.ctx = self.context

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands = flake8 pythonforandroid/ tests/ ci/
 ignore =
     E123, E124, E126,
     E226,
+    E129,
     E402, E501, E722,
     F812, F841, W503,
     W504


### PR DESCRIPTION
I haven't had much time to work on this since my initial proof of concept, but I've got back to it now. This PR is a work in progress, I wouldn't usually make it anywhere near this early but I know people are following this closely so I thought I might as well be clear what is going on with it.

Right now this is the most minimal possible implementation, I literally just got it working and there are many hacks to be resolved. However, it should work, the whole build process is now included although it's only tested on my machine so far there could be issues in other environments (especially macOS?). The main difference to the proof of concept is that I began moving the build into p4a's system rather than the shell/Makefile system used in Python bpo-30386. There's nothing wrong with that system, but since it isn't maintained it seems safer to make full use of p4a's tools instead. 

Non-exhaustive non-ordered list of things to do (note: even if checked off it doesn't mean the implementation is final, just that the bulk of the work is done on that feature):
- [x] move Python bundling code from the bootstrap to the python recipes (makes more sense now that there are several)
- [x] trim/strip the python3 bundle so that APKs are not too big (target: no bigger than python3crystax) [edit: done for now, got down to 11MB including Kivy etc., just by trimming out obvious stuff]
- [x] move to use Python 3.7.0 instead of the bpo-30386 fork
  - [x] and also check compatibility with 3.7.1
- [x] add proper APP_PLATFORM setting functionality, including adding it to the build and dist folder disambiguation
- [ ] ~~make the python3 recipe use p4a's arch system as much as possible, including making p4a understand clang toolchains~~ [edit: won't hold up merging for this, will make a new issue for it]
- [x] get everything working with APIs 21 to 27+, ~~currently tested only with API 24 and there are definitely things that need doing to make everything work with 27+~~
- [ ] ~~check why ctypes isn't building and fix it if it's simple (it should be, I think it works in bpo-30386)~~ [edit: won't hold up merging for this, will make a new issue for it]
- [ ] ~~openssl recipe compatibility~~ [edit: won't hold up merging for this, will make a new issue for it]
- [ ] ~~sqlite recipe compatibility~~ [edit: won't hold up merging for this, will make a new issue for it]**
- [x] clean the code, resolving all TODOs and hacks that are not confined to the new recipe (which can be merged as a WIP that is known to need tidying)
- [x] check that python2 and python3crystax builds still work
  - [x] python2
  - [x] python3crystax

Minor note: as it stands this recipe doesn't support API lower than 21 due to Android limitations. There are some patches that exist to fix that, but I'm probably not going to look into that any time soon, so API 21 may effectively be the lowest supported API for this recipe.