### PR TITLE
[libsodium] Updated to last version (1.0.16)

### DIFF
--- a/pythonforandroid/recipes/libsodium/__init__.py
+++ b/pythonforandroid/recipes/libsodium/__init__.py
@@ -4,9 +4,10 @@ import sh
 
 
 class LibsodiumRecipe(Recipe):
-    version = '1.0.8'
+    version = '1.0.16'
     url = 'https://github.com/jedisct1/libsodium/releases/download/{version}/libsodium-{version}.tar.gz'
     depends = ['python2']
+    patches = ['size_max_fix.patch']
 
     def should_build(self, arch):
         super(LibsodiumRecipe, self).should_build(arch)
@@ -17,7 +18,7 @@ class LibsodiumRecipe(Recipe):
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
             bash = sh.Command('bash')
-            shprint(bash, 'configure', '--enable-minimal', '--disable-soname-versions', '--host=arm-linux-androideabi', '--enable-shared', _env=env)
+            shprint(bash, 'configure', '--disable-soname-versions', '--host=arm-linux-androideabi', '--enable-shared', _env=env)
             shprint(sh.make, _env=env)
             shutil.copyfile('src/libsodium/.libs/libsodium.so', join(self.ctx.get_libs_dir(arch.arch), 'libsodium.so'))
 

--- a/pythonforandroid/recipes/libsodium/size_max_fix.patch
+++ b/pythonforandroid/recipes/libsodium/size_max_fix.patch
@@ -1,0 +1,12 @@
+diff -urN libsodium-1.0.16.ori/src/libsodium/include/sodium/export.h libsodium-1.0.16/src/libsodium/include/sodium/export.h
+--- libsodium-1.0.16.ori/src/libsodium/include/sodium/export.h	2017-12-12 00:03:07.000000000 +0100
++++ libsodium-1.0.16/src/libsodium/include/sodium/export.h	2018-10-31 09:46:06.051189444 +0100
+@@ -47,6 +47,8 @@
+ # endif
+ #endif
+ 
++#include <limits.h>
++
+ #define SODIUM_MIN(A, B) ((A) < (B) ? (A) : (B))
+ #define SODIUM_SIZE_MAX SODIUM_MIN(UINT64_MAX, SIZE_MAX)
+ 


### PR DESCRIPTION
This patch update libsodium to last available version, and remove the
"--enable-minimal" flag which was restricting features and causing
runtime troubles in other recipes.