### PR TITLE
[CORE FIX/ENHANCEMENT] Speedup copy that can be very very long (up to 2 minutes)

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -267,8 +267,8 @@ class GuestPythonRecipe(TargetPythonRecipe):
                 '2' if self.version[0] == '2' else '',
                 self.major_minor_version_string
             ))
-        module_filens = list(glob.glob(join(modules_build_dir, '*.so')) +
-                             glob.glob(join(modules_build_dir, '*.py')))
+        module_filens = (glob.glob(join(modules_build_dir, '*.so')) +
+                         glob.glob(join(modules_build_dir, '*.py')))
         info("Copy {} files into the bundle".format(len(module_filens)))
         for filen in module_filens:
             info(" - copy {}".format(filen))


### PR DESCRIPTION
This fixes the slow copy issue we have when copying files to our distribution folder and affects to python2 and python3.

I tested this in python 3 and @tito made and tested this commit in his own builds for python 2. Travis will say the final words but I suspect that  we can  reduce travis's build timings...will see...

@inclement please...take a look on this when you have time...this affects the core!

Again :smile:, ¡¡¡Thanks @tito!!!