### PR TITLE
allow installing/using p4a in a virtualenv

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -635,8 +635,8 @@ def run_pymodules_install(ctx, modules):
         # This bash method is what old-p4a used
         # It works but should be replaced with something better
         shprint(sh.bash, '-c', (
-            "source venv/bin/activate && env CC=/bin/false CXX=/bin/false "
-            "PYTHONPATH={0} pip install --target '{0}' --no-deps -r requirements.txt"
+            "env CC=/bin/false CXX=/bin/false "
+            "PYTHONPATH={0} venv/bin/pip install --target '{0}' --no-deps -r requirements.txt"
         ).format(ctx.get_site_packages_dir()))
 
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -167,13 +167,6 @@ def build_dist_from_args(ctx, dist, args):
     ctx.recipe_build_order = build_order
     ctx.python_modules = python_modules
 
-    if python_modules and hasattr(sys, 'real_prefix'):
-        error('virtualenv is needed to install pure-Python modules, but')
-        error('virtualenv does not support nesting, and you are running')
-        error('python-for-android in one. Please run p4a outside of a')
-        error('virtualenv instead.')
-        exit(1)
-
     info('The selected bootstrap is {}'.format(bs.name))
     info_main('# Creating dist with {} bootstrap'.format(bs.name))
     bs.distribution = dist


### PR DESCRIPTION
I only tried to build a distribution, not an apk from it, but it seems to work fine. The pure python libs i added to --requirements were installed fine in the python-install of the created distribution, just like when i ran p4a from outside of a virtualenv.