### PR TITLE
Update gradle version

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/gradle/wrapper/gradle-wrapper.properties
+++ b/pythonforandroid/bootstraps/sdl2/build/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/build.tmpl.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
        jcenter()
+       google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -847,7 +847,9 @@ class ToolchainCL(object):
 
                 # gradle output apks somewhere else
                 # and don't have version in file
-                apk_dir = join(dist.dist_dir, "build", "outputs", "apk")
+                apk_dir = join(dist.dist_dir,
+                               "build", "outputs", "apk",
+                               args.build_mode)
                 apk_glob = "*-{}.apk"
                 apk_add_version = True
 


### PR DESCRIPTION
To solve the ci errors when trying to download the corresponding build tools which seems to not exist anymore...

Resolves: #1506