### PR TITLE
 fix missing gethostbyname_r on Android 5.1

### DIFF
--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -29,6 +29,7 @@ class Python2Recipe(GuestPythonRecipe):
                #  is_api_lt(21)), # Todo: this should be tested
                'patches/fix-missing-extensions.patch',
                'patches/fix-filesystem-default-encoding.patch',
+               'patches/fix-gethostbyaddr.patch',
                'patches/fix-posix-declarations.patch',
                'patches/fix-pwd-gecos.patch']
 

--- a/pythonforandroid/recipes/python2/patches/fix-gethostbyaddr.patch
+++ b/pythonforandroid/recipes/python2/patches/fix-gethostbyaddr.patch
@@ -1,0 +1,12 @@
+--- Python-2.7.15/Modules/socketmodule.c.orig	2017-12-29 01:40:09.915694810 +0100
++++ Python-2.7.15/Modules/socketmodule.c	2017-12-29 01:40:36.967694486 +0100
+@@ -156,6 +156,9 @@
+    On the other hand, not all Linux versions agree, so there the settings
+    computed by the configure script are needed! */
+
++/* Android hack, same reason are what is described above */
++#undef HAVE_GETHOSTBYNAME_R
++
+ #ifndef linux
+ # undef HAVE_GETHOSTBYNAME_R_3_ARG
+ # undef HAVE_GETHOSTBYNAME_R_5_ARG


### PR DESCRIPTION
@tito faced the `gethostbyname_r` issue and send me a fix for that.

This also should fix the second issue described in https://github.com/kivy/python-for-android/pull/1217#issuecomment-453608150, which is the same that @tito found:

See Also: https://bugs.python.org/issue26857

¡¡¡Thanks @tito!!!