### PR TITLE
removed mmap from blacklist

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/pygame/build/blacklist.txt
@@ -78,7 +78,6 @@ multiprocessing/dummy*
 lib-dynload/termios.so
 lib-dynload/_lsprof.so
 lib-dynload/*audioop.so
-lib-dynload/mmap.so
 lib-dynload/_hotshot.so
 lib-dynload/_csv.so
 lib-dynload/_heapq.so

--- a/pythonforandroid/bootstraps/sdl2/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/sdl2/build/blacklist.txt
@@ -69,7 +69,6 @@ multiprocessing/dummy*
 lib-dynload/termios.so
 lib-dynload/_lsprof.so
 lib-dynload/*audioop.so
-lib-dynload/mmap.so
 lib-dynload/_hotshot.so
 lib-dynload/_heapq.so
 lib-dynload/_json.so

--- a/pythonforandroid/bootstraps/service_only/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/service_only/build/blacklist.txt
@@ -69,7 +69,6 @@ multiprocessing/dummy*
 lib-dynload/termios.so
 lib-dynload/_lsprof.so
 lib-dynload/*audioop.so
-lib-dynload/mmap.so
 lib-dynload/_hotshot.so
 lib-dynload/_heapq.so
 lib-dynload/_json.so

--- a/pythonforandroid/bootstraps/webview/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/webview/build/blacklist.txt
@@ -69,7 +69,6 @@ multiprocessing/dummy*
 lib-dynload/termios.so
 lib-dynload/_lsprof.so
 lib-dynload/*audioop.so
-lib-dynload/mmap.so
 lib-dynload/_hotshot.so
 lib-dynload/_heapq.so
 lib-dynload/_json.so


### PR DESCRIPTION
mmap was blacklisted, but it is actually useful, e.g. to communicate
between a frontend and a service.
This patch remove it from blacklists.