### PR TITLE
[WIP][CORE UPDATE - PART XII] Pycryptodome for both versions of python

### DIFF
--- a/pythonforandroid/recipes/pycryptodome/__init__.py
+++ b/pythonforandroid/recipes/pycryptodome/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class PycryptodomeRecipe(PythonRecipe):
     version = '3.4.6'
     url = 'https://github.com/Legrandin/pycryptodome/archive/v{version}.tar.gz'
-    depends = [('python2', 'python3crystax'), 'setuptools', 'cffi']
+    depends = ['setuptools', 'cffi']
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super(PycryptodomeRecipe, self).get_recipe_env(arch, with_flags_in_cc)


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Note: this has to be merged only when the core-update has been merged because it has been tested with the new python core and depends on some recipes which aren't python3  compatible in the current master branch (setuptools and cffi)