### PR TITLE
[CORE UPDATE - PART V] Fix pycrypto

### DIFF
--- a/pythonforandroid/recipes/pycrypto/__init__.py
+++ b/pythonforandroid/recipes/pycrypto/__init__.py
@@ -4,26 +4,26 @@ from pythonforandroid.toolchain import (
     info,
     shprint,
 )
-from os.path import join
 import sh
 
 
 class PyCryptoRecipe(CompiledComponentsPythonRecipe):
-    version = '2.6.1'
-    url = 'https://pypi.python.org/packages/source/p/pycrypto/pycrypto-{version}.tar.gz'
-    depends = ['openssl', 'python2']
+    version = '2.7a1'
+    url = 'https://github.com/dlitz/pycrypto/archive/v{version}.zip'
+    depends = ['openssl', ('python2', 'python3')]
     site_packages_name = 'Crypto'
-
+    call_hostpython_via_targetpython = False
     patches = ['add_length.patch']
 
-    def get_recipe_env(self, arch=None):
+    def get_recipe_env(self, arch=None, clang=True):
         env = super(PyCryptoRecipe, self).get_recipe_env(arch)
-        openssl_build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
-        env['CC'] = '%s -I%s' % (env['CC'], join(openssl_build_dir, 'include'))
+        openssl_recipe = Recipe.get_recipe('openssl', self.ctx)
+        env['CC'] = env['CC'] + openssl_recipe.include_flags(arch)
+
         env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
             self.ctx.get_libs_dir(arch.arch) +
-            '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
-            openssl_build_dir)
+            '-L{}'.format(self.ctx.libs_dir)) + openssl_recipe.link_flags(arch)
+
         env['EXTRA_CFLAGS'] = '--host linux-armv'
         env['ac_cv_func_malloc_0_nonnull'] = 'yes'
         return env

--- a/pythonforandroid/recipes/pycrypto/__init__.py
+++ b/pythonforandroid/recipes/pycrypto/__init__.py
@@ -20,9 +20,10 @@ class PyCryptoRecipe(CompiledComponentsPythonRecipe):
         openssl_recipe = Recipe.get_recipe('openssl', self.ctx)
         env['CC'] = env['CC'] + openssl_recipe.include_flags(arch)
 
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{}'.format(
-            self.ctx.get_libs_dir(arch.arch) +
-            '-L{}'.format(self.ctx.libs_dir)) + openssl_recipe.link_flags(arch)
+        env['LDFLAGS'] += ' -L{}'.format(self.ctx.get_libs_dir(arch.arch))
+        env['LDFLAGS'] += ' -L{}'.format(self.ctx.libs_dir)
+        env['LDFLAGS'] += openssl_recipe.link_dirs_flags(arch)
+        env['LIBS'] = env.get('LIBS', '') + openssl_recipe.link_libs_flags()
 
         env['EXTRA_CFLAGS'] = '--host linux-armv'
         env['ac_cv_func_malloc_0_nonnull'] = 'yes'


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Here I fix pycrypto to make it work with the core-update pull request, which also contains a new version of the openssl libs. I Also update pycrypto to latest version and grants compatibility for both versions of python.

Note: this has to be merged only when the core-update has been merged because it depends on the new python2 recipe and the openssl libs (1.1)