### PR TITLE
Fix APP_PLATFORM not properly passed in NDKRecipe

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -668,7 +668,13 @@ class NDKRecipe(Recipe):
 
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
-            shprint(sh.ndk_build, 'V=1', 'APP_ABI=' + arch.arch, *extra_args, _env=env)
+            shprint(
+                sh.ndk_build,
+                'V=1',
+                'APP_PLATFORM=android-' + str(self.ctx.ndk_api),
+                'APP_ABI=' + arch.arch,
+                *extra_args, _env=env
+            )
 
 
 class PythonRecipe(Recipe):


### PR DESCRIPTION
Fix APP_PLATFORM not properly passed in NDKRecipe. This is needed so certain NDKAPI/--minimum-api values won't lead to build errors with NDK based recipes, e.g. when using NDKAPI=21 with the current `jpeg` recipe