### PR TITLE
fix wrong conditional for build custom_rules.tmpl.xml

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -483,7 +483,7 @@ main.py that loads it.''')
             join(res_dir, 'values/strings.xml'),
             **render_args)
 
-    if exists("custom_rules.tmpl.xml"):
+    if exists(join("templates", "custom_rules.tmpl.xml")):
         render(
             'custom_rules.tmpl.xml',
             'custom_rules.xml',


### PR DESCRIPTION
without this, **ant debug** stop with message:

~~~
/root/.buildozer/android/platform/android-sdk-20/tools/ant/build.xml:655: /root/fleet_dispatch_client/.buildozer/android/platform/build/dists/myapp/tmp-src does not exist.
~~~