### PR TITLE
[CORE UPDATE - PART IX] Pymunk for both versions of python and enhance flags

### DIFF
--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -13,9 +13,9 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
         env = super(PymunkRecipe, self).get_recipe_env(arch)
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
         env['LDFLAGS'] += " -shared -llog"
-        env['LDFLAGS'] += " -landroid"
         env['LDFLAGS'] += ' -L{}'.format(join(self.ctx.ndk_platform, 'usr', 'lib'))
         env['LDFLAGS'] += " --sysroot={}".format(self.ctx.ndk_platform)
+        env['LIBS'] = env.get('LIBS', '') + ' -landroid'
         return env
 
 

--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -1,3 +1,4 @@
+from os.path import join
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 
@@ -5,17 +6,16 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
     name = "pymunk"
     version = '5.2.0'
     url = 'https://pypi.python.org/packages/5e/bd/e67edcffdee3d0a1e3ebf0050bb9746a61d616f5502ceedddf0f7fd0a896/pymunk-5.2.0.zip'
-    depends = [('python2', 'python3crystax'), 'cffi', 'setuptools']
+    depends = ['cffi', 'setuptools']
     call_hostpython_via_targetpython = False
 
     def get_recipe_env(self, arch):
         env = super(PymunkRecipe, self).get_recipe_env(arch)
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
-        arch_noeabi = arch.arch.replace('eabi', '')
         env['LDFLAGS'] += " -shared -llog"
-        env['LDFLAGS'] += " -landroid -lpython2.7"
-        env['LDFLAGS'] += " --sysroot={ctx.ndk_dir}/platforms/android-{ctx.android_api}/arch-{arch_noeabi}".format(
-            ctx=self.ctx, arch_noeabi=arch_noeabi)
+        env['LDFLAGS'] += " -landroid"
+        env['LDFLAGS'] += ' -L{}'.format(join(self.ctx.ndk_platform, 'usr', 'lib'))
+        env['LDFLAGS'] += " --sysroot={}".format(self.ctx.ndk_platform)
         return env
 
 


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Grants compatibility for both versions of python and enhance flags

Note: this has to be merged only when the core-update has been merged because it has been tested with the new python core and depends on some recipes which aren't python3  compatible in the current master branch (setuptools)