### PR TITLE
Pin pyjnius version

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -6,7 +6,7 @@ from os.path import join
 
 
 class PyjniusRecipe(CythonRecipe):
-    version = 'master'
+    version = '6233ffe6415acfef9f97ff993e12e8db064c7c75'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
     depends = [('python2', 'python3crystax'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']


### PR DESCRIPTION
This pull request adds a version pin for pyjnius as requested here: #1415 

Please note I am proposing this as a **permanent measure** because this is such a core component - not this specific version of course, but that it is always pinned.

Even if you just randomly bump the version up in any random commit without checking, this is a huge improvement: it will prevent p4a master builds from randomly failing out of the blue *when not even changing the commit*, and people will be able to go back to an earlier p4a master commit to avoid sudden pyjnius breakages instead of patching around in the recipes folder (which depending on the build pipeline might be quite a time waster to do, especially compared to just going back to a known working p4a master commit).

Summed up, please pin this, carelessly bump it whenever, and have less unhappy users. :smile:

(And I'm not proposing pinning *everything*, I know you have way too many recipes and people would forget to bump it, I understand - but at least the core components like pyjnius, would that possibly sound feasible?)