### PR TITLE
[WIP][CORE UPDATE - PART XIV] Libtorrent+boost for both versions of python and updated versions

### DIFF
--- a/pythonforandroid/recipes/boost/__init__.py
+++ b/pythonforandroid/recipes/boost/__init__.py
@@ -1,5 +1,6 @@
 from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
 from os.path import join, exists
+from os import environ
 import sh
 
 """
@@ -9,11 +10,36 @@ including python bindings
 
 
 class BoostRecipe(Recipe):
-    version = '1.60.0'
-    # Don't forget to change the URL when changing the version
-    url = 'http://downloads.sourceforge.net/project/boost/boost/{version}/boost_1_60_0.tar.bz2'
-    depends = ['python2']
-    patches = ['disable-so-version.patch', 'use-android-libs.patch']
+    # Todo: make recipe compatible with all p4a architectures
+    '''
+    .. note:: This recipe can be built only against API 21+ and arch armeabi-v7a
+
+    .. versionchanged:: 0.6.0
+         Rewrote recipe to support clang's build. The following changes has
+         been made:
+
+            - Bumped version number to 1.68.0
+            - Better version handling for url
+            - Added python 3 compatibility
+            - Default compiler for ndk's toolchain set to clang
+            - Python version will be detected via user-config.jam
+            - Changed stl's lib from ``gnustl_shared`` to ``c++_shared``
+    '''
+    version = '1.68.0'
+    url = 'http://downloads.sourceforge.net/project/boost/' \
+          'boost/{version}/boost_{version_underscore}.tar.bz2'
+    depends = [('python2', 'python3')]
+    patches = ['disable-so-version.patch',
+               'use-android-libs.patch',
+               'fix-android-issues.patch']
+
+    @property
+    def versioned_url(self):
+        if self.url is None:
+            return None
+        return self.url.format(
+            version=self.version,
+            version_underscore=self.version.replace('.', '_'))
 
     def should_build(self, arch):
         return not exists(join(self.get_build_dir(arch.arch), 'b2'))
@@ -28,9 +54,11 @@ class BoostRecipe(Recipe):
                 shprint(bash, join(self.ctx.ndk_dir, 'build/tools/make-standalone-toolchain.sh'),
                         '--arch=' + env['ARCH'],
                         '--platform=android-' + str(self.ctx.android_api),
-                        '--toolchain=' + env['CROSSHOST'] + '-' + env['TOOLCHAIN_VERSION'],
+                        '--toolchain=' + env['CROSSHOST'] + '-' + self.ctx.toolchain_version + ':-llvm',
+                        '--use-llvm',
+                        '--stl=libc++',
                         '--install-dir=' + env['CROSSHOME']
-                )
+                        )
             # Set custom configuration
             shutil.copyfile(join(self.get_recipe_dir(), 'user-config.jam'),
                             join(env['BOOST_BUILD_PATH'], 'user-config.jam'))
@@ -38,31 +66,38 @@ class BoostRecipe(Recipe):
     def build_arch(self, arch):
         super(BoostRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
+        env['PYTHON_HOST'] = self.ctx.hostpython
         with current_directory(self.get_build_dir(arch.arch)):
             # Compile Boost.Build engine with this custom toolchain
             bash = sh.Command('bash')
-            shprint(bash, 'bootstrap.sh',
-                    '--with-python=' + join(env['PYTHON_ROOT'], 'bin/python.host'),
-                    '--with-python-version=2.7',
-                    '--with-python-root=' + env['PYTHON_ROOT']
-            )  # Do not pass env
+            shprint(bash, 'bootstrap.sh')  # Do not pass env
         # Install app stl
-        shutil.copyfile(join(env['CROSSHOME'], env['CROSSHOST'], 'lib/libgnustl_shared.so'),
-                        join(self.ctx.get_libs_dir(arch.arch), 'libgnustl_shared.so'))
+        shutil.copyfile(
+            join(self.ctx.ndk_dir, 'sources/cxx-stl/llvm-libc++/libs/'
+                                   'armeabi-v7a/libc++_shared.so'),
+            join(self.ctx.get_libs_dir(arch.arch), 'libc++_shared.so'))
 
     def select_build_arch(self, arch):
         return arch.arch.replace('eabi-v7a', '').replace('eabi', '')
 
     def get_recipe_env(self, arch):
-        env = super(BoostRecipe, self).get_recipe_env(arch)
+        # We don't use the normal env because we
+        # are building with a standalone toolchain
+        env = environ.copy()
+
         env['BOOST_BUILD_PATH'] = self.get_build_dir(arch.arch)  # find user-config.jam
         env['BOOST_ROOT'] = env['BOOST_BUILD_PATH']  # find boost source
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+
+        env['PYTHON_ROOT'] = self.ctx.python_recipe.link_root(arch.arch)
+        env['PYTHON_INCLUDE'] = self.ctx.python_recipe.include_root(arch.arch)
+        env['PYTHON_MAJOR_MINOR'] = self.ctx.python_recipe.version[:3]
+        env['PYTHON_LINK_VERSION'] = self.ctx.python_recipe.major_minor_version_string
+        if 'python3' in self.ctx.python_recipe.name:
+            env['PYTHON_LINK_VERSION'] += 'm'
+
         env['ARCH'] = self.select_build_arch(arch)
-        env['ANDROIDAPI'] = str(self.ctx.android_api)
         env['CROSSHOST'] = env['ARCH'] + '-linux-androideabi'
         env['CROSSHOME'] = join(env['BOOST_ROOT'], 'standalone-' + env['ARCH'] + '-toolchain')
-        env['TOOLCHAIN_PREFIX'] = join(env['CROSSHOME'], 'bin', env['CROSSHOST'])
         return env
 
 

--- a/pythonforandroid/recipes/boost/fix-android-issues.patch
+++ b/pythonforandroid/recipes/boost/fix-android-issues.patch
@@ -1,0 +1,68 @@
+diff -u -r boost_1_68_0.orig/boost/config/user.hpp boost_1_68_0/boost/config/user.hpp
+--- boost_1_68_0.orig/boost/config/user.hpp	2018-08-01 22:50:46.000000000 +0200
++++ boost_1_68_0/boost/config/user.hpp	2018-08-27 15:43:38.000000000 +0200
+@@ -13,6 +13,12 @@
+ //  configuration policy:
+ //
+ 
++// Android defines
++// There is problem with std::atomic on android (and some other platforms).
++// See this link for more info:
++// https://code.google.com/p/android/issues/detail?id=42735#makechanges
++#define BOOST_ASIO_DISABLE_STD_ATOMIC 1
++
+ // define this to locate a compiler config file:
+ // #define BOOST_COMPILER_CONFIG <myheader>
+ 
+diff -u -r boost_1_68_0.orig/boost/asio/detail/config.hpp boost_1_68_0/boost/asio/detail/config.hpp
+--- boost_1_68_0.orig/boost/asio/detail/config.hpp  2018-08-01 22:50:46.000000000 +0200
++++ boost_1_68_0/boost/asio/detail/config.hpp   2018-09-19 12:39:56.000000000 +0200
+@@ -804,7 +804,11 @@
+ #  if defined(__clang__)
+ #   if (__cplusplus >= 201402)
+ #    if __has_include(<experimental/string_view>)
+-#     define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     if __clang_major__ >= 7
++#      undef BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW
++#     else
++#      define BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
++#     endif // __clang_major__ >= 7
+ #    endif // __has_include(<experimental/string_view>)
+ #   endif // (__cplusplus >= 201402)
+ #  endif // defined(__clang__)
+diff -u -r boost_1_68_0.orig/boost/system/error_code.hpp boost_1_68_0/boost/system/error_code.hpp
+--- boost_1_68_0.orig/boost/system/error_code.hpp	2018-08-01 22:50:53.000000000 +0200
++++ boost_1_68_0/boost/system/error_code.hpp	2018-08-27 15:44:29.000000000 +0200
+@@ -17,6 +17,7 @@
+ #include <boost/assert.hpp>
+ #include <boost/noncopyable.hpp>
+ #include <boost/utility/enable_if.hpp>
++#include <stdio.h>
+ #include <ostream>
+ #include <string>
+ #include <stdexcept>
+diff -u -r boost_1_68_0.orig/libs/filesystem/src/operations.cpp boost_1_68_0/libs/filesystem/src/operations.cpp
+--- boost_1_68_0.orig/libs/filesystem/src/operations.cpp	2018-08-01 22:50:47.000000000 +0200
++++ boost_1_68_0/libs/filesystem/src/operations.cpp	2018-08-27 15:47:15.000000000 +0200
+@@ -232,6 +232,21 @@
+ 
+ # if defined(BOOST_POSIX_API)
+ 
++#  if defined(__ANDROID__)
++#  define truncate libboost_truncate_wrapper
++// truncate() is present in Android libc only starting from ABI 21, so here's a simple wrapper
++static int libboost_truncate_wrapper(const char *path, off_t length)
++{
++  int fd = open(path, O_WRONLY);
++  if (fd == -1) {
++    return -1;
++  }
++  int status = ftruncate(fd, length);
++  close(fd);
++  return status;
++}
++#  endif
++
+ typedef int err_t;
+ 
+ //  POSIX uses a 0 return to indicate success

--- a/pythonforandroid/recipes/boost/user-config.jam
+++ b/pythonforandroid/recipes/boost/user-config.jam
@@ -1,28 +1,61 @@
 import os ;
 
-local ANDROIDNDK = [ os.environ ANDROIDNDK ] ;
-local ANDROIDAPI = [ os.environ ANDROIDAPI ] ;
-local TOOLCHAIN_VERSION = [ os.environ TOOLCHAIN_VERSION ] ;
-local TOOLCHAIN_PREFIX = [ os.environ TOOLCHAIN_PREFIX ] ;
 local ARCH = [ os.environ ARCH ] ;
+local CROSSHOME = [ os.environ CROSSHOME ] ;
+local PYTHON_HOST = [ os.environ PYTHON_HOST ] ;
 local PYTHON_ROOT = [ os.environ PYTHON_ROOT ] ;
+local PYTHON_INCLUDE = [ os.environ PYTHON_INCLUDE ] ;
+local PYTHON_LINK_VERSION = [ os.environ PYTHON_LINK_VERSION ] ;
+local PYTHON_MAJOR_MINOR = [ os.environ PYTHON_MAJOR_MINOR ] ;
 
-using gcc : $(ARCH) : $(TOOLCHAIN_PREFIX)-g++ :
+using clang : $(ARCH) : $(CROSSHOME)/bin/arm-linux-androideabi-clang++ :
+<archiver>$(CROSSHOME)/bin/arm-linux-androideabi-ar
+<root>$(CROSSHOME)/sysroot
 <architecture>$(ARCH)
-<archiver>$(TOOLCHAIN_PREFIX)-ar
-<compileflags>-DBOOST_SP_USE_PTHREADS
-<compileflags>-DBOOST_AC_USE_PTHREADS
-<cxxflags>-DBOOST_SP_USE_PTHREADS
-<cxxflags>-DBOOST_AC_USE_PTHREADS
-<cxxflags>-frtti
-<cxxflags>-fexceptions
-<compileflags>-I$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)/usr/include
-<compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/include
-<compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)/include
-<compileflags>-I$(PYTHON_ROOT)/include/python2.7
-<linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)
-<linkflags>-L$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)
-<linkflags>-L$(PYTHON_ROOT)/lib
-<linkflags>-lgnustl_shared
-<linkflags>-lpython2.7
+<compileflags>-fexceptions
+<compileflags>-frtti
+<compileflags>-fpic
+<compileflags>-ffunction-sections
+<compileflags>-funwind-tables
+<compileflags>-march=armv7-a
+<compileflags>-msoft-float
+<compileflags>-mfpu=neon
+<compileflags>-mthumb
+<linkflags>-march=armv7-a
+<linkflags>-Wl,--fix-cortex-a8
+<compileflags>-Os
+<compileflags>-fomit-frame-pointer
+<compileflag>-fno-strict-aliasing
+<compileflags>-DANDROID
+<compileflags>-D__ANDROID__
+<compileflags>-DANDROID_TOOLCHAIN=clang
+<compileflags>-DANDROID_ABI=armv7-a
+<compileflags>-DANDROID_STL=c++_shared
+<compileflags>-DBOOST_ALL_NO_LIB
+#<compileflags>-DNDEBUG
+<compileflags>-O2
+<compileflags>-g
+<compileflags>-fvisibility=hidden
+<compileflags>-fvisibility-inlines-hidden
+<compileflags>-fdata-sections
+<cxxflags>-D__arm__
+<cxxflags>-D_REENTRANT
+<cxxflags>-D_GLIBCXX__PTHREADS
+<compileflags>-Wno-long-long
+<compileflags>-Wno-missing-field-initializers
+<compileflags>-Wno-unused-variable
+<linkflags>-Wl,-z,relro
+<linkflags>-Wl,-z,now
+<linkflags>-lc++_shared
+<linkflags>-L$(PYTHON_ROOT)
+<linkflags>-lpython$(PYTHON_LINK_VERSION)
+<linkflags>-Wl,-O1
+<linkflags>-Wl,-Bsymbolic-functions
+;
+
+using python : $(PYTHON_MAJOR_MINOR)
+    : $(PYTHON_host)
+    : $(PYTHON_ROOT) $(PYTHON_INCLUDE)
+    : $(PYTHON_ROOT)/libpython$(PYTHON_LINK_VERSION).so
+    : #<define>BOOST_ALL_DYN_LINK
 ;

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -1,5 +1,7 @@
 from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
-from os.path import join
+from multiprocessing import cpu_count
+from os.path import join, basename
+from os import listdir, walk
 import sh
 
 # This recipe builds libtorrent with Python bindings
@@ -7,71 +9,128 @@ import sh
 # which is all provided by the boost recipe
 
 
+def get_lib_from(search_directory, lib_extension='.so'):
+    '''Scan directories recursively until find any file with the given
+    extension. The default extension to search is ``.so``.'''
+    for root, dirs, files in walk(search_directory):
+        for file in files:
+            if file.endswith(lib_extension):
+                print('get_lib_from: {}\n\t- {}'.format(
+                    search_directory, join(root, file)))
+                return join(root, file)
+    return None
+
+
 class LibtorrentRecipe(Recipe):
-    version = '1.0.9'
-    # Don't forget to change the URL when changing the version
-    url = 'https://github.com/arvidn/libtorrent/archive/libtorrent-1_0_9.tar.gz'
+    # Todo: make recipe compatible with all p4a architectures
+    '''
+    .. note:: This recipe can be built only against API 21+ and arch armeabi-v7a
+
+    .. versionchanged:: 0.6.0
+         Rewrote recipe to support clang's build and boost 1.68. The following
+         changes has been made:
+
+            - Bumped version number to 1.2.0
+            - added python 3 compatibility
+            - new system to detect/copy generated libraries
+    '''
+    version = '1_2_0'
+    url = 'https://github.com/arvidn/libtorrent/archive/libtorrent_{version}.tar.gz'
+
     depends = ['boost']
     opt_depends = ['openssl']
-    patches = ['disable-so-version.patch', 'use-soname-python.patch', 'setup-lib-name.patch']
+    patches = ['disable-so-version.patch',
+               'use-soname-python.patch',
+               'setup-lib-name.patch']
+
+    # libtorrent.so is not included because is not a system library
+    generated_libraries = [
+        'boost_system', 'boost_python{py_version}', 'torrent_rasterbar']
 
     def should_build(self, arch):
-        return not (
-            self.has_libs(arch, 'libboost_python.so', 'libboost_system.so', 'libtorrent_rasterbar.so')
-            and self.ctx.has_package('libtorrent', arch.arch))
+        python_version = self.ctx.python_recipe.version[:3].replace('.', '')
+        libs = ['lib' + lib_name.format(py_version=python_version) +
+                '.so' for lib_name in self.generated_libraries]
+        return not (self.has_libs(arch, *libs) and
+                    self.ctx.has_package('libtorrent', arch.arch))
 
     def prebuild_arch(self, arch):
         super(LibtorrentRecipe, self).prebuild_arch(arch)
         if 'openssl' in recipe.ctx.recipe_build_order:
             # Patch boost user-config.jam to use openssl
-            self.get_recipe('boost', self.ctx).apply_patch(join(self.get_recipe_dir(), 'user-config-openssl.patch'), arch.arch)
+            self.get_recipe('boost', self.ctx).apply_patch(
+                join(self.get_recipe_dir(), 'user-config-openssl.patch'), arch.arch)
 
     def build_arch(self, arch):
         super(LibtorrentRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
-        with current_directory(join(self.get_build_dir(arch.arch), 'bindings/python')):
-            # Compile libtorrent with boost libraries and python bindings
+        env['PYTHON_HOST'] = self.ctx.hostpython
+
+        # Define build variables
+        build_dir = self.get_build_dir(arch.arch)
+        ctx_libs_dir = self.ctx.get_libs_dir(arch.arch)
+        encryption = 'openssl' if 'openssl' in recipe.ctx.recipe_build_order else 'built-in'
+        build_args = [
+            '-q',
+            # '-a',  # force build, useful to debug the build
+            '-j' + str(cpu_count()),
+            '--debug-configuration',  # so we know if our python is detected
+            # '--deprecated-functions=off',
+            'toolset=clang-arm',
+            'abi=aapcs',
+            'binary-format=elf',
+            'cxxflags=-std=c++11',
+            'target-os=android',
+            'threading=multi',
+            'link=shared',
+            'boost-link=shared',
+            'libtorrent-link=shared',
+            'runtime-link=shared',
+            'encryption={}'.format('on' if encryption == 'openssl' else 'off'),
+            'crypto=' + encryption
+        ]
+        crypto_folder = 'encryption-off'
+        if encryption == 'openssl':
+            crypto_folder = 'crypto-openssl'
+            build_args.extend(['openssl-lib=' + env['OPENSSL_BUILD_PATH'],
+                               'openssl-include=' + env['OPENSSL_INCLUDE']
+                               ])
+        build_args.append('release')
+
+        # Compile libtorrent with boost libraries and python bindings
+        with current_directory(join(build_dir, 'bindings/python')):
             b2 = sh.Command(join(env['BOOST_ROOT'], 'b2'))
-            shprint(b2,
-                    '-q',
-                    '-j5',
-                    'toolset=gcc-' + env['ARCH'],
-                    'target-os=android',
-                    'threading=multi',
-                    'link=shared',
-                    'boost-link=shared',
-                    'boost=source',
-                    'encryption=openssl' if 'openssl' in recipe.ctx.recipe_build_order else '',
-                    '--prefix=' + env['CROSSHOME'],
-                    'release', _env=env)
-        # Common build directories
-        build_subdirs = 'gcc-arm/release/boost-link-shared/boost-source'
-        if 'openssl' in recipe.ctx.recipe_build_order:
-            build_subdirs += '/encryption-openssl'
-        build_subdirs += '/libtorrent-python-pic-on/target-os-android/threading-multi/visibility-hidden'
-        # Copy the shared libraries into the libs folder
-        shutil.copyfile(join(env['BOOST_BUILD_PATH'], 'bin.v2/libs/python/build', build_subdirs, 'libboost_python.so'),
-                        join(self.ctx.get_libs_dir(arch.arch), 'libboost_python.so'))
-        shutil.copyfile(join(env['BOOST_BUILD_PATH'], 'bin.v2/libs/system/build', build_subdirs, 'libboost_system.so'),
-                        join(self.ctx.get_libs_dir(arch.arch), 'libboost_system.so'))
-        if 'openssl' in recipe.ctx.recipe_build_order:
-            shutil.copyfile(
-                join(env['BOOST_BUILD_PATH'], 'bin.v2/libs/date_time/build', build_subdirs, 'libboost_date_time.so'),
-                join(self.ctx.get_libs_dir(arch.arch), 'libboost_date_time.so'))
-        shutil.copyfile(
-            join(self.get_build_dir(arch.arch), 'bin', build_subdirs, 'libtorrent_rasterbar.so'),
-            join(self.ctx.get_libs_dir(arch.arch), 'libtorrent_rasterbar.so'))
-        shutil.copyfile(
-            join(self.get_build_dir(arch.arch), 'bindings/python/bin', build_subdirs, 'libtorrent.so'),
-            join(self.ctx.get_site_packages_dir(arch.arch), 'libtorrent.so'))
+            shprint(b2, *build_args, _env=env)
+
+        # Copy only the boost shared libraries into the libs folder. Because
+        # boost build two boost_python libraries, we force to search the lib
+        # into the corresponding build path.
+        b2_build_dir = 'build/clang-linux-arm/release/{encryption}/' \
+                       'lt-visibility-hidden/'.format(encryption=crypto_folder)
+        boost_libs_dir = join(env['BOOST_BUILD_PATH'], 'bin.v2/libs')
+        for boost_lib in listdir(boost_libs_dir):
+            lib_path = get_lib_from(join(boost_libs_dir, boost_lib, b2_build_dir))
+            if lib_path:
+                lib_name = basename(lib_path)
+                shutil.copyfile(lib_path, join(ctx_libs_dir, lib_name))
+
+        # Copy libtorrent shared libraries into the right places
+        system_libtorrent = get_lib_from(join(build_dir, 'bin'))
+        if system_libtorrent:
+            shutil.copyfile(system_libtorrent,
+                            join(ctx_libs_dir, 'libtorrent_rasterbar.so'))
+
+        python_libtorrent = get_lib_from(join(build_dir, 'bindings/python/bin'))
+        shutil.copyfile(python_libtorrent,
+                        join(self.ctx.get_site_packages_dir(arch.arch), 'libtorrent.so'))
 
     def get_recipe_env(self, arch):
-        env = super(LibtorrentRecipe, self).get_recipe_env(arch)
-        # Copy environment from boost recipe
-        env.update(self.get_recipe('boost', self.ctx).get_recipe_env(arch))
+        # Use environment from boost recipe, cause we use b2 tool from boost
+        env = self.get_recipe('boost', self.ctx).get_recipe_env(arch)
         if 'openssl' in recipe.ctx.recipe_build_order:
             r = self.get_recipe('openssl', self.ctx)
             env['OPENSSL_BUILD_PATH'] = r.get_build_dir(arch.arch)
+            env['OPENSSL_INCLUDE'] = join(r.get_build_dir(arch.arch), 'include')
             env['OPENSSL_VERSION'] = r.version
         return env
 

--- a/pythonforandroid/recipes/libtorrent/setup-lib-name.patch
+++ b/pythonforandroid/recipes/libtorrent/setup-lib-name.patch
@@ -1,20 +1,20 @@
---- libtorrent/bindings/python/setup.py	2016-02-28 08:28:49.000000000 +0100
-+++ patch/bindings/python/setup.py	2016-07-12 12:03:05.256455888 +0200
-@@ -97,7 +97,7 @@
- 	source_list = os.listdir(os.path.join(os.path.dirname(__file__), "src"))
- 	source_list = [os.path.join("src", s) for s in source_list if s.endswith(".cpp")]
- 
--	ext = [Extension('libtorrent',
-+	ext = [Extension('libtorrent_rasterbar',
- 		sources = source_list,
- 		language='c++',
- 		include_dirs = parse_cmd(extra_cmd, '-I'),
-@@ -107,7 +107,7 @@
- 			+ target_specific(),
- 		libraries = ['torrent-rasterbar'] + parse_cmd(extra_cmd, '-l'))]
- 
--setup(name = 'python-libtorrent',
-+setup(name = 'libtorrent',
- 	version = '1.0.9',
- 	author = 'Arvid Norberg',
- 	author_email = 'arvid@libtorrent.org',
+--- libtorrent/bindings/python/setup.py.orig	2018-11-26 22:21:48.772142135 +0100
++++ libtorrent/bindings/python/setup.py	2018-11-26 22:23:23.092141235 +0100
+@@ -167,7 +167,7 @@
+         extra_compile = flags.parse(extra_cmd)
+
+         ext = [Extension(
+-            'libtorrent',
++            'libtorrent_rasterbar',
+             sources=sorted(source_list),
+             language='c++',
+             include_dirs=flags.include_dirs,
+@@ -178,7 +178,7 @@
+         ]
+
+ setup(
+-    name='python-libtorrent',
++    name='libtorrent',
+     version='1.2.0',
+     author='Arvid Norberg',
+     author_email='arvid@libtorrent.org',

--- a/pythonforandroid/recipes/libtorrent/use-soname-python.patch
+++ b/pythonforandroid/recipes/libtorrent/use-soname-python.patch
@@ -1,11 +1,11 @@
---- libtorrent/bindings/python/Jamfile	2016-01-17 23:52:45.000000000 +0100
-+++ libtorrent-patch/bindings/python/Jamfile	2016-02-09 17:11:44.261578000 +0100
-@@ -35,7 +35,7 @@
- 
-         if ( <toolset>gcc in $(properties) )
-         {
--           result += <linkflags>-Wl,-Bsymbolic ;
-+           result += <linkflags>-Wl,-soname=libtorrent.so,-Bsymbolic ;
-         }
-     }
+--- libtorrent/bindings/python/Jamfile.orig	2018-12-07 16:46:50.851838981 +0100
++++ libtorrent/bindings/python/Jamfile	2018-12-07 16:49:09.099837663 +0100
+@@ -113,7 +113,7 @@
+
+ 		if ( <toolset>gcc in $(properties) )
+ 		{
+-			 result += <linkflags>-Wl,-Bsymbolic ;
++			 result += <linkflags>-Wl,-soname=libtorrent.so,-Bsymbolic ;
+ 		}
+ 	}
  

--- a/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
+++ b/pythonforandroid/recipes/libtorrent/user-config-openssl.patch
@@ -1,25 +1,21 @@
---- boost/user-config.jam	2016-03-02 14:31:41.280414820 +0100
-+++ boost-patch/user-config.jam	2016-03-02 14:32:08.904384741 +0100
-@@ -6,6 +6,7 @@
- local TOOLCHAIN_PREFIX = [ os.environ TOOLCHAIN_PREFIX ] ;
- local ARCH = [ os.environ ARCH ] ;
- local PYTHON_ROOT = [ os.environ PYTHON_ROOT ] ;
+--- boost/user-config.jam.orig	2018-12-07 14:16:45.911924859 +0100
++++ boost/user-config.jam	2018-12-07 14:20:16.243922853 +0100
+@@ -9,6 +9,8 @@
+ local PYTHON_INCLUDE = [ os.environ PYTHON_INCLUDE ] ;
+ local PYTHON_LINK_VERSION = [ os.environ PYTHON_LINK_VERSION ] ;
+ local PYTHON_MAJOR_MINOR = [ os.environ PYTHON_MAJOR_MINOR ] ;
 +local OPENSSL_BUILD_PATH = [ os.environ OPENSSL_BUILD_PATH ] ;
++local OPENSSL_VERSION = [ os.environ OPENSSL_VERSION ] ;
  
- using gcc : $(ARCH) : $(TOOLCHAIN_PREFIX)-g++ :
- <architecture>$(ARCH)
-@@ -20,9 +21,14 @@
- <compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/include
- <compileflags>-I$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)/include
- <compileflags>-I$(PYTHON_ROOT)/include/python2.7
-+<compileflags>-I$(OPENSSL_BUILD_PATH)/include
-+<compileflags>-I$(OPENSSL_BUILD_PATH)/include/openssl
- <linkflags>--sysroot=$(ANDROIDNDK)/platforms/android-$(ANDROIDAPI)/arch-$(ARCH)
- <linkflags>-L$(ANDROIDNDK)/sources/cxx-stl/gnu-libstdc++/$(TOOLCHAIN_VERSION)/libs/$(ARCH)
- <linkflags>-L$(PYTHON_ROOT)/lib
+ #using clang : $(ARCH) : $(ANDROID_BINARIES_PATH)/clang++ :
+ #<archiver>$(ANDROID_BINARIES_PATH)/llvm-ar
+@@ -56,6 +58,9 @@
+ <linkflags>-Wl,-z,relro
+ <linkflags>-Wl,-z,now
+ <linkflags>-lc++_shared
 +<linkflags>-L$(OPENSSL_BUILD_PATH)
- <linkflags>-lgnustl_shared
- <linkflags>-lpython2.7
 +<linkflags>-lcrypto$(OPENSSL_VERSION)
 +<linkflags>-lssl$(OPENSSL_VERSION)
- ;
+ <linkflags>-L$(PYTHON_ROOT)
+ <linkflags>-lpython$(PYTHON_LINK_VERSION)
+ <linkflags>-Wl,-O1


### PR DESCRIPTION
This is one more part for the pr #1537 (discussed previously in #1460 and #1534)

Grants compatibility for both versions of python, maintaining the same build method (android's ndk standalone toolchain and b2 tool) but now we will use clang as the compiler, plus starts the migration of the stl lib from gnustl_shared to c++_shared (the only one stl lib starting from ndk18)

Note: this has to be merged only when the core-update has been merged because it has been tested with the new python core and depends on the new openssl lib version 1.1 introduced in  #1537