### PR TITLE
Allow patching from any folder + fix pygame components issues

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -166,14 +166,18 @@ class Recipe(with_metaclass(RecipeMeta)):
                         shprint(sh.git, 'submodule', 'update', '--recursive')
             return target
 
-    def apply_patch(self, filename, arch):
+    def apply_patch(self, filename, arch, build_dir=None):
         """
         Apply a patch from the current recipe directory into the current
         build directory.
+
+        .. versionchanged:: 0.6.0
+            Add ability to apply patch from any dir via kwarg `build_dir`'''
         """
         info("Applying patch {}".format(filename))
+        build_dir = build_dir if build_dir else self.get_build_dir(arch)
         filename = join(self.get_recipe_dir(), filename)
-        shprint(sh.patch, "-t", "-d", self.get_build_dir(arch), "-p1",
+        shprint(sh.patch, "-t", "-d", build_dir, "-p1",
                 "-i", filename, _tail=10)
 
     def copy_file(self, filename, dest):
@@ -428,8 +432,11 @@ class Recipe(with_metaclass(RecipeMeta)):
         build_dir = self.get_build_dir(arch.arch)
         return exists(join(build_dir, '.patched'))
 
-    def apply_patches(self, arch):
-        '''Apply any patches for the Recipe.'''
+    def apply_patches(self, arch, build_dir=None):
+        '''Apply any patches for the Recipe.
+
+        .. versionchanged:: 0.6.0
+            Add ability to apply patches from any dir via kwarg `build_dir`'''
         if self.patches:
             info_main('Applying patches for {}[{}]'
                       .format(self.name, arch.arch))
@@ -438,6 +445,7 @@ class Recipe(with_metaclass(RecipeMeta)):
                 info_main('{} already patched, skipping'.format(self.name))
                 return
 
+            build_dir = build_dir if build_dir else self.get_build_dir(arch.arch)
             for patch in self.patches:
                 if isinstance(patch, (tuple, list)):
                     patch, patch_check = patch
@@ -446,9 +454,9 @@ class Recipe(with_metaclass(RecipeMeta)):
 
                 self.apply_patch(
                         patch.format(version=self.version, arch=arch.arch),
-                        arch.arch)
+                        arch.arch, build_dir=build_dir)
 
-            shprint(sh.touch, join(self.get_build_dir(arch.arch), '.patched'))
+            shprint(sh.touch, join(build_dir, '.patched'))
 
     def should_build(self, arch):
         '''Should perform any necessary test and return True only if it needs

--- a/pythonforandroid/recipes/pygame_bootstrap_components/__init__.py
+++ b/pythonforandroid/recipes/pygame_bootstrap_components/__init__.py
@@ -9,9 +9,10 @@ class PygameJNIComponentsRecipe(BootstrapNDKRecipe):
     version = 'master'
     url = 'https://github.com/kivy/p4a-pygame-bootstrap-components/archive/{version}.zip'
     dir_name = 'bootstrap_components'
+    patches = ['jpeg-ndk15-plus.patch']
 
     def prebuild_arch(self, arch):
-        super(PygameJNIComponentsRecipe, self).postbuild_arch(arch)
+        super(PygameJNIComponentsRecipe, self).prebuild_arch(arch)
 
         info('Unpacking pygame bootstrap JNI dir components')
         with current_directory(self.get_build_container_dir(arch)):
@@ -25,11 +26,9 @@ class PygameJNIComponentsRecipe(BootstrapNDKRecipe):
         info('Unpacking was successful, deleting original container dir')
         shprint(sh.rm, '-rf', self.get_build_dir(arch))
 
-        info('Applying jpeg assembler patch')
-        ndk_15_plus_patch = join(self.get_recipe_dir(), 'jpeg-ndk15-plus.patch')
-        shprint(sh.patch, '-t', '-d',
-                join(self.get_build_container_dir(arch), 'jpeg'), '-p1',
-                '-i', ndk_15_plus_patch, _tail=10)
+    def apply_patches(self, arch, build_dir=None):
+        super(PygameJNIComponentsRecipe, self).apply_patches(
+            arch, build_dir=self.get_build_container_dir(arch.arch))
 
 
 recipe = PygameJNIComponentsRecipe()

--- a/pythonforandroid/recipes/pygame_bootstrap_components/jpeg-ndk15-plus.patch
+++ b/pythonforandroid/recipes/pygame_bootstrap_components/jpeg-ndk15-plus.patch
@@ -2,8 +2,8 @@ The distributed jpeg has troubles to be build with newer ndks, starting from
 the introduction of the `unified headers` (ndk > 15). This patch allow us to
 build the distributed `external jpeg` in sdl package, got the solution in here:
 https://github.com/oNaiPs/droidVncServer/issues/53
---- jpeg/Android.mk.orig	2015-06-21 15:14:54.000000000 +0200
-+++ jpeg/Android.mk	2019-01-14 10:57:06.384806168 +0100
+--- jni/jpeg/Android.mk.orig	2015-06-21 15:14:54.000000000 +0200
++++ jni/jpeg/Android.mk	2019-01-14 10:57:06.384806168 +0100
 @@ -20,7 +20,7 @@
  endif
 
@@ -13,8 +13,8 @@ https://github.com/oNaiPs/droidVncServer/issues/53
 
  ifeq ($(strip $(ANDROID_JPEG_NO_ASSEMBLER)),true)
  LOCAL_SRC_FILES += jidctint.c jidctfst.c
- --- jpeg/jidctfst.S.orig	2019-01-14 11:00:38.000000000 +0100
-+++ jpeg/jidctfst.S	2019-01-14 11:00:56.844803970 +0100
+--- jni/jpeg/jidctfst.S.orig	2019-01-14 11:00:38.000000000 +0100
++++ jni/jpeg/jidctfst.S	2019-01-14 11:00:56.844803970 +0100
 @@ -63,7 +63,7 @@
 
 


### PR DESCRIPTION
This is needed to properly apply the patches for the pygame bootstrap components recipe, because we must apply the patches from build_container_dir and the current patching method only allow us to do that from the build directory (which not exists in pygame components because we delete it). Also fix a typo error for pygame components.