### PR TITLE
Moved ndk_api parsing earlier in program initialisation

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -350,20 +350,7 @@ class Context(object):
                     'set it with `--ndk-version=...`.')
         self.ndk_ver = ndk_ver
 
-        ndk_api = None
-        if user_ndk_api:
-            ndk_api = user_ndk_api
-            info('Getting NDK API version (i.e. minimum supported API) from user argument')
-        elif 'NDKAPI' in environ:
-            ndk_api = environ.get('NDKAPI', None)
-            info('Found Android API target in $NDKAPI')
-        else:
-            ndk_api = min(self.android_api, DEFAULT_NDK_API)
-            warning('NDK API target was not set manually, using '
-                    'the default of {} = min(android-api={}, default ndk-api={})'.format(
-                        ndk_api, self.android_api, DEFAULT_NDK_API))
-        ndk_api = int(ndk_api)
-        self.ndk_api = ndk_api
+        self.ndk_api = user_ndk_api
 
         if self.ndk_api > self.android_api:
             error('Target NDK API is {}, higher than the target Android API {}.'.format(

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -197,6 +197,15 @@ def split_argument_list(l):
     return re.split(r'[ ,]+', l)
 
 
+def select_ndk_api(user_ndk_api, user_android_api):
+    ndk_api = min(DEFAULT_NDK_API, user_android_api)
+    if user_ndk_api == 0:
+        warning(('No valid --ndk-api received, using the default of {} = '
+                 'min(android-api={}, default ndk-api={})').format(
+                     user_ndk_api, user_android_api, DEFAULT_NDK_API))
+    return min(21, user_android_api)
+
+
 class NoAbbrevParser(argparse.ArgumentParser):
     """We want to disable argument abbreviation so as not to interfere
     with passing through arguments to build.py, but in python2 argparse
@@ -528,7 +537,9 @@ class ToolchainCL(object):
         self.ndk_dir = args.ndk_dir
         self.android_api = args.android_api
         self.ndk_version = args.ndk_version
+        args.ndk_api = select_ndk_api(args.ndk_api, args.android_api)
         self.ndk_api = args.ndk_api
+
         self.ctx.symlink_java_src = args.symlink_java_src
         self.ctx.java_build_tool = args.java_build_tool
 


### PR DESCRIPTION
This is actually quite important because we need to know a reasonable number for the NDK API even in places where the build environment has not been prepared.

I've removed the ability to set this parameter via environment variable because, on reflection, I don't think it's actually really important or useful. The environment variables we do accept are there partly for legacy reasons, and are mainly useful for the ndk/sdk locations rather than the api number to target.

The control flow around argument parsing could do with revisiting, but I think this is the neatest solution for now.