### PR TITLE
Allow dist overwrite by default

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -130,7 +130,7 @@ class Context(object):
     def ndk_api(self):
         '''The API number compile against'''
         if self._ndk_api is None:
-            raise ValueError('Tried to access ndk_api_api but it has not '
+            raise ValueError('Tried to access ndk_api but it has not '
                              'been set - this should not happen, something '
                              'went wrong!')
         return self._ndk_api

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -5,6 +5,7 @@ import json
 from pythonforandroid.logger import (info, info_notify, warning,
                                      Err_Style, Err_Fore, error)
 from pythonforandroid.util import current_directory
+from shutil import rmtree
 
 
 class Distribution(object):
@@ -46,7 +47,8 @@ class Distribution(object):
                          ndk_api=None,
                          force_build=False,
                          extra_dist_dirs=[],
-                         require_perfect_match=False):
+                         require_perfect_match=False,
+                         allow_replace_dist=True):
         '''Takes information about the distribution, and decides what kind of
         distribution it will be.
 
@@ -70,6 +72,10 @@ class Distribution(object):
         require_perfect_match : bool
             If True, will only match distributions with precisely the
             correct set of recipes.
+        allow_replace_dist : bool
+            If True, will allow an existing dist with the specified
+            name but incompatible requirements to be overwritten by
+            a new one with the current requirements.
         '''
 
         existing_dists = Distribution.get_distributions(ctx)
@@ -123,7 +129,7 @@ class Distribution(object):
         # If there was a name match but we didn't already choose it,
         # then the existing dist is incompatible with the requested
         # configuration and the build cannot continue
-        if name_match_dist is not None:
+        if name_match_dist is not None and not allow_replace_dist:
             error('Asked for dist with name {name} with recipes ({req_recipes}) and '
                   'NDK API {req_ndk_api}, but a dist '
                   'with this name already exists and has either incompatible recipes '
@@ -153,6 +159,12 @@ class Distribution(object):
         dist.ndk_api = ctx.ndk_api
 
         return dist
+
+    def folder_exists(self):
+        return exists(self.dist_dir)
+
+    def delete(self):
+        rmtree(self.dist_dir)
 
     @classmethod
     def get_distributions(cls, ctx, extra_dist_dirs=[]):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -142,6 +142,8 @@ def require_prebuilt_dist(func):
                                       user_ndk_api=self.ndk_api)
         dist = self._dist
         if dist.needs_build:
+            if dist.folder_exists():  # possible if the dist is being replaced
+                dist.delete()
             info_notify('No dist exists that meets your requirements, '
                         'so one will be built.')
             build_dist_from_args(ctx, dist, args)
@@ -158,7 +160,8 @@ def dist_from_args(ctx, args):
         name=args.dist_name,
         ndk_api=args.ndk_api,
         recipes=split_argument_list(args.requirements),
-        require_perfect_match=args.require_perfect_match)
+        require_perfect_match=args.require_perfect_match,
+        allow_replace_dist=args.allow_replace_dist)
 
 
 def build_dist_from_args(ctx, dist, args):
@@ -315,6 +318,12 @@ class ToolchainCL(object):
             default=False,
             description=('Whether the dist recipes must perfectly match '
                          'those requested'))
+
+        add_boolean_option(
+            generic_parser, ["allow-replace-dist"],
+            default=True,
+            description='Whether existing dist names can be automatically replaced'
+            )
 
         generic_parser.add_argument(
             '--local-recipes', '--local_recipes',
@@ -921,10 +930,11 @@ class ToolchainCL(object):
 
     def delete_dist(self, _args):
         dist = self._dist
-        if dist.needs_build:
+        if not dist.folder_exists():
             info('No dist exists that matches your specifications, '
                  'exiting without deleting.')
-        shutil.rmtree(dist.dist_dir)
+            return
+        dist.delete()
 
     def sdk_tools(self, args):
         """Runs the android binary from the detected SDK directory, passing


### PR DESCRIPTION
My python3 change fixed a bug where dists could be overwritten if a previous dist with the same name but different recipes was present. This wasn't the original intention of the code. However, it looks like the old buggy behaviour was more desirable in practice, so this PR allows dist overwriting by default but adds an option to configure it.