### PR TITLE
[WIP] Rework libxml2, libxslt and lxml (update versions)

### DIFF
--- a/pythonforandroid/recipes/libxml2/__init__.py
+++ b/pythonforandroid/recipes/libxml2/__init__.py
@@ -1,53 +1,58 @@
-from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.toolchain import shprint, shutil, current_directory
 from os.path import exists, join
 import sh
 
 
 class Libxml2Recipe(Recipe):
-    version = "2.7.8"
-    url = "http://xmlsoft.org/sources/libxml2-{version}.tar.gz"
+    version = '2.9.8'
+    url = 'http://xmlsoft.org/sources/libxml2-{version}.tar.gz'
     depends = []
-    patches = ["add-glob.c.patch"]
+    patches = ['add-glob.c.patch']
 
     def should_build(self, arch):
         super(Libxml2Recipe, self).should_build(arch)
-        return not exists(join(self.ctx.get_libs_dir(arch.arch), "libxml2.a"))
+        return not exists(
+            join(self.get_build_dir(arch.arch), '.libs', 'libxml2.a'))
 
     def build_arch(self, arch):
         super(Libxml2Recipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
-            env["CC"] += " -I%s" % self.get_build_dir(arch.arch)
-            shprint(
-                sh.Command("./configure"),
-                "--host=arm-linux-eabi",
-                "--without-modules",
-                "--without-legacy",
-                "--without-history",
-                "--without-debug",
-                "--without-docbook",
-                "--without-python",
-                "--without-threads",
-                "--without-iconv",
-                _env=env,
-            )
+
+            if not exists('configure'):
+                shprint(sh.Command('./autogen.sh'), _env=env)
+            shprint(sh.Command('autoreconf'), '-vif', _env=env)
+            build_arch = shprint(
+                sh.gcc, '-dumpmachine').stdout.decode('utf-8').split('\n')[0]
+            shprint(sh.Command('./configure'),
+                    '--build=' + build_arch,
+                    '--host=' + arch.command_prefix,
+                    '--target=' + arch.command_prefix,
+                    '--without-modules',
+                    '--without-legacy',
+                    '--without-history',
+                    '--without-debug',
+                    '--without-docbook',
+                    '--without-python',
+                    '--without-threads',
+                    '--without-iconv',
+                    '--disable-shared',
+                    '--enable-static',
+                    _env=env)
 
             # Ensure we only build libxml2.la as if we do everything
             # we'll need the glob dependency which is a big headache
             shprint(sh.make, "libxml2.la", _env=env)
-            shutil.copyfile(
-                ".libs/libxml2.a", join(self.ctx.get_libs_dir(arch.arch), "libxml2.a")
-            )
+
+            shutil.copyfile('.libs/libxml2.a',
+                            join(self.ctx.libs_dir, 'libxml2.a'))
 
     def get_recipe_env(self, arch):
         env = super(Libxml2Recipe, self).get_recipe_env(arch)
-        env["CONFIG_SHELL"] = "/bin/bash"
-        env["SHELL"] = "/bin/bash"
-        env[
-            "CC"
-        ] = "arm-linux-androideabi-gcc -DANDROID -mandroid -fomit-frame-pointer --sysroot={}".format(
-            self.ctx.ndk_platform
-        )
+        env['CONFIG_SHELL'] = '/bin/bash'
+        env['SHELL'] = '/bin/bash'
+        env['CC'] += ' -I' + self.get_build_dir(arch.arch)
         return env
 
 

--- a/pythonforandroid/recipes/libxslt/__init__.py
+++ b/pythonforandroid/recipes/libxslt/__init__.py
@@ -1,61 +1,73 @@
-from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.toolchain import shprint, shutil, current_directory
 from os.path import exists, join
 import sh
 
 
 class LibxsltRecipe(Recipe):
-    version = "1.1.28"
-    url = "http://xmlsoft.org/sources/libxslt-{version}.tar.gz"
-    depends = ["libxml2"]
-    patches = ["fix-dlopen.patch"]
+    version = '1.1.32'
+    url = 'http://xmlsoft.org/sources/libxslt-{version}.tar.gz'
+    depends = ['libxml2']
+    patches = ['fix-dlopen.patch']
 
     call_hostpython_via_targetpython = False
 
     def should_build(self, arch):
-        super(LibxsltRecipe, self).should_build(arch)
-        return not exists(join(self.ctx.get_libs_dir(arch.arch), "libxslt.a"))
+        return not exists(
+            join(self.get_build_dir(arch.arch),
+                 'libxslt', '.libs', 'libxslt.a'))
 
     def build_arch(self, arch):
         super(LibxsltRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
-        with current_directory(self.get_build_dir(arch.arch)):
+        build_dir = self.get_build_dir(arch.arch)
+        with current_directory(build_dir):
             # If the build is done with /bin/sh things blow up,
             # try really hard to use bash
-            env["CC"] += " -I%s" % self.get_build_dir(arch.arch)
-            libxml = Recipe.get_recipe(
-                'libxml2', self.ctx).get_build_dir(arch.arch)
-            shprint(
-                sh.Command("./configure"),
-                "--build=i686-pc-linux-gnu",
-                "--host=arm-linux-eabi",
-                "--without-plugins",
-                "--without-debug",
-                "--without-python",
-                "--without-crypto",
-                "--with-libxml-src=%s" % libxml,
-                _env=env,
-            )
+            libxml2_recipe = Recipe.get_recipe('libxml2', self.ctx)
+            libxml2_build_dir = libxml2_recipe.get_build_dir(arch.arch)
+            build_arch = shprint(sh.gcc, '-dumpmachine').stdout.decode(
+                'utf-8').split('\n')[0]
+
+            if not exists('configure'):
+                shprint(sh.Command('./autogen.sh'), _env=env)
+            shprint(sh.Command('autoreconf'), '-vif', _env=env)
+            shprint(sh.Command('./configure'),
+                    '--build=' + build_arch,
+                    '--host=' + arch.command_prefix,
+                    '--target=' + arch.command_prefix,
+                    '--without-plugins',
+                    '--without-debug',
+                    '--without-python',
+                    '--without-crypto',
+                    '--with-libxml-src=' + libxml2_build_dir,
+                    '--disable-shared',
+                    _env=env)
             shprint(sh.make, "V=1", _env=env)
-            shutil.copyfile(
-                "libxslt/.libs/libxslt.a",
-                join(self.ctx.get_libs_dir(arch.arch), "libxslt.a"),
-            )
-            shutil.copyfile(
-                "libexslt/.libs/libexslt.a",
-                join(self.ctx.get_libs_dir(arch.arch), "libexslt.a"),
-            )
+
+            shutil.copyfile('libxslt/.libs/libxslt.a',
+                            join(self.ctx.libs_dir, 'libxslt.a'))
+            shutil.copyfile('libexslt/.libs/libexslt.a',
+                            join(self.ctx.libs_dir, 'libexslt.a'))
 
     def get_recipe_env(self, arch):
         env = super(LibxsltRecipe, self).get_recipe_env(arch)
-        env["CONFIG_SHELL"] = "/bin/bash"
-        env["SHELL"] = "/bin/bash"
-        env[
-            "CC"
-        ] = "arm-linux-androideabi-gcc -DANDROID -mandroid -fomit-frame-pointer --sysroot={}".format(
-            self.ctx.ndk_platform
-        )
+        env['CONFIG_SHELL'] = '/bin/bash'
+        env['SHELL'] = '/bin/bash'
 
-        env["LDSHARED"] = "%s -nostartfiles -shared -fPIC" % env["CC"]
+        libxml2_recipe = Recipe.get_recipe('libxml2', self.ctx)
+        libxml2_build_dir = libxml2_recipe.get_build_dir(arch.arch)
+        libxml2_libs_dir = join(libxml2_build_dir, '.libs')
+
+        env['CFLAGS'] = ' '.join([
+            env['CFLAGS'],
+            '-I' + libxml2_build_dir,
+            '-I' + join(libxml2_build_dir, 'include', 'libxml'),
+            '-I' + self.get_build_dir(arch.arch),
+        ])
+        env['LDFLAGS'] += ' -L' + libxml2_libs_dir
+        env['LIBS'] = '-lxml2 -lz -lm'
+
         return env
 
 

--- a/pythonforandroid/recipes/lxml/__init__.py
+++ b/pythonforandroid/recipes/lxml/__init__.py
@@ -1,57 +1,82 @@
-from pythonforandroid.toolchain import Recipe, shutil
-from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from pythonforandroid.recipe import Recipe, CompiledComponentsPythonRecipe
+from pythonforandroid.logger import shprint
 from os.path import exists, join
-from os import listdir
+from os import uname
+import sh
 
 
 class LXMLRecipe(CompiledComponentsPythonRecipe):
-    version = "3.6.0"
-    url = "https://pypi.python.org/packages/source/l/lxml/lxml-{version}.tar.gz"
-    depends = ["libxml2", "libxslt"]
-    name = "lxml"
+    version = '4.2.5'
+    url = 'https://pypi.python.org/packages/source/l/lxml/lxml-{version}.tar.gz'  # noqa
+    depends = ['libxml2', 'libxslt', 'setuptools']
+    name = 'lxml'
 
     call_hostpython_via_targetpython = False  # Due to setuptools
 
     def should_build(self, arch):
         super(LXMLRecipe, self).should_build(arch)
-        return True
-        return not exists(join(self.ctx.get_libs_dir(arch.arch), "etree.so"))
 
-    def build_arch(self, arch):
-        super(LXMLRecipe, self).build_arch(arch)
+        py_ver = self.ctx.python_recipe.major_minor_version_string
+        build_platform = '{system}-{machine}'.format(
+            system=uname()[0], machine=uname()[-1]).lower()
+        build_dir = join(self.get_build_dir(arch.arch), 'build',
+                         'lib.' + build_platform + '-' + py_ver, 'lxml')
+        py_libs = ['_elementpath.so', 'builder.so', 'etree.so', 'objectify.so']
 
-        def get_lib_build_dir_name():
-            for f in listdir(join(self.get_build_dir(arch.arch), "build")):
-                if f.startswith("lib.linux-x86_64"):
-                    return f
-            return None
+        return not all([exists(join(build_dir, lib)) for lib in py_libs])
 
-        def get_so_name(so_target, dirpath):
-            for f in listdir(dirpath):
-                if f.startswith(so_target.partition(".")[0] + ".") and \
-                        f.endswith(".so"):
-                    return join(dirpath, f)
-            return None
+    def build_compiled_components(self, arch):
+        # Hack to make it link properly to librt, inserted automatically by the
+        # installer (Note: the librt doesn't exist in android but it is
+        # integrated into libc, so we create a symbolic link which we will
+        # remove when our build finishes)
+        link_c = join(self.ctx.ndk_platform, 'usr', 'lib', 'libc')
+        link_rt = join(self.ctx.ndk_platform, 'usr', 'lib', 'librt')
+        shprint(sh.ln, '-sf', link_c + '.so', link_rt + '.so')
+        shprint(sh.ln, '-sf', link_c + '.a', link_rt + '.a')
 
-        so_origin_dir = "%s/build/%s/lxml/" % (self.get_build_dir(arch.arch),
-                                               get_lib_build_dir_name())
-        shutil.copyfile(
-            join(so_origin_dir, get_so_name("etree.so", so_origin_dir)),
-            join(self.ctx.get_libs_dir(arch.arch), "etree.so"),
-        )
-        shutil.copyfile(
-            join(so_origin_dir, get_so_name("objectify.so", so_origin_dir)),
-            join(self.ctx.get_libs_dir(arch.arch), "objectify.so"),
-        )
+        super(LXMLRecipe, self).build_compiled_components(arch)
+
+        shprint(sh.rm, '-r', link_rt + '.so')
+        shprint(sh.rm, '-r', link_rt + '.a')
 
     def get_recipe_env(self, arch):
         env = super(LXMLRecipe, self).get_recipe_env(arch)
-        libxslt_recipe = Recipe.get_recipe("libxslt", self.ctx).get_build_dir(arch.arch)
-        libxml2_recipe = Recipe.get_recipe("libxml2", self.ctx).get_build_dir(arch.arch)
-        env["CC"] += " -I%s/include -I%s " % (
-            libxml2_recipe,
-            libxslt_recipe,
-        )
+
+        # libxslt flags
+        libxslt_recipe = Recipe.get_recipe('libxslt', self.ctx)
+        libxslt_build_dir = libxslt_recipe.get_build_dir(arch.arch)
+
+        cflags = ' -I' + libxslt_build_dir
+        cflags += ' -I' + join(libxslt_build_dir, 'libxslt')
+        cflags += ' -I' + join(libxslt_build_dir, 'libexslt')
+
+        env['LDFLAGS'] += ' -L' + join(libxslt_build_dir, 'libxslt', '.libs')
+        env['LDFLAGS'] += ' -L' + join(libxslt_build_dir, 'libexslt', '.libs')
+        env['LIBS'] = '-lxslt -lexslt'
+
+        # libxml2 flags
+        libxml2_recipe = Recipe.get_recipe('libxml2', self.ctx)
+        libxml2_build_dir = libxml2_recipe.get_build_dir(arch.arch)
+        libxml2_libs_dir = join(libxml2_build_dir, '.libs')
+
+        cflags += ' -I' + libxml2_build_dir
+        cflags += ' -I' + join(libxml2_build_dir, 'include')
+        cflags += ' -I' + join(libxml2_build_dir, 'include', 'libxml')
+        cflags += ' -I' + self.get_build_dir(arch.arch)
+        env['LDFLAGS'] += ' -L' + libxml2_libs_dir
+        env['LIBS'] += ' -lxml2'
+
+        # android's ndk flags
+        ndk_lib_dir = join(self.ctx.ndk_platform, 'usr', 'lib')
+        ndk_include_dir = join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+        cflags += ' -I' + ndk_include_dir
+        env['LDFLAGS'] += ' -L' + ndk_lib_dir
+        env['LIBS'] += ' -lz -lm -lc'
+
+        if cflags not in env['CFLAGS']:
+            env['CFLAGS'] += cflags
+
         return env
 
 


### PR DESCRIPTION
The lxml recipe depends on those two libraries, if we update lxml we must update the two libraries (libxml2 and libxslt). This rework takes care of that and also:

  - replace double quotes to single quotes because I think that it's more readable
  - fix imports
  - shortened lines

**Note:** Successfully build for python3 and python2 (tested some days ago in a real python3's app but it would be great that someone could test it again)