### PR TITLE
[CORE UPDATE - PART XIII] Pysha3 for both versions of python

### DIFF
--- a/pythonforandroid/recipes/pysha3/__init__.py
+++ b/pythonforandroid/recipes/pysha3/__init__.py
@@ -6,14 +6,16 @@ from pythonforandroid.recipe import PythonRecipe
 class Pysha3Recipe(PythonRecipe):
     version = '1.0.2'
     url = 'https://github.com/tiran/pysha3/archive/{version}.tar.gz'
-    depends = [('python2', 'python3crystax'), 'setuptools']
+    depends = ['setuptools']
+    call_hostpython_via_targetpython = False
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super(Pysha3Recipe, self).get_recipe_env(arch, with_flags_in_cc)
-        # sets linker to use the correct gcc (cross compiler)
-        env['LDSHARED'] = env['CC'] + ' -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions'
         # CFLAGS may only be used to specify C compiler flags, for macro definitions use CPPFLAGS
-        env['CPPFLAGS'] = env['CFLAGS'] + ' -I{}/sources/python/3.5/include/python/'.format(self.ctx.ndk_dir)
+        env['CPPFLAGS'] = env['CFLAGS']
+        if self.ctx.ndk == 'crystax':
+            env['CPPFLAGS'] += ' -I{}/sources/python/{}/include/python/'.format(
+                self.ctx.ndk_dir, self.ctx.python_recipe.version[0:3])
         env['CFLAGS'] = ''
         # LDFLAGS may only be used to specify linker flags, for libraries use LIBS
         env['LDFLAGS'] = env['LDFLAGS'].replace('-lm', '').replace('-lcrystax', '')


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Grants compatibility for both versions of python, remove unneeded flags and fix the hardcoded ones.

Note: this has to be merged only when the core-update has been merged because it has been tested with the new python core and depends on some recipes which aren't python3  compatible in the current master branch (setuptools)