### PR TITLE
Uses target python3 on conditional buids, fixes #1485

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -4,6 +4,7 @@ from enum import Enum
 class TargetPython(Enum):
     python2 = 0
     python3crystax = 1
+    python3 = 2
 
 
 # recipes that currently break the build
@@ -94,9 +95,14 @@ BROKEN_RECIPES_PYTHON3_CRYSTAX = set([
     'storm',
     'vlc',
 ])
+# to be created via https://github.com/kivy/python-for-android/issues/1514
+BROKEN_RECIPES_PYTHON3 = set([
+])
+
 BROKEN_RECIPES = {
     TargetPython.python2: BROKEN_RECIPES_PYTHON2,
     TargetPython.python3crystax: BROKEN_RECIPES_PYTHON3_CRYSTAX,
+    TargetPython.python3: BROKEN_RECIPES_PYTHON3,
 }
 # recipes that were already built will be skipped
 CORE_RECIPES = set([

--- a/ci/rebuild_updated_recipes.py
+++ b/ci/rebuild_updated_recipes.py
@@ -9,7 +9,6 @@ To run locally, set the environment variables before running:
 ```
 ANDROID_SDK_HOME=~/.buildozer/android/platform/android-sdk-20
 ANDROID_NDK_HOME=~/.buildozer/android/platform/android-ndk-r9c
-CRYSTAX_NDK_HOME=~/.buildozer/crystax-ndk
 ./ci/rebuild_update_recipes.py
 ```
 
@@ -20,7 +19,7 @@ Current limitations:
   [ERROR]:   Didn't find any valid dependency graphs.
   [ERROR]:   This means that some of your requirements pull in conflicting dependencies.
 - only rebuilds on sdl2 bootstrap
-- supports mainly python3crystax with fallback to python2, but no python3 support
+- supports mainly python3 with fallback to python2
 """
 import sh
 import os
@@ -56,9 +55,7 @@ def build(target_python, requirements):
     testapp = 'setup_testapp_python2.py'
     android_sdk_home = os.environ['ANDROID_SDK_HOME']
     android_ndk_home = os.environ['ANDROID_NDK_HOME']
-    crystax_ndk_home = os.environ['CRYSTAX_NDK_HOME']
-    if target_python == TargetPython.python3crystax:
-        android_ndk_home = crystax_ndk_home
+    if target_python == TargetPython.python3:
         testapp = 'setup_testapp_python3.py'
     requirements.add(target_python.name)
     requirements = ','.join(requirements)
@@ -75,7 +72,7 @@ def build(target_python, requirements):
 
 
 def main():
-    target_python = TargetPython.python3crystax
+    target_python = TargetPython.python3
     recipes = modified_recipes()
     print('recipes modified:', recipes)
     recipes -= CORE_RECIPES

--- a/pythonforandroid/recipes/jedi/__init__.py
+++ b/pythonforandroid/recipes/jedi/__init__.py
@@ -1,13 +1,11 @@
-
 from pythonforandroid.recipe import PythonRecipe
 
 
 class JediRecipe(PythonRecipe):
-    # version = 'master'
     version = 'v0.9.0'
     url = 'https://github.com/davidhalter/jedi/archive/{version}.tar.gz'
 
-    depends = [('python2', 'python3crystax')]
+    depends = [('python2', 'python3crystax', 'python3')]
 
     patches = ['fix_MergedNamesDict_get.patch']
     # This apparently should be fixed in jedi 0.10 (not released to


### PR DESCRIPTION
`python3crystax` support was removed from the CI in #1471.
Conditional builds now relies on `python3` with fallback to `python2`.

Adds `python3` support to `jedi` recipe to demonstrate.