### PR TITLE
Cleans broken python3crystax recipe list

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -55,16 +55,7 @@ BROKEN_RECIPES_PYTHON2 = set([
     'zope',
 ])
 BROKEN_RECIPES_PYTHON3_CRYSTAX = set([
-    # not yet python3crystax compatible
-    'apsw', 'atom', 'boost', 'brokenrecipe', 'cdecimal', 'cherrypy',
-    'coverage', 'dateutil', 'enaml', 'ethash', 'kiwisolver', 'libgeos',
-    'libnacl', 'libsodium', 'libtorrent', 'libtribler', 'libzbar', 'libzmq',
-    'm2crypto', 'mysqldb', 'ndghttpsclient', 'pil', 'pycrypto', 'pyethereum',
-    'pygame', 'pyleveldb', 'pyproj', 'pyzmq', 'regex', 'shapely',
-    'simple-crypt', 'twsisted', 'vispy', 'websocket-client', 'zbar',
-    'zeroconf', 'zope',
-    # https://github.com/kivy/python-for-android/issues/550
-    'audiostream',
+    'brokenrecipe',
     # enum34 is not compatible with Python 3.6 standard library
     # https://stackoverflow.com/a/45716067/185510
     'enum34',


### PR DESCRIPTION
With #1435 we're falling back automatically to python2 if the recipe is
incompatible. This is better than maintaining a skip list, because the
recipe will still be compiled under python2 on conflicting dependency
graph for python3crystax.