### PR TITLE
Fix handling of file paths in module dependencies

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -8,6 +8,7 @@ import glob
 import sys
 import re
 import sh
+import subprocess
 
 from pythonforandroid.util import (ensure_dir, current_directory)
 from pythonforandroid.logger import (info, warning, error, info_notify,
@@ -559,6 +560,26 @@ class Context(object):
         return exists(join(self.get_libs_dir(arch), lib))
 
     def has_package(self, name, arch=None):
+        # If this is a file path, it'll need special handling:
+        if name.find("/") >= 0 or name.find("\\") >= 0:
+            if not os.path.exists(name):
+                # Non-existing dir, cannot look this up.
+                return False
+            if os.path.exists(os.path.join(name, "setup.py")):
+                # Get name from setup.py:
+                name = subprocess.check_output([
+                    sys.executable, "setup.py", "--name"],
+                    cwd=name)
+                try:
+                    name = name.decode('utf-8', 'replace')
+                except AttributeError:
+                    pass
+                name = name.strip()
+            else:
+                # A folder with whatever, cannot look this up.
+                return False
+
+        # Try to look up recipe by name:
         try:
             recipe = Recipe.get_recipe(name, self)
         except IOError:


### PR DESCRIPTION
This fixes the handling of file paths in module dependencies in `--requirements`, which previously led to them simply being ignored (and hence breaking any build that would try to use this).