### PR TITLE
python3 is a core recipe built via .travis.yml

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -101,5 +101,5 @@ BROKEN_RECIPES = {
 # recipes that were already built will be skipped
 CORE_RECIPES = set([
     'pyjnius', 'kivy', 'openssl', 'requests', 'sqlite3', 'setuptools',
-    'numpy', 'android', 'python2',
+    'numpy', 'android', 'python2', 'python3',
 ])


### PR DESCRIPTION
Also it doesn't make sense to build it against other target python versions e.g. `python3crystax`. Therefore it should be skipped from conditional builds.