### PR TITLE
[CORE UPDATE - PART VI] Fix scrypt

### DIFF
--- a/pythonforandroid/recipes/scrypt/__init__.py
+++ b/pythonforandroid/recipes/scrypt/__init__.py
@@ -1,4 +1,3 @@
-import os
 from pythonforandroid.recipe import CythonRecipe
 
 
@@ -6,7 +5,7 @@ class ScryptRecipe(CythonRecipe):
 
     version = '0.8.6'
     url = 'https://bitbucket.org/mhallin/py-scrypt/get/v{version}.zip'
-    depends = [('python2', 'python3crystax'), 'setuptools', 'openssl']
+    depends = ['setuptools', 'openssl']
     call_hostpython_via_targetpython = False
     patches = ["remove_librt.patch"]
 
@@ -15,23 +14,12 @@ class ScryptRecipe(CythonRecipe):
         Adds openssl recipe to include and library path.
         """
         env = super(ScryptRecipe, self).get_recipe_env(arch, with_flags_in_cc)
-        openssl_build_dir = self.get_recipe(
-            'openssl', self.ctx).get_build_dir(arch.arch)
-        env['CFLAGS'] += ' -I{}'.format(os.path.join(openssl_build_dir, 'include'))
-        env['LDFLAGS'] += ' -L{}'.format(
-            self.ctx.get_libs_dir(arch.arch) +
-            '-L{}'.format(self.ctx.libs_dir)) + ' -L{}'.format(
-            openssl_build_dir)
-        # required additional library and path for Crystax
-        if self.ctx.ndk == 'crystax':
-            # only keeps major.minor (discards patch)
-            python_version = self.ctx.python_recipe.version[0:3]
-            ndk_dir_python = os.path.join(self.ctx.ndk_dir, 'sources/python/', python_version)
-            env['LDFLAGS'] += ' -L{}'.format(os.path.join(ndk_dir_python, 'libs', arch.arch))
-            env['LDFLAGS'] += ' -lpython{}m'.format(python_version)
-            # until `pythonforandroid/archs.py` gets merged upstream:
-            # https://github.com/kivy/python-for-android/pull/1250/files#diff-569e13021e33ced8b54385f55b49cbe6
-            env['CFLAGS'] += ' -I{}/include/python/'.format(ndk_dir_python)
+        openssl_recipe = self.get_recipe('openssl', self.ctx)
+        env['CFLAGS'] += openssl_recipe.include_flags(arch)
+        env['LDFLAGS'] += ' -L{}'.format(self.ctx.get_libs_dir(arch.arch))
+        env['LDFLAGS'] += ' -L{}'.format(self.ctx.libs_dir)
+        env['LDFLAGS'] += openssl_recipe.link_dirs_flags(arch)
+        env['LIBS'] = env.get('LIBS', '') + openssl_recipe.link_libs_flags()
         return env
 
 


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Here I fix scrypt recipe to make it work with the core-update pull request, which also contains a new version of the openssl libs. Also grants compatibility for both versions of python.

Note: this has to be merged only when the core-update has been merged because it depends on the new python2 recipe and the openssl libs (1.1)