### PR TITLE
Use API 27 as new default for travis & docs

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -98,10 +98,10 @@ the latest useable NDK version is r10e, which can be downloaded here:
 
 - `Legacy 32-bit Linux NDK r10e <http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86.bin>`_
 
-First, install a platform to target (you can also replace ``19`` with
+First, install a platform to target (you can also replace ``27`` with
 a different platform number, this will be used again later)::
 
-  $SDK_DIR/tools/bin/sdkmanager "platforms;android-19"
+  $SDK_DIR/tools/bin/sdkmanager "platforms;android-27"
 
 Second, install the build-tools. You can use
 ``$SDK_DIR/tools/bin/sdkmanager --list`` to see all the
@@ -112,9 +112,9 @@ possibilities, but 26.0.2 is the latest version at the time of writing::
 Then, you can edit your ``~/.bashrc`` or other favorite shell to include new environment variables necessary for building on android::
 
     # Adjust the paths!
-    export ANDROIDSDK="$HOME/Documents/android-sdk-21"
+    export ANDROIDSDK="$HOME/Documents/android-sdk-27"
     export ANDROIDNDK="$HOME/Documents/android-ndk-r10e"
-    export ANDROIDAPI="26"  # Target API version of your application
+    export ANDROIDAPI="27"  # Target API version of your application
     export NDKAPI="19"  # Minimum supported API version of your application
     export ANDROIDNDKVER="r10e"  # Version of the NDK you installed
 
@@ -260,7 +260,7 @@ command line. For example, you can add the options you would always
 include such as::
 
     --dist_name my_example
-    --android_api 19
+    --android_api 27
     --requirements kivy,openssl
 
 

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -68,7 +68,7 @@ class BdistAPK(Command):
             sys.argv.append('--version={}'.format(version))
 
         if not argv_contains('--arch'):
-            arch = 'armeabi'
+            arch = 'armeabi-v7a'
             self.arch = arch
             sys.argv.append('--arch={}'.format(arch))
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -287,7 +287,7 @@ class ToolchainCL(object):
 
         generic_parser.add_argument(
             '--arch', help='The archs to build for, separated by commas.',
-            default='armeabi')
+            default='armeabi-v7a')
 
         # Options for specifying the Distribution
         generic_parser.add_argument(

--- a/testapps/setup_testapp_flask.py
+++ b/testapps/setup_testapp_flask.py
@@ -4,13 +4,12 @@ from setuptools import find_packages
 
 options = {'apk': {'debug': None,
                    'requirements': 'python2,flask,pyjnius',
-                   'android-api': 19,
+                   'android-api': 27,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'testapp_flask',
                    'ndk-version': '10.3.2',
                    'bootstrap': 'webview',
                    'permissions': ['INTERNET', 'VIBRATE'],
-                   'arch': 'armeabi-v7a',
                    'window': None,
                    }}
 

--- a/testapps/setup_testapp_python2.py
+++ b/testapps/setup_testapp_python2.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python2',
-                   'android-api': 19,
+                   'android-api': 27,
                    'ndk-api': 19,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python2',

--- a/testapps/setup_testapp_python2_sqlite_openssl.py
+++ b/testapps/setup_testapp_python2_sqlite_openssl.py
@@ -3,14 +3,13 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python2,openssl,requests,peewee,sqlite3',
-                   'android-api': 19,
+                   'android-api': 27,
                    'ndk-api': 19,
                    'ndk-dir': '/home/sandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python2_sqlite_openssl',
                    'ndk-version': '10.3.2',
                    'permission': 'VIBRATE',
                    'permission': 'INTERNET',
-                   'arch': 'armeabi-v7a',
                    'window': None,
                    }}
 

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -7,7 +7,6 @@ options = {'apk': {'requirements': 'libffi,sdl2,pyjnius,kivy,python3',
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_googlendk',
                    'ndk-version': '10.3.2',
-                   'arch': 'armeabi-v7a',
                    'permission': 'VIBRATE',
                    }}
 

--- a/testapps/setup_testapp_python3crystax.py
+++ b/testapps/setup_testapp_python3crystax.py
@@ -8,7 +8,6 @@ options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3crystax',
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest_python3',
                    'ndk-version': '10.3.2',
-                   'arch': 'armeabi-v7a',
                    'permission': 'VIBRATE',
                    }}
 


### PR DESCRIPTION
Use API 27 as default for travis & examples, including `armeabi-v7a` as arch default.
26 is new absolute minimum of the Play Store, and otherwise the new SDL2 2.0.9 pull request won't build.