### PR TITLE
Unify configChanges manifest entry and add missing values

### DIFF
--- a/pythonforandroid/bootstraps/pygame/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/pygame/build/templates/AndroidManifest.tmpl.xml
@@ -29,7 +29,7 @@
 
     <activity android:name="org.renpy.android.PythonActivity"
               android:label="@string/iconName"
-			  android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
+              android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
               android:launchMode="singleTask"
               android:process=":python"
               android:screenOrientation="{{ args.orientation }}"

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -63,7 +63,7 @@
 
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
-                  android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
+                  android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -57,7 +57,7 @@
 
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
-                  android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
+                  android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
                   >
             <intent-filter>


### PR DESCRIPTION
The current manifests don't specify some values in configChanges, e.g. the ones relevant for the side-by-side feature of new Android versions. If these values are missing, the SDLActivity will be restarted - however, SDL2 as a result will simply quit even when the application is in foreground/active without restarting properly, so the application crashes/instant-quits at any of these events.

In this spirit, the pygame bootstrap also seemed to have a lot more of these values added already, avoiding such config-triggered crashes. But for some reason these weren't in the other bootstraps. I unified the values for all bootstraps, and added the missing ones of newer API levels like `density`.

**Note:** to fully get side by side working, we also need #1528 - but with these combined, it works perfectly!