### PR TITLE
Fix broken --ndk-api default value

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -261,7 +261,7 @@ class ToolchainCL(object):
             help=('The version of the Android NDK. This is optional: '
                   'we try to work it out automatically from the ndk_dir.'))
         generic_parser.add_argument(
-            '--ndk-api', type=int, default=0,
+            '--ndk-api', type=int, default=None,
             help=('The Android API level to compile against. This should be your '
                   '*minimal supported* API, not normally the same as your --android-api. '
                   'Defaults to min(ANDROID_API, {}) if not specified.').format(DEFAULT_NDK_API))


### PR DESCRIPTION
I ran into this by accident while making the other pull requests. `--ndk-api` defaults to `0` in the parser, but code in other places (e.g. `distribution.py`) expects it to be `None` if not set. This breaks locating the proper final distribution in some cases when it's not specified, therefore I suggest this should be fixed.