### PR TITLE
Update OpenSSL to 1.1.1

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -37,7 +37,6 @@ class Arch(object):
             '-DANDROID',
             '-fomit-frame-pointer',
             '-D__ANDROID_API__={}'.format(self.ctx.ndk_api)]
-            # '-D__ANDROID_API__={}'.format(self.ctx._android_api)]
         if not clang:
             cflags += ['-mandroid']
         else:

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -30,13 +30,25 @@ class Arch(object):
                 d.format(arch=self))
             for d in self.ctx.include_dirs]
 
-    def get_env(self, with_flags_in_cc=True):
+    def get_env(self, with_flags_in_cc=True, clang=False):
         env = {}
 
-        env['CFLAGS'] = ' '.join([
-            '-DANDROID', '-mandroid', '-fomit-frame-pointer'
-            ' -D__ANDROID_API__={}'.format(self.ctx.ndk_api),
-            ])
+        cflags = [
+            '-DANDROID',
+            '-fomit-frame-pointer',
+            '-D__ANDROID_API__={}'.format(self.ctx.ndk_api)]
+            # '-D__ANDROID_API__={}'.format(self.ctx._android_api)]
+        if not clang:
+            cflags += ['-mandroid']
+        else:
+            cflags += ['-target armv7-none-linux-androideabi']
+            android_host = 'arm-linux-androideabi'
+            platform_dir = join(self.ctx.ndk_dir, 'platforms', 'android-{}'.format(self.ctx.ndk_api), 'arch-arm')
+            toolchain = '{android_host}-4.9'.format(android_host=android_host)
+            toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
+            cflags += ['-gcc-toolchain {}'.format(toolchain)]
+
+        env['CFLAGS'] = ' '.join(cflags)
         env['LDFLAGS'] = ' '
 
         sysroot = join(self.ctx._ndk_dir, 'sysroot')
@@ -82,9 +94,21 @@ class Arch(object):
             env['NDK_CCACHE'] = self.ctx.ccache
             env.update({k: v for k, v in environ.items() if k.startswith('CCACHE_')})
 
-        cc = find_executable('{command_prefix}-gcc'.format(
-            command_prefix=command_prefix), path=environ['PATH'])
+        if clang:
+            clang_path = join(
+                self.ctx.ndk_dir, 'toolchains', 'llvm', 'prebuilt',
+                'linux-x86_64', 'bin')
+            environ['PATH'] = '{clang_path}:{path}'.format(
+                clang_path=clang_path, path=environ['PATH'])
+            exe = join(clang_path, 'clang')
+            execxx = join(clang_path, 'clang++')
+        else:
+            exe = '{command_prefix}-gcc'.format(command_prefix=command_prefix)
+            execxx = '{command_prefix}-g++'.format(command_prefix=command_prefix)
+
+        cc = find_executable(exe, path=environ['PATH'])
         if cc is None:
+            print(environ['PATH'])
             print('Searching path are: {!r}'.format(environ['PATH']))
             warning('Couldn\'t find executable for CC. This indicates a '
                     'problem locating the {} executable in the Android '
@@ -93,20 +117,20 @@ class Arch(object):
             exit(1)
 
         if with_flags_in_cc:
-            env['CC'] = '{ccache}{command_prefix}-gcc {cflags}'.format(
-                command_prefix=command_prefix,
+            env['CC'] = '{ccache}{exe} {cflags}'.format(
+                exe=exe,
                 ccache=ccache,
                 cflags=env['CFLAGS'])
-            env['CXX'] = '{ccache}{command_prefix}-g++ {cxxflags}'.format(
-                command_prefix=command_prefix,
+            env['CXX'] = '{ccache}{execxx} {cxxflags}'.format(
+                execxx=execxx,
                 ccache=ccache,
                 cxxflags=env['CXXFLAGS'])
         else:
-            env['CC'] = '{ccache}{command_prefix}-gcc'.format(
-                command_prefix=command_prefix,
+            env['CC'] = '{ccache}{exe}'.format(
+                exe=exe,
                 ccache=ccache)
-            env['CXX'] = '{ccache}{command_prefix}-g++'.format(
-                command_prefix=command_prefix,
+            env['CXX'] = '{ccache}{execxx}'.format(
+                execxx=execxx,
                 ccache=ccache)
 
         env['AR'] = '{}-ar'.format(command_prefix)
@@ -151,8 +175,8 @@ class ArchARM(Arch):
 class ArchARMv7_a(ArchARM):
     arch = 'armeabi-v7a'
 
-    def get_env(self, with_flags_in_cc=True):
-        env = super(ArchARMv7_a, self).get_env(with_flags_in_cc)
+    def get_env(self, with_flags_in_cc=True, clang=False):
+        env = super(ArchARMv7_a, self).get_env(with_flags_in_cc, clang=clang)
         env['CFLAGS'] = (env['CFLAGS'] +
                          (' -march=armv7-a -mfloat-abi=softfp '
                           '-mfpu=vfp -mthumb'))
@@ -166,8 +190,8 @@ class Archx86(Arch):
     command_prefix = 'i686-linux-android'
     platform_dir = 'arch-x86'
 
-    def get_env(self, with_flags_in_cc=True):
-        env = super(Archx86, self).get_env(with_flags_in_cc)
+    def get_env(self, with_flags_in_cc=True, clang=False):
+        env = super(Archx86, self).get_env(with_flags_in_cc, clang=clang)
         env['CFLAGS'] = (env['CFLAGS'] +
                          ' -march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32')
         env['CXXFLAGS'] = env['CFLAGS']
@@ -180,8 +204,8 @@ class Archx86_64(Arch):
     command_prefix = 'x86_64-linux-android'
     platform_dir = 'arch-x86'
 
-    def get_env(self, with_flags_in_cc=True):
-        env = super(Archx86_64, self).get_env(with_flags_in_cc)
+    def get_env(self, with_flags_in_cc=True, clang=False):
+        env = super(Archx86_64, self).get_env(with_flags_in_cc, clang=clang)
         env['CFLAGS'] = (env['CFLAGS'] +
                          ' -march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel')
         env['CXXFLAGS'] = env['CFLAGS']
@@ -194,8 +218,8 @@ class ArchAarch_64(Arch):
     command_prefix = 'aarch64-linux-android'
     platform_dir = 'arch-arm64'
 
-    def get_env(self, with_flags_in_cc=True):
-        env = super(ArchAarch_64, self).get_env(with_flags_in_cc)
+    def get_env(self, with_flags_in_cc=True, clang=False):
+        env = super(ArchAarch_64, self).get_env(with_flags_in_cc, clang=clang)
         incpath = ' -I' + join(dirname(__file__), 'includes', 'arm64-v8a')
         env['EXTRA_CFLAGS'] = incpath
         env['CFLAGS'] += incpath

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -126,21 +126,21 @@ class Distribution(object):
 
         assert len(possible_dists) < 2
 
-        # If there was a name match but we didn't already choose it,
-        # then the existing dist is incompatible with the requested
-        # configuration and the build cannot continue
-        if name_match_dist is not None and not allow_replace_dist:
-            error('Asked for dist with name {name} with recipes ({req_recipes}) and '
-                  'NDK API {req_ndk_api}, but a dist '
-                  'with this name already exists and has either incompatible recipes '
-                  '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
-                      name=name,
-                      req_ndk_api=ndk_api,
-                      dist_ndk_api=name_match_dist.ndk_api,
-                      req_recipes=', '.join(recipes),
-                      dist_recipes=', '.join(name_match_dist.recipes)))
-            error('No compatible dist found, so exiting.')
-            exit(1)
+        # # If there was a name match but we didn't already choose it,
+        # # then the existing dist is incompatible with the requested
+        # # configuration and the build cannot continue
+        # if name_match_dist is not None:
+        #     error('Asked for dist with name {name} with recipes ({req_recipes}) and '
+        #           'NDK API {req_ndk_api}, but a dist '
+        #           'with this name already exists and has either incompatible recipes '
+        #           '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
+        #               name=name,
+        #               req_ndk_api=ndk_api,
+        #               dist_ndk_api=name_match_dist.ndk_api,
+        #               req_recipes=', '.join(recipes),
+        #               dist_recipes=', '.join(name_match_dist.recipes)))
+        #     error('No compatible dist found, so exiting.')
+        #     exit(1)
 
         # If we got this far, we need to build a new dist
         dist = Distribution(ctx)

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -126,21 +126,21 @@ class Distribution(object):
 
         assert len(possible_dists) < 2
 
-        # # If there was a name match but we didn't already choose it,
-        # # then the existing dist is incompatible with the requested
-        # # configuration and the build cannot continue
-        # if name_match_dist is not None:
-        #     error('Asked for dist with name {name} with recipes ({req_recipes}) and '
-        #           'NDK API {req_ndk_api}, but a dist '
-        #           'with this name already exists and has either incompatible recipes '
-        #           '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
-        #               name=name,
-        #               req_ndk_api=ndk_api,
-        #               dist_ndk_api=name_match_dist.ndk_api,
-        #               req_recipes=', '.join(recipes),
-        #               dist_recipes=', '.join(name_match_dist.recipes)))
-        #     error('No compatible dist found, so exiting.')
-        #     exit(1)
+        # If there was a name match but we didn't already choose it,
+        # then the existing dist is incompatible with the requested
+        # configuration and the build cannot continue
+        if name_match_dist is not None:
+            error('Asked for dist with name {name} with recipes ({req_recipes}) and '
+                  'NDK API {req_ndk_api}, but a dist '
+                  'with this name already exists and has either incompatible recipes '
+                  '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
+                      name=name,
+                      req_ndk_api=ndk_api,
+                      dist_ndk_api=name_match_dist.ndk_api,
+                      req_recipes=', '.join(recipes),
+                      dist_recipes=', '.join(name_match_dist.recipes)))
+            error('No compatible dist found, so exiting.')
+            exit(1)
 
         # If we got this far, we need to build a new dist
         dist = Distribution(ctx)

--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -148,8 +148,10 @@ def shprint(command, *args, **kwargs):
     kwargs["_bg"] = True
     is_critical = kwargs.pop('_critical', False)
     tail_n = kwargs.pop('_tail', None)
+    full_debug = False
     if "P4A_FULL_DEBUG" in os.environ:
         tail_n = 0
+        full_debug = True
     filter_in = kwargs.pop('_filter', None)
     filter_out = kwargs.pop('_filterout', None)
     if len(logger.handlers) > 1:
@@ -177,6 +179,10 @@ def shprint(command, *args, **kwargs):
             if isinstance(line, bytes):
                 line = line.decode('utf-8', errors='replace')
             if logger.level > logging.DEBUG:
+                if full_debug:
+                    stdout.write(line)
+                    stdout.flush()
+                    continue
                 msg = line.replace(
                     '\n', ' ').replace(
                         '\t', ' ').replace(

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -406,12 +406,12 @@ class Recipe(with_metaclass(RecipeMeta)):
             else:
                 info('{} is already unpacked, skipping'.format(self.name))
 
-    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True, clang=False):
         """Return the env specialized for the recipe
         """
         if arch is None:
             arch = self.filtered_archs[0]
-        return arch.get_env(with_flags_in_cc=with_flags_in_cc)
+        return arch.get_env(with_flags_in_cc=with_flags_in_cc, clang=clang)
 
     def prebuild_arch(self, arch):
         '''Run any pre-build tasks for the Recipe. By default, this checks if

--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -9,12 +9,12 @@ IF BOOTSTRAP == 'pygame':
 
     def check_pause():
         return SDL_ANDROID_CheckPause()
-    
+
     def wait_for_resume():
         android_accelerometer_enable(False)
         SDL_ANDROID_WaitForResume()
         android_accelerometer_enable(accelerometer_enabled)
-    
+
     def map_key(scancode, keysym):
         SDL_ANDROID_MapKey(scancode, keysym)
 
@@ -300,16 +300,16 @@ IF IS_PYGAME:
             j_chooser_title = <bytes>chooser_title
         android_action_send(j_mimetype, j_filename, j_subject, j_text,
                 j_chooser_title)
-    
+
     cdef extern int android_checkstop()
     cdef extern void android_ackstop()
-    
+
     def check_stop():
         return android_checkstop()
-    
+
     def ack_stop():
         android_ackstop()
-    
+
 # -------------------------------------------------------------------
 # URL Opening.
 def open_url(url):
@@ -330,7 +330,7 @@ class AndroidBrowser(object):
         return open_url(url)
     def open_new_tab(self, url):
         return open_url(url)
-    
+
 import webbrowser
 webbrowser.register('android', AndroidBrowser)
 
@@ -381,5 +381,3 @@ class AndroidService(object):
         '''Stop the service.
         '''
         stop_service()
-
-

--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -17,8 +17,8 @@ class CryptographyRecipe(CompiledComponentsPythonRecipe):
         env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         env['CFLAGS'] += ' -I' + join(openssl_dir, 'include')
         env['LDFLAGS'] += ' -L' + openssl_dir + \
-                          ' -lssl' + r.version + \
-                          ' -lcrypto' + r.version
+                          ' -lssl' + r.lib_version + \
+                          ' -lcrypto' + r.lib_version
 
         return env
 

--- a/pythonforandroid/recipes/dateutil/__init__.py
+++ b/pythonforandroid/recipes/dateutil/__init__.py
@@ -6,7 +6,7 @@ class DateutilRecipe(PythonRecipe):
     version = '2.6.0'
     url = 'https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz'
 
-    depends = ['python2', "setuptools"]
+    depends = [('python2', 'python3'), "setuptools"]
     call_hostpython_via_targetpython = False
     install_in_hostpython = True
 

--- a/pythonforandroid/recipes/libcurl/__init__.py
+++ b/pythonforandroid/recipes/libcurl/__init__.py
@@ -10,7 +10,6 @@ class LibcurlRecipe(Recipe):
     depends = ['openssl']
 
     def should_build(self, arch):
-        return True
         super(LibcurlRecipe, self).should_build(arch)
         return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libcurl.so'))
 

--- a/pythonforandroid/recipes/libcurl/__init__.py
+++ b/pythonforandroid/recipes/libcurl/__init__.py
@@ -10,6 +10,7 @@ class LibcurlRecipe(Recipe):
     depends = ['openssl']
 
     def should_build(self, arch):
+        return True
         super(LibcurlRecipe, self).should_build(arch)
         return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libcurl.so'))
 
@@ -19,6 +20,10 @@ class LibcurlRecipe(Recipe):
 
         r = self.get_recipe('openssl', self.ctx)
         openssl_dir = r.get_build_dir(arch.arch)
+
+        # with-ssl assume the libcrypto is in lib/ subdirectory
+        # but it will be within the openssl_dir directory directly.
+        env["LDFLAGS"] += " -L{}".format(openssl_dir)
 
         with current_directory(self.get_build_dir(arch.arch)):
             dst_dir = join(self.get_build_dir(arch.arch), 'dist')

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -72,7 +72,7 @@ class LibtorrentRecipe(Recipe):
         if 'openssl' in recipe.ctx.recipe_build_order:
             r = self.get_recipe('openssl', self.ctx)
             env['OPENSSL_BUILD_PATH'] = r.get_build_dir(arch.arch)
-            env['OPENSSL_VERSION'] = r.version
+            env['OPENSSL_VERSION'] = r.lib_version
         return env
 
 

--- a/pythonforandroid/recipes/openssl/disable-sover.patch
+++ b/pythonforandroid/recipes/openssl/disable-sover.patch
@@ -1,20 +1,11 @@
---- openssl/Makefile	2016-01-28 17:26:49.159522273 +0100
-+++ b/Makefile	2016-01-28 17:26:54.358438402 +0100
-@@ -342,7 +342,7 @@
- link-shared:
- 	@ set -e; for i in $(SHLIBDIRS); do \
- 		$(MAKE) -f $(HERE)/Makefile.shared -e $(BUILDENV) \
--			LIBNAME=$$i LIBVERSION=$(SHLIB_MAJOR).$(SHLIB_MINOR) \
-+			LIBNAME=$$i LIBVERSION= \
- 			LIBCOMPATVERSIONS=";$(SHLIB_VERSION_HISTORY)" \
- 			symlink.$(SHLIB_TARGET); \
- 		libs="$$libs -l$$i"; \
-@@ -356,7 +356,7 @@
- 			libs="$(LIBKRB5) $$libs"; \
- 		fi; \
- 		$(CLEARENV) && $(MAKE) -f Makefile.shared -e $(BUILDENV) \
--			LIBNAME=$$i LIBVERSION=$(SHLIB_MAJOR).$(SHLIB_MINOR) \
-+			LIBNAME=$$i LIBVERSION= \
- 			LIBCOMPATVERSIONS=";$(SHLIB_VERSION_HISTORY)" \
- 			LIBDEPS="$$libs $(EX_LIBS)" \
- 			link_a.$(SHLIB_TARGET); \
+--- openssl/Makefile.orig       2018-10-20 22:49:40.418310423 +0200
++++ openssl/Makefile    2018-10-20 22:50:23.347322403 +0200
+@@ -19,7 +19,7 @@
+ SHLIB_MAJOR=1
+ SHLIB_MINOR=1
+ SHLIB_TARGET=linux-shared
+-SHLIB_EXT=.so.$(SHLIB_VERSION_NUMBER)
++SHLIB_EXT=$(SHLIB_VERSION_NUMBER).so
+ SHLIB_EXT_SIMPLE=.so
+ SHLIB_EXT_IMPORT=
+ 

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -96,7 +96,7 @@ class Python2Recipe(TargetPythonRecipe):
                 setuplocal = join('Modules', 'Setup.local')
                 shprint(sh.cp, join(self.get_recipe_dir(), 'Setup.local-ssl'), setuplocal)
                 shprint(sh.sed, '-i.backup', 's#^SSL=.*#SSL={}#'.format(openssl_build_dir), setuplocal)
-                env['OPENSSL_VERSION'] = recipe.version
+                env['OPENSSL_VERSION'] = recipe.lib_version
 
             if 'sqlite3' in self.ctx.recipe_build_order:
                 # Include sqlite3 in python2 build

--- a/pythonforandroid/recipes/python3/Setup.local-ssl
+++ b/pythonforandroid/recipes/python3/Setup.local-ssl
@@ -1,0 +1,4 @@
+SSL=
+_ssl _ssl.c \
+  -DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
+  -L$(SSL) -lssl$(OPENSSL_VERSION) -lcrypto$(OPENSSL_VERSION)

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,4 +1,4 @@
-from pythonforandroid.recipe import TargetPythonRecipe
+from pythonforandroid.recipe import TargetPythonRecipe, Recipe
 from pythonforandroid.toolchain import shprint, current_directory
 from pythonforandroid.logger import logger, info, error
 from pythonforandroid.util import ensure_dir, walk_valid_filens

--- a/pythonforandroid/recipes/requests/__init__.py
+++ b/pythonforandroid/recipes/requests/__init__.py
@@ -4,11 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class RequestsRecipe(PythonRecipe):
     version = '2.13.0'
     url = 'https://github.com/kennethreitz/requests/archive/v{version}.tar.gz'
-<<<<<<< Updated upstream
     depends = [('hostpython2', 'hostpython3', 'hostpython3crystax'), 'setuptools']
-=======
-    depends = [('hostpython2', 'hostpython3crystax', 'hostpython3'), 'setuptools']
->>>>>>> Stashed changes
     site_packages_name = 'requests'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/requests/__init__.py
+++ b/pythonforandroid/recipes/requests/__init__.py
@@ -4,7 +4,11 @@ from pythonforandroid.recipe import PythonRecipe
 class RequestsRecipe(PythonRecipe):
     version = '2.13.0'
     url = 'https://github.com/kennethreitz/requests/archive/v{version}.tar.gz'
-    depends = [('hostpython2', 'hostpython3crystax'), 'setuptools']
+<<<<<<< Updated upstream
+    depends = [('hostpython2', 'hostpython3', 'hostpython3crystax'), 'setuptools']
+=======
+    depends = [('hostpython2', 'hostpython3crystax', 'hostpython3'), 'setuptools']
+>>>>>>> Stashed changes
     site_packages_name = 'requests'
     call_hostpython_via_targetpython = False
 

--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -5,7 +5,7 @@ class SetuptoolsRecipe(PythonRecipe):
     version = '40.0.0'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
 
-    depends = [('python2', 'python3crystax')]
+    depends = [('python2', 'python3crystax', 'python3')]
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = True


### PR DESCRIPTION
This PR updates OpenSSL to 1.1.1, and uses clang for compilation.
There is now a distinction between the version we use for downloading, and the version used for creating the library: OpenSSL 1.1 now have prefix with "1.1.so". This explains why others recipes that depends on it require the "library" version.

Let me know if i must remove and make a separate PR for others recipes that are broken on python3 because there was a missing deps (and forget my commit, we can squash and merge for that)