### PR TITLE
[CORE UPDATE - PART VIII] Netifaces for both versions of python (updates the netifaces version)

### DIFF
--- a/pythonforandroid/recipes/netifaces/__init__.py
+++ b/pythonforandroid/recipes/netifaces/__init__.py
@@ -3,25 +3,17 @@ from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 class NetifacesRecipe(CompiledComponentsPythonRecipe):
 
-    version = '0.10.4'
+    version = '0.10.7'
 
-    url = 'https://pypi.python.org/packages/18/fa/dd13d4910aea339c0bb87d2b3838d8fd923c11869b1f6e741dbd0ff3bc00/netifaces-{version}.tar.gz'
+    url = 'https://files.pythonhosted.org/packages/81/39/4e9a026265ba944ddf1fea176dbb29e0fe50c43717ba4fcf3646d099fe38/netifaces-{version}.tar.gz'
 
-    depends = [('python2', 'python3crystax'), 'setuptools']
+    depends = ['setuptools']
+
+    patches = ['fix-build.patch']
 
     site_packages_name = 'netifaces'
 
     call_hostpython_via_targetpython = False
-
-    def get_recipe_env(self, arch):
-        env = super(NetifacesRecipe, self).get_recipe_env(arch)
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
-        env['CFLAGS'] += ' -I' + env['PYTHON_ROOT'] + '/include/python2.7'
-        # Set linker to use the correct gcc
-        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
-        env['LDFLAGS'] += ' -L' + env['PYTHON_ROOT'] + '/lib' + \
-                          ' -lpython2.7'
-        return env
 
 
 recipe = NetifacesRecipe()

--- a/pythonforandroid/recipes/netifaces/__init__.py
+++ b/pythonforandroid/recipes/netifaces/__init__.py
@@ -5,7 +5,7 @@ class NetifacesRecipe(CompiledComponentsPythonRecipe):
 
     version = '0.10.7'
 
-    url = 'https://files.pythonhosted.org/packages/81/39/4e9a026265ba944ddf1fea176dbb29e0fe50c43717ba4fcf3646d099fe38/netifaces-{version}.tar.gz'
+    url = 'https://files.pythonhosted.org/packages/source/n/netifaces/netifaces-{version}.tar.gz'
 
     depends = ['setuptools']
 

--- a/pythonforandroid/recipes/netifaces/fix-build.patch
+++ b/pythonforandroid/recipes/netifaces/fix-build.patch
@@ -1,0 +1,11 @@
+--- netifaces/setup.py.orig	2018-05-02 09:45:09.000000000 +0200
++++ netifaces/setup.py	2018-12-11 14:12:02.785808692 +0100
+@@ -55,7 +55,7 @@
+         self.check_requirements()
+         build_ext.build_extensions(self)
+ 
+-    def test_build(self, contents, link=True, execute=False, libraries=None,
++    def test_build(self, contents, link=False, execute=False, libraries=None,
+                    include_dirs=None, library_dirs=None):
+         name = os.path.join(self.build_temp, 'conftest-%s.c' % self.conftestidx)
+         self.conftestidx += 1


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Grants compatibility for both versions of python and cleans up from unneeded source code as well as update the netifaces version.

Note: this has to be merged only when the core-update has been merged because it has been tested with the new python core and depends on some recipes which aren't python3  compatible in the current master branch (setuptools)