### PR TITLE
Fix linkage problems with python's versioned library (reintroduce `INSTSONAME`)

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -231,7 +231,12 @@ class GuestPythonRecipe(TargetPythonRecipe):
                     _env=env)
 
             if not exists('python'):
-                shprint(sh.make, 'all', _env=env)
+                py_version = self.major_minor_version_string
+                if self.major_minor_version_string[0] == '3':
+                    py_version += 'm'
+                shprint(sh.make, 'all',
+                        'INSTSONAME=libpython{version}.so'.format(
+                            version=py_version), _env=env)
 
             # TODO: Look into passing the path to pyconfig.h in a
             # better way, although this is probably acceptable
@@ -291,9 +296,8 @@ class GuestPythonRecipe(TargetPythonRecipe):
         python_lib_name = 'libpython' + self.major_minor_version_string
         if self.major_minor_version_string[0] == '3':
             python_lib_name += 'm'
-        for lib in [python_lib_name + '.so', python_lib_name + '.so.1.0']:
-            shprint(sh.cp, join(python_build_dir, lib),
-                    'libs/{}'.format(arch.arch))
+        shprint(sh.cp, join(python_build_dir, python_lib_name + '.so'),
+                'libs/{}'.format(arch.arch))
 
         info('Renaming .so files to reflect cross-compile')
         self.reduce_object_file_names(join(dirn, 'site-packages'))


### PR DESCRIPTION
We fix this issue by re-introducing `INSTSONAME`. This variable has been used in all our python recipes, because allow us to remove the version of the compiled python library which is mandatory, at the time of writing, because android does not support versioned libraries (the Java method called to load the libraries only supports a .so suffix).

A little history, because I didn't find any official documentation for this variable, and **it's quite important for us**:

  - This variable it's not hacked, it's official and was introduced a long time ago, forms part of the python's shared library building process (python/cpython@1142de3)
  - @tito introduced this variable almost at the beginning of the p4a project in (bdefea1)
  - @inclement also make use of it when he reworked the python2 recipe (4c8b5bc)
  - this variable still exists in the current python2 recipe and we make use of it precisely to solve the mentioned android's libraries version problem
  - Somehow, during the process of making the new python3 recipe, we loose this variable and then, we begin to have linkage problems at runtime with our python library as described in issue #1501

Note: ¡¡¡Special thanks to @JonasT!!!...to force me to search this information ;)

References: python/cpython@1142de3, bdefea1 and 4c8b5bc
Resolves: #1501

**If there is some planning to merge #1537 soon, maybe it would be better not to merge this, to avoid fixing merge conflicts in there.I think that it would be less problematic for all of us to  fix the merge conflicts in here.**