### PR TITLE
Minor fixes to basic common bootstrap handling code

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -1,4 +1,4 @@
-from os.path import (join, dirname, isdir, splitext, basename)
+from os.path import (join, dirname, isdir, normpath, splitext, basename)
 from os import listdir, walk, sep
 import sh
 import glob
@@ -16,8 +16,8 @@ from pythonforandroid.recipe import Recipe
 def copy_files(src_root, dest_root, override=True):
     for root, dirnames, filenames in walk(src_root):
         for filename in filenames:
-            subdir = root.replace(src_root, "")
-            if subdir.startswith(sep):
+            subdir = normpath(root.replace(src_root, ""))
+            if subdir.startswith(sep):  # ensure it is relative
                 subdir = subdir[1:]
             dest_dir = join(dest_root, subdir)
             if not os.path.exists(dest_dir):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -141,9 +141,6 @@ def require_prebuilt_dist(func):
                                       user_ndk_ver=self.ndk_version,
                                       user_ndk_api=self.ndk_api)
         dist = self._dist
-        bs = Bootstrap.get_bootstrap(args.bootstrap, ctx)
-        # recipes rarely change, but during dev, bootstraps can change from
-        # build to build, so run prepare_bootstrap even if needs_build is false
         if dist.needs_build:
             if dist.folder_exists():  # possible if the dist is being replaced
                 dist.delete()


### PR DESCRIPTION
Minor fixes to basic common bootstrap handling code as suggested by @AndreMiras here: #1496 (see the code review comments)

Please note I added `normpath` *without* replacing the two code lines after it as suggested in the code review, since that one does something different (not a path normalization, but ensures it is a relative path) and I'm pretty sure it needs to stay in.

**Tested, ready for merge**