### PR TITLE
Pins pyjnius==1.1.3, fixes #1416

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -6,7 +6,7 @@ from os.path import join
 
 
 class PyjniusRecipe(CythonRecipe):
-    version = 'master'
+    version = '1.1.3'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
     depends = [('python2', 'python3crystax'), ('genericndkbuild', 'sdl2', 'sdl'), 'six']


### PR DESCRIPTION
Just like we pinned `pyjnius==1.1.2` on `stable` branch in https://github.com/kivy/python-for-android/pull/1426 we're now pinning `pyjnius==1.1.3` on `master`.