### PR TITLE
Fix outdated hardcoded python recipe references in lxml, reportlab & Pillow recipe

### DIFF
--- a/pythonforandroid/recipes/Pillow/__init__.py
+++ b/pythonforandroid/recipes/Pillow/__init__.py
@@ -10,7 +10,6 @@ class PillowRecipe(CompiledComponentsPythonRecipe):
     url = 'https://github.com/python-pillow/Pillow/archive/{version}.tar.gz'
     site_packages_name = 'Pillow'
     depends = [
-        ('python2', 'python3crystax'),
         'png',
         'jpeg',
         'freetype',

--- a/pythonforandroid/recipes/lxml/__init__.py
+++ b/pythonforandroid/recipes/lxml/__init__.py
@@ -7,7 +7,7 @@ from os import listdir
 class LXMLRecipe(CompiledComponentsPythonRecipe):
     version = "3.6.0"
     url = "https://pypi.python.org/packages/source/l/lxml/lxml-{version}.tar.gz"
-    depends = [("python2", "python3crystax"), "libxml2", "libxslt"]
+    depends = ["libxml2", "libxslt"]
     name = "lxml"
 
     call_hostpython_via_targetpython = False  # Due to setuptools

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -8,7 +8,7 @@ from pythonforandroid.logger import (info, shprint)
 class ReportLabRecipe(CompiledComponentsPythonRecipe):
     version = 'c088826211ca'
     url = 'https://bitbucket.org/rptlab/reportlab/get/{version}.tar.gz'
-    depends = [('python2', 'python3crystax'), 'freetype']
+    depends = ['freetype']
 
     def prebuild_arch(self, arch):
         if not self.is_patched(arch):


### PR DESCRIPTION
Fix outdated hardcoded python recipe references in lxml, reportlab & Pillow recipe which prevent building with the new python3 recipe