### PR TITLE
Allow Python 3 To Be Built On Non-ARM Architectures

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -178,7 +178,7 @@ class Archx86_64(Arch):
     arch = 'x86_64'
     toolchain_prefix = 'x86_64'
     command_prefix = 'x86_64-linux-android'
-    platform_dir = 'arch-x86'
+    platform_dir = 'arch-x86_64'
 
     def get_env(self, with_flags_in_cc=True):
         env = super(Archx86_64, self).get_env(with_flags_in_cc)

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -70,7 +70,7 @@ class Python3Recipe(TargetPythonRecipe):
             android_host = arch.command_prefix
             android_build = sh.Command(join(recipe_build_dir, 'config.guess'))().stdout.strip().decode('utf-8')
             platform_dir = join(self.ctx.ndk_dir, 'platforms', platform_name, arch.platform_dir)
-            toolchain = '{android_host}-4.9'.format(android_host=android_host)
+            toolchain = '{android_host}-4.9'.format(android_host=arch.toolchain_prefix)
             toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
             
             target_data = arch.command_prefix.split('-')

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -67,14 +67,20 @@ class Python3Recipe(TargetPythonRecipe):
             env = environ.copy()
 
             # TODO: Get this information from p4a's arch system
-            android_host = 'arm-linux-androideabi'
+            android_host = arch.toolchain_prefix
             android_build = sh.Command(join(recipe_build_dir, 'config.guess'))().stdout.strip().decode('utf-8')
-            platform_dir = join(self.ctx.ndk_dir, 'platforms', platform_name, 'arch-arm')
+            platform_dir = join(self.ctx.ndk_dir, 'platforms', platform_name, arch.platform_dir)
             toolchain = '{android_host}-4.9'.format(android_host=android_host)
             toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
+            
+            target_data = arch.command_prefix.split('-')
+            if targetData[0] == 'arm':
+                targetData[0] = 'armv7a'
+            target = '-'.join([targetData[0], 'none', targetData[1], targetData[2]])
+    
             CC = '{clang} -target {target} -gcc-toolchain {toolchain}'.format(
                 clang=join(self.ctx.ndk_dir, 'toolchains', 'llvm', 'prebuilt', 'linux-x86_64', 'bin', 'clang'),
-                target='armv7-none-linux-androideabi',
+                target=target,
                 toolchain=toolchain)
 
             AR = join(toolchain, 'bin', android_host) + '-ar'

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -119,6 +119,8 @@ class Python3Recipe(TargetPythonRecipe):
             # bpo-30386 Makefile system.
             logger.warning('Doing some hacky stuff to link properly')
             lib_dir = join(sysroot, 'usr', 'lib')
+            if arch.arch == 'x86_64':
+                lib_dir = join(sysroot, 'usr', 'lib64')
             env['LDFLAGS'] += ' -L{}'.format(lib_dir)
             shprint(sh.cp, join(lib_dir, 'crtbegin_so.o'), './')
             shprint(sh.cp, join(lib_dir, 'crtend_so.o'), './')

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -100,7 +100,7 @@ class Python3Recipe(TargetPythonRecipe):
                 hostpython_dir=self.get_recipe('hostpython3', self.ctx).get_path_to_python(),
                 old_path=env['PATH'])
 
-            ndk_flags = ('--sysroot={ndk_sysroot} -D__ANDROID_API__={android_api} '
+            ndk_flags = ('-fPIC --sysroot={ndk_sysroot} -D__ANDROID_API__={android_api} '
                          '-isystem {ndk_android_host}').format(
                              ndk_sysroot=join(self.ctx.ndk_dir, 'sysroot'),
                              android_api=self.ctx.ndk_api,

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -67,7 +67,7 @@ class Python3Recipe(TargetPythonRecipe):
             env = environ.copy()
 
             # TODO: Get this information from p4a's arch system
-            android_host = arch.toolchain_prefix
+            android_host = arch.command_prefix
             android_build = sh.Command(join(recipe_build_dir, 'config.guess'))().stdout.strip().decode('utf-8')
             platform_dir = join(self.ctx.ndk_dir, 'platforms', platform_name, arch.platform_dir)
             toolchain = '{android_host}-4.9'.format(android_host=android_host)

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -74,9 +74,9 @@ class Python3Recipe(TargetPythonRecipe):
             toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
             
             target_data = arch.command_prefix.split('-')
-            if targetData[0] == 'arm':
-                targetData[0] = 'armv7a'
-            target = '-'.join([targetData[0], 'none', targetData[1], targetData[2]])
+            if target_data[0] == 'arm':
+                target_data[0] = 'armv7a'
+            target = '-'.join([target_data[0], 'none', target_data[1], target_data[2]])
     
             CC = '{clang} -target {target} -gcc-toolchain {toolchain}'.format(
                 clang=join(self.ctx.ndk_dir, 'toolchains', 'llvm', 'prebuilt', 'linux-x86_64', 'bin', 'clang'),

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -106,7 +106,7 @@ class Python3Recipe(TargetPythonRecipe):
                              android_api=self.ctx.ndk_api,
                              ndk_android_host=join(
                                  self.ctx.ndk_dir, 'sysroot', 'usr', 'include', android_host))
-            sysroot = join(self.ctx.ndk_dir, 'platforms', platform_name, 'arch-arm')
+            sysroot = join(self.ctx.ndk_dir, 'platforms', platform_name, arch.platform_dir)
             env['CFLAGS'] = env.get('CFLAGS', '') + ' ' + ndk_flags
             env['CPPFLAGS'] = env.get('CPPFLAGS', '') + ' ' + ndk_flags
             env['LDFLAGS'] = env.get('LDFLAGS', '') + ' --sysroot={} -L{}'.format(sysroot, join(sysroot, 'usr', 'lib'))

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -72,12 +72,12 @@ class Python3Recipe(TargetPythonRecipe):
             platform_dir = join(self.ctx.ndk_dir, 'platforms', platform_name, arch.platform_dir)
             toolchain = '{android_host}-4.9'.format(android_host=arch.toolchain_prefix)
             toolchain = join(self.ctx.ndk_dir, 'toolchains', toolchain, 'prebuilt', 'linux-x86_64')
-            
+
             target_data = arch.command_prefix.split('-')
             if target_data[0] == 'arm':
                 target_data[0] = 'armv7a'
             target = '-'.join([target_data[0], 'none', target_data[1], target_data[2]])
-    
+
             CC = '{clang} -target {target} -gcc-toolchain {toolchain}'.format(
                 clang=join(self.ctx.ndk_dir, 'toolchains', 'llvm', 'prebuilt', 'linux-x86_64', 'bin', 'clang'),
                 target=target,


### PR DESCRIPTION
This makes it no longer hardcoded to build on ARM.