### PR TITLE
Add ctypes support for python3's recipe

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -27,6 +27,10 @@ and works with any recent version of the Android NDK.
 Select Python 3 by adding it to your requirements,
 e.g. ``--requirements=python3``.
 
+.. note:: ctypes is not included automatically, if you would like to use it
+          then add libffi to your requirements,
+          e.g. ``--requirements=kivy,libffi,python3``.
+
 
 CrystaX python3
 ###############

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -37,6 +37,7 @@ public class PythonUtil {
         ArrayList<String> libsList = new ArrayList<String>();
         addLibraryIfExists(libsList, "crystax", libsDir);
         addLibraryIfExists(libsList, "sqlite3", libsDir);
+        addLibraryIfExists(libsList, "ffi", libsDir);
         libsList.add("SDL2");
         libsList.add("SDL2_image");
         libsList.add("SDL2_mixer");

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,4 +1,4 @@
-from pythonforandroid.recipe import TargetPythonRecipe
+from pythonforandroid.recipe import TargetPythonRecipe, Recipe
 from pythonforandroid.toolchain import shprint, current_directory
 from pythonforandroid.logger import logger, info, error
 from pythonforandroid.util import ensure_dir, walk_valid_filens
@@ -33,15 +33,37 @@ SITE_PACKAGES_FILEN_BLACKLIST = []
 
 
 class Python3Recipe(TargetPythonRecipe):
+    '''
+    .. note::
+        In order to build certain python modules, we need to add some extra
+        recipes to our build requirements:
+
+            - ctypes: you must add the recipe for ``libffi``.
+    '''
     version = '3.7.1'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
     depends = ['hostpython3']
     conflicts = ['python3crystax', 'python2']
+    opt_depends = ['libffi']
 
     # This recipe can be built only against API 21+
     MIN_NDK_API = 21
+
+    def set_libs_flags(self, env, arch):
+        '''Takes care to properly link libraries with python depending on our
+        requirements and the attribute :attr:`opt_depends`.
+        '''
+        if 'libffi' in self.ctx.recipe_build_order:
+            info('Activating flags for libffi')
+            recipe = Recipe.get_recipe('libffi', self.ctx)
+            include = ' -I' + ' -I'.join(recipe.get_include_dirs(arch))
+            ldflag = ' -L' + join(recipe.get_build_dir(arch.arch),
+                                  recipe.get_host(arch), '.libs') + ' -lffi'
+            env['CPPFLAGS'] = env.get('CPPFLAGS', '') + include
+            env['LDFLAGS'] = env.get('LDFLAGS', '') + ldflag
+        return env
 
     def build_arch(self, arch):
         if self.ctx.ndk_api < self.MIN_NDK_API:
@@ -118,6 +140,8 @@ class Python3Recipe(TargetPythonRecipe):
             shprint(sh.cp, join(lib_dir, 'crtend_so.o'), './')
 
             env['SYSROOT'] = sysroot
+
+            env = self.set_libs_flags(env, arch)
 
             if not exists('config.status'):
                 shprint(sh.Command(join(recipe_build_dir, 'configure')),

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -2,7 +2,7 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3',
+options = {'apk': {'requirements': 'libffi,sdl2,pyjnius,kivy,python3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_googlendk',


### PR DESCRIPTION
Should be mentioned that the current test app for python3 has been modified by adding libffi to the requirements because the ui for the app has some button to test the ctypes module.

Note: This is the pull request #1463 cleaned up, with documentation and with the commits squashed into one single commit