### PR TITLE
Make SDL2 & services_only bootstrap properly error with missing --private

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/build.py
+++ b/pythonforandroid/bootstraps/sdl2/build/build.py
@@ -599,6 +599,9 @@ tools directory of the Android SDK.
                         if x.strip() and not x.strip().startswith('#')]
         WHITELIST_PATTERNS += patterns
 
+    if args.private is None:
+        print('Need --private directory with app files to package for .apk')
+        exit(1)
     make_package(args)
 
     return args

--- a/pythonforandroid/bootstraps/service_only/build/build.py
+++ b/pythonforandroid/bootstraps/service_only/build/build.py
@@ -496,6 +496,9 @@ tools directory of the Android SDK.
                         if x.strip() and not x.strip().startswith('#')]
         WHITELIST_PATTERNS += patterns
 
+    if args.private is None:
+        print('Need --private directory with app files to package for .apk')
+        exit(1)
     make_package(args)
 
     return args


### PR DESCRIPTION
The SDL2 & services_only bootstraps don't support building without `--private`, but the package assembling `build.py` will give an obscure backtrace if the option is omitted. This pull request adds in a proper error.