### PR TITLE
Fix --private and others showing weird error when used without argument

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -772,7 +772,7 @@ class ToolchainCL(object):
                 if len(argx) > 1:
                     unknown_args[i] = '='.join(
                         (argx[0], realpath(expanduser(argx[1]))))
-                else:
+                elif i + 1 < len(unknown_args):
                     unknown_args[i+1] = realpath(expanduser(unknown_args[i+1]))
 
         env = os.environ.copy()


### PR DESCRIPTION
When using some of the options like `--private` without an argument, which shouldn't be done but users make mistakes sometimes, this currently causes a weird backtrace error that isn't obvious to the average user. This pull request addresses that problem such that better error handling can happen