### PR TITLE
Fix --force-build incorrectly listed as --force_build, fixes #1565

### DIFF
--- a/doc/source/commands.rst
+++ b/doc/source/commands.rst
@@ -67,7 +67,7 @@ supply those that you need.
   distribution must contain, as a comma separated list. These must be
   names of recipes or the pypi names of Python modules.
 
-``--force_build BOOL``
+``--force-build BOOL``
   Whether the distribution must be compiled from scratch.
 
 ``--arch``


### PR DESCRIPTION
Fix `--force-build` incorrectly listed as `--force_build` in the documentation, fixes #1565