### PR TITLE
Fix android module JAVA_NAMESPACE and JNI_NAMESPACE with unicode

### DIFF
--- a/pythonforandroid/recipes/android/__init__.py
+++ b/pythonforandroid/recipes/android/__init__.py
@@ -30,7 +30,7 @@ class AndroidRecipe(IncludedFilesBehaviour, CythonRecipe):
         th = '#define {} {}\n'
         tpy = '{} = {}\n'
 
-        bootstrap = bootstrap_name = self.ctx.bootstrap.name
+        bootstrap = bootstrap_name = self.ctx.bootstrap.name.decode('utf-8')
         is_sdl2 = bootstrap_name in ('sdl2', 'sdl2python3', 'sdl2_gradle')
         is_pygame = bootstrap_name in ('pygame',)
         is_webview = bootstrap_name in ('webview',)
@@ -38,8 +38,8 @@ class AndroidRecipe(IncludedFilesBehaviour, CythonRecipe):
         if is_sdl2 or is_webview:
             if is_sdl2:
                 bootstrap = 'sdl2'
-            java_ns = 'org.kivy.android'
-            jni_ns = 'org/kivy/android'
+            java_ns = u'org.kivy.android'
+            jni_ns = u'org/kivy/android'
         elif is_pygame:
             java_ns = 'org.renpy.android'
             jni_ns = 'org/renpy/android'

--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -175,13 +175,13 @@ api_version = autoclass('android.os.Build$VERSION').SDK_INT
 version_codes = autoclass('android.os.Build$VERSION_CODES')
 
 
-python_act = autoclass(JAVA_NAMESPACE + '.PythonActivity')
-Rect = autoclass('android.graphics.Rect')
+python_act = autoclass(JAVA_NAMESPACE + u'.PythonActivity')
+Rect = autoclass(u'android.graphics.Rect')
 mActivity = python_act.mActivity
 if mActivity:
     # PyGame backend already has the listener so adding
     # one here leads to a crash/too much cpu usage.
-    # SDL2 now does noe need the listener so there is
+    # SDL2 now does not need the listener so there is
     # no point adding a processor intensive layout listenere here.
     height = 0
     def get_keyboard_height():


### PR DESCRIPTION
If not switched to unicode, anything with formating such as `+` will trigger an error for py3 when accessing `JAVA_NAMESPACE` and likes:

    b'1' + u'2'
    u'1' + b'1'

and py2 just doesn't care.