### PR TITLE
Installs requirements in a single statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,10 @@ data_files = []
 
 # must be a single statement since buildozer is currently parsing it, refs:
 # https://github.com/kivy/buildozer/issues/722
-install_reqs = ['appdirs', 'colorama>=0.3.3', 'jinja2', 'six', 'enum34;python_version<"3.4"']
-if os.name != 'nt':
-    install_reqs.append('sh>=1.10')
+install_reqs = [
+    'appdirs', 'colorama>=0.3.3', 'jinja2', 'six',
+    'enum34; python_version<"3.4"', 'sh>=1.10; sys_platform!="nt"'
+]
 
 # By specifying every file manually, package_data will be able to
 # include them in binary distributions. Note that we have to add


### PR DESCRIPTION
Relies on PEP 508 to set conditional requirements in one statement.
Fixes buildozer p4a requirements install.