### PR TITLE
Add support for ctypes to python3's recipe

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -37,6 +37,7 @@ public class PythonUtil {
         ArrayList<String> libsList = new ArrayList<String>();
         addLibraryIfExists(libsList, "crystax", libsDir);
         addLibraryIfExists(libsList, "sqlite3", libsDir);
+        addLibraryIfExists(libsList, "ffi", libsDir);
         libsList.add("SDL2");
         libsList.add("SDL2_image");
         libsList.add("SDL2_mixer");

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -73,7 +73,7 @@ class Python3Recipe(TargetPythonRecipe):
             recipe = Recipe.get_recipe('libffi', self.ctx)
             include = ' -I' + ' -I'.join(recipe.get_include_dirs(arch))
             ldflag = ' -L' + join(recipe.get_build_dir(arch.arch),
-                                   recipe.get_host(arch), '.libs') + ' -lffi'
+                                  recipe.get_host(arch), '.libs') + ' -lffi'
             add_flags(include, ldflag)
             # libffi needs some extra configurations
             env['LIBFFI_CFLAGS'] = env.get('CFLAGS', '') + include

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -2,7 +2,7 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3',
+options = {'apk': {'requirements': 'libffi,sdl2,pyjnius,kivy,python3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_googlendk',


### PR DESCRIPTION
Should be mentioned that the current test app for python3 has been modified by adding libffi to the requirements because the ui for the app has some button to test the ctypes module.

References: This commit partially fixes some of the points mentioned in issue number #1455