### PR TITLE
Fix libnacl recipe missing libsodium

### DIFF
--- a/pythonforandroid/recipes/libnacl/__init__.py
+++ b/pythonforandroid/recipes/libnacl/__init__.py
@@ -3,7 +3,7 @@ from pythonforandroid.toolchain import PythonRecipe
 class LibNaClRecipe(PythonRecipe):
     version = '1.4.4'
     url = 'https://github.com/saltstack/libnacl/archive/v{version}.tar.gz'
-    depends = ['hostpython2', 'setuptools']
+    depends = ['hostpython2', 'setuptools', 'libsodium']
     site_packages_name = 'libnacl'
     call_hostpython_via_targetpython = False
 


### PR DESCRIPTION
From their [`setup.py`](https://github.com/saltstack/libnacl) I don't see anything including `libsodium`, however the package is a `ctypes` wrapper (from their description), therefore I don't think it's usable without actually including `libsodium` as a dependency.