### PR TITLE
Fixes audiostream recipe on Python3

### DIFF
--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -7,7 +7,7 @@ class AudiostreamRecipe(CythonRecipe):
     version = 'master'
     url = 'https://github.com/kivy/audiostream/archive/{version}.zip'
     name = 'audiostream'
-    depends = ['python2', ('sdl', 'sdl2'), 'pyjnius']
+    depends = [('python2', 'python3'), ('sdl', 'sdl2'), 'pyjnius']
 
     def get_recipe_env(self, arch):
         env = super(AudiostreamRecipe, self).get_recipe_env(arch)
@@ -18,12 +18,14 @@ class AudiostreamRecipe(CythonRecipe):
             sdl_include = 'SDL2'
             sdl_mixer_include = 'SDL2_mixer'
             env['USE_SDL2'] = 'True'
-            env['SDL2_INCLUDE_DIR'] = '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include'
+            env['SDL2_INCLUDE_DIR'] = join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include')
 
         env['CFLAGS'] += ' -I{jni_path}/{sdl_include}/include -I{jni_path}/{sdl_mixer_include}'.format(
                               jni_path=join(self.ctx.bootstrap.build_dir, 'jni'),
                               sdl_include=sdl_include,
                               sdl_mixer_include=sdl_mixer_include)
+        env['NDKPLATFORM'] = self.ctx.ndk_platform
+        env['LIBLINK'] = 'NOTNONE'
         return env
 
 

--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -25,7 +25,7 @@ class AudiostreamRecipe(CythonRecipe):
                               sdl_include=sdl_include,
                               sdl_mixer_include=sdl_mixer_include)
         env['NDKPLATFORM'] = self.ctx.ndk_platform
-        env['LIBLINK'] = 'NOTNONE'
+        env['LIBLINK'] = 'NOTNONE'  # Hacky fix. Needed by audiostream setup.py
         return env
 
 


### PR DESCRIPTION
This PR adds python3 support to audiostream recipe.
Before merging we need to merge kivy/audiostream#24 .

