### PR TITLE
[WIP] Fix incorrect assumption that OS python minor version matches hostpython

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -669,8 +669,12 @@ def run_pymodules_install(ctx, modules):
     venv = sh.Command(ctx.virtualenv)
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '--python=python{}'.format(ctx.python_recipe.major_minor_version_string),
-                'venv')
+                '--python=python{}'.format(
+                    ctx.python_recipe.major_minor_version_string.
+                    partition(".")[0]
+                    ),
+                'venv'
+               )
 
         info('Creating a requirements.txt file for the Python modules')
         with open('requirements.txt', 'w') as fileh:


### PR DESCRIPTION
This fixes a call which makes the incorrect assumption that OS python minor version matches the hostpython's minor version. (which will lead to a build error when the minor versions differ, as e.g. described here: https://github.com/JonasT/p4a-build-spaces/issues/4 )