### PR TITLE
Fix reportlab GPL issue by removing problematic component

### DIFF
--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -13,8 +13,20 @@ class ReportLabRecipe(CompiledComponentsPythonRecipe):
     def prebuild_arch(self, arch):
         if not self.is_patched(arch):
             super(ReportLabRecipe, self).prebuild_arch(arch)
-            self.apply_patch('patches/fix-setup.patch', arch.arch)
             recipe_dir = self.get_build_dir(arch.arch)
+
+            # Some versions of reportlab ship with a GPL-licensed font.
+            # Remove it, since this is problematic in .apks unless the
+            # entire app is GPL:
+            font_dir = os.path.join(recipe_dir,
+                "src", "reportlab", "fonts")
+            if os.path.exists(font_dir):
+                for l in os.listdir(font_dir):
+                    if l.lower().startswith('darkgarden'):
+                        os.remove(os.path.join(font_dir, l))
+
+            # Apply patches:
+            self.apply_patch('patches/fix-setup.patch', arch.arch)
             shprint(sh.touch, os.path.join(recipe_dir, '.patched'))
             ft = self.get_recipe('freetype', self.ctx)
             ft_dir = ft.get_build_dir(arch.arch)

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -19,7 +19,7 @@ class ReportLabRecipe(CompiledComponentsPythonRecipe):
             # Remove it, since this is problematic in .apks unless the
             # entire app is GPL:
             font_dir = os.path.join(recipe_dir,
-                "src", "reportlab", "fonts")
+                                    "src", "reportlab", "fonts")
             if os.path.exists(font_dir):
                 for l in os.listdir(font_dir):
                     if l.lower().startswith('darkgarden'):


### PR DESCRIPTION
This fixes the reportlab GPL issue by removing problematic component. (By default, reportlab has a GPL'ed font that is included into the `.apk` which is quite bad for licensing reasons.)

I tested that:

- the DarkGarden font is gone from the `.apk` (by manually unzipping it and opening the `private.mp3` tarball)
- that the build with `python3crystax` still works
- that a `python3crystax` app can still successfully export PDF with text

So as far as I'm concerned, this should be ready for merging