### PR TITLE
Put install_reqs on line so that buildozer's rubbish parsing will work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ package_data = {'': ['*.tmpl',
 data_files = []
 
 
-install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2', 'six',
-    'enum34;python_version<"3.4"']
+# must be a single statement since buildozer is currently parsing it, refs:
+# https://github.com/kivy/buildozer/issues/722
+install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2', 'six', 'enum34;python_version<"3.4"']
 if os.name != 'nt':
     install_reqs.append('sh>=1.10')
 


### PR DESCRIPTION
This is currently making buildozer fail because it tries to parse the line with a regex.