### PR TITLE
[WIP] Restores the ability to compile the python files into .pyo/.pyc (for both versions of python)

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -253,11 +253,15 @@ def compile_dir(dfn, optimize_python=True):
     if get_bootstrap_name() != "sdl2":
         # HISTORICALLY DISABLED for other than sdl2. NEEDS REVIEW! -JonasT
         return
-    # -OO = strip docstrings
     if PYTHON is None:
         return
-    args = [PYTHON, '-m', 'compileall', '-f', dfn]
+
+    if int(PYTHON_VERSION[0]) >= 3:
+        args = [PYTHON, '-m', 'compileall', '-b', '-f', dfn]
+    else:
+        args = [PYTHON, '-m', 'compileall', '-f', dfn]
     if optimize_python:
+        # -OO = strip docstrings
         args.insert(1, '-OO')
     subprocess.call(args)
 

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -250,9 +250,6 @@ def compile_dir(dfn, optimize_python=True):
     Compile *.py in directory `dfn` to *.pyo
     '''
 
-    if get_bootstrap_name() != "sdl2":
-        # HISTORICALLY DISABLED for other than sdl2. NEEDS REVIEW! -JonasT
-        return
     if PYTHON is None:
         return
 

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -39,6 +39,10 @@ def get_hostpython():
     return get_dist_info_for('hostpython')
 
 
+def get_python_version():
+    return get_dist_info_for('python_version')
+
+
 def get_bootstrap_name():
     return get_dist_info_for('bootstrap')
 
@@ -53,6 +57,7 @@ else:
 curdir = dirname(__file__)
 
 PYTHON = get_hostpython()
+PYTHON_VERSION = get_python_version()
 if PYTHON is not None and not exists(PYTHON):
     PYTHON = None
 
@@ -63,17 +68,18 @@ BLACKLIST_PATTERNS = [
     '^*.bzr/*',
     '^*.svn/*',
 
-    # pyc/py
-    '*.pyc',
-    # '*.py',
-
     # temp files
     '~',
     '*.bak',
     '*.swp',
 ]
+# pyc/py
 if PYTHON is not None:
     BLACKLIST_PATTERNS.append('*.py')
+    if PYTHON_VERSION and int(PYTHON_VERSION[0]) == 2:
+        # we only blacklist `.pyc` for python2 because in python3 the compiled
+        # extension is `.pyc` (.pyo files not exists for python >= 3.6)
+        BLACKLIST_PATTERNS.append('*.pyc')
 
 WHITELIST_PATTERNS = []
 if get_bootstrap_name() in ('sdl2', 'webview', 'service_only'):

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -23,16 +23,24 @@ from fnmatch import fnmatch
 import jinja2
 
 
-def get_bootstrap_name():
+def get_dist_info_for(key):
     try:
         with open(join(dirname(__file__), 'dist_info.json'), 'r') as fileh:
             info = json.load(fileh)
-        bootstrap = str(info["bootstrap"])
+        value = str(info[key])
     except (OSError, KeyError) as e:
-        print("BUILD FAILURE: Couldn't extract bootstrap name " +
+        print("BUILD FAILURE: Couldn't extract the key `" + key + "` " +
               "from dist_info.json: " + str(e))
         sys.exit(1)
-    return bootstrap
+    return value
+
+
+def get_hostpython():
+    return get_dist_info_for('hostpython')
+
+
+def get_bootstrap_name():
+    return get_dist_info_for('bootstrap')
 
 
 if os.name == 'nt':
@@ -44,9 +52,8 @@ else:
 
 curdir = dirname(__file__)
 
-# Try to find a host version of Python that matches our ARM version.
-PYTHON = join(curdir, 'python-install', 'bin', 'python.host')
-if not exists(PYTHON):
+PYTHON = get_hostpython()
+if PYTHON is not None and not exists(PYTHON):
     PYTHON = None
 
 BLACKLIST_PATTERNS = [

--- a/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
+++ b/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
@@ -305,6 +305,11 @@ int main(int argc, char *argv[]) {
   /* Get the entrypoint, search the .pyo then .py
    */
   char *dot = strrchr(env_entrypoint, '.');
+#if PY_MAJOR_VERSION > 2
+  char *ext = ".pyc";
+#else
+  char *ext = ".pyo";
+#endif
   if (dot <= 0) {
     LOGP("Invalid entrypoint, abort.");
     return -1;
@@ -313,14 +318,14 @@ int main(int argc, char *argv[]) {
       LOGP("Entrypoint path is too long, try increasing ENTRYPOINT_MAXLEN.");
       return -1;
   }
-  if (!strcmp(dot, ".pyo")) {
+  if (!strcmp(dot, ext)) {
     if (!file_exists(env_entrypoint)) {
       /* fallback on .py */
       strcpy(entrypoint, env_entrypoint);
       entrypoint[strlen(env_entrypoint) - 1] = '\0';
       LOGP(entrypoint);
       if (!file_exists(entrypoint)) {
-        LOGP("Entrypoint not found (.pyo, fallback on .py), abort");
+        LOGP("Entrypoint not found (.pyc/.pyo, fallback on .py), abort");
         return -1;
       }
     } else {
@@ -330,7 +335,11 @@ int main(int argc, char *argv[]) {
     /* if .py is passed, check the pyo version first */
     strcpy(entrypoint, env_entrypoint);
     entrypoint[strlen(env_entrypoint) + 1] = '\0';
+#if PY_MAJOR_VERSION > 2
+    entrypoint[strlen(env_entrypoint)] = 'c';
+#else
     entrypoint[strlen(env_entrypoint)] = 'o';
+#endif
     if (!file_exists(entrypoint)) {
       /* fallback on pure python version */
       if (!file_exists(env_entrypoint)) {
@@ -340,7 +349,7 @@ int main(int argc, char *argv[]) {
       strcpy(entrypoint, env_entrypoint);
     }
   } else {
-    LOGP("Entrypoint have an invalid extension (must be .py or .pyo), abort.");
+    LOGP("Entrypoint have an invalid extension (must be .py or .pyc/.pyo), abort.");
     return -1;
   }
   // LOGP("Entrypoint is:");

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -150,7 +150,8 @@ public class PythonActivity extends SDLActivity {
                 File path = new File(getIntent().getData().getSchemeSpecificPart());
 
                 Project p = Project.scanDirectory(path);
-                SDLActivity.nativeSetEnv("ANDROID_ENTRYPOINT", p.dir + "/main.py");
+                String entry_point = getEntryPoint(p.dir);
+                SDLActivity.nativeSetEnv("ANDROID_ENTRYPOINT", p.dir + "/" + entry_point);
                 SDLActivity.nativeSetEnv("ANDROID_ARGUMENT", p.dir);
                 SDLActivity.nativeSetEnv("ANDROID_APP_PATH", p.dir);
 
@@ -171,7 +172,8 @@ public class PythonActivity extends SDLActivity {
                     // pass
                 }
             } else {
-                SDLActivity.nativeSetEnv("ANDROID_ENTRYPOINT", "main.pyo");
+                String entry_point = getEntryPoint(app_root_dir);
+                SDLActivity.nativeSetEnv("ANDROID_ENTRYPOINT", entry_point);
                 SDLActivity.nativeSetEnv("ANDROID_ARGUMENT", app_root_dir);
                 SDLActivity.nativeSetEnv("ANDROID_APP_PATH", app_root_dir);
             }
@@ -368,9 +370,10 @@ public class PythonActivity extends SDLActivity {
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
+        String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/main.pyo");
+        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
@@ -463,6 +466,21 @@ public class PythonActivity extends SDLActivity {
         });
     }
 
+    public String getEntryPoint(String search_dir) {
+        /* Get the main file (.pyc|.pyo|.py) depending on if we
+         * have a compiled version or not.
+        */
+        List<String> entryPoints = new ArrayList<String>();
+        entryPoints.add("main.pyo");  // python 2 compiled files
+        entryPoints.add("main.pyc");  // python 3 compiled files
+		for (String value : entryPoints) {
+            File mainFile = new File(search_dir + "/" + value);
+            if (mainFile.exists()) {
+                return value;
+            }
+        }
+        return "main.py";
+    }
 
     protected void showLoadingScreen() {
         // load the bitmap

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -74,6 +74,22 @@ public class PythonActivity extends Activity {
         return app_root;
     }
 
+    public String getEntryPoint(String search_dir) {
+        /* Get the main file (.pyc|.pyo|.py) depending on if we
+         * have a compiled version or not.
+        */
+        List<String> entryPoints = new ArrayList<String>();
+        entryPoints.add("main.pyo");  // python 2 compiled files
+        entryPoints.add("main.pyc");  // python 3 compiled files
+		for (String value : entryPoints) {
+            File mainFile = new File(search_dir + "/" + value);
+            if (mainFile.exists()) {
+                return value;
+            }
+        }
+        return "main.py";
+    }
+
     public static void initialize() {
         // The static nature of the singleton and Android quirkiness force us to initialize everything here
         // Otherwise, when exiting the app and returning to it, these variables *keep* their pre exit values
@@ -142,9 +158,10 @@ public class PythonActivity extends Activity {
         // Set up the Python environment
         String app_root_dir = getAppRoot();
         String mFilesDirectory = mActivity.getFilesDir().getAbsolutePath();
+        String entry_point = getEntryPoint(app_root_dir);
 
         Log.v(TAG, "Setting env vars for start.c and Python to use");
-        PythonActivity.nativeSetEnv("ANDROID_ENTRYPOINT", "main.pyo");
+        PythonActivity.nativeSetEnv("ANDROID_ENTRYPOINT", entry_point);
         PythonActivity.nativeSetEnv("ANDROID_ARGUMENT", app_root_dir);
         PythonActivity.nativeSetEnv("ANDROID_APP_PATH", app_root_dir);
         PythonActivity.nativeSetEnv("ANDROID_PRIVATE", mFilesDirectory);
@@ -368,9 +385,10 @@ public class PythonActivity extends Activity {
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
+        String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/main.pyo");
+        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -81,6 +81,22 @@ public class PythonActivity extends Activity {
         return app_root;
     }
 
+    public String getEntryPoint(String search_dir) {
+        /* Get the main file (.pyc|.pyo|.py) depending on if we
+         * have a compiled version or not.
+        */
+        List<String> entryPoints = new ArrayList<String>();
+        entryPoints.add("main.pyo");  // python 2 compiled files
+        entryPoints.add("main.pyc");  // python 3 compiled files
+		for (String value : entryPoints) {
+            File mainFile = new File(search_dir + "/" + value);
+            if (mainFile.exists()) {
+                return value;
+            }
+        }
+        return "main.py";
+    }
+
     public static void initialize() {
         // The static nature of the singleton and Android quirkyness force us to initialize everything here
         // Otherwise, when exiting the app and returning to it, these variables *keep* their pre exit values
@@ -170,9 +186,10 @@ public class PythonActivity extends Activity {
         setContentView(mLayout);
 
         String mFilesDirectory = mActivity.getFilesDir().getAbsolutePath();
+        String entry_point = getEntryPoint(app_root_dir);
 
         Log.v(TAG, "Setting env vars for start.c and Python to use");
-        PythonActivity.nativeSetEnv("ANDROID_ENTRYPOINT", "main.pyo");
+        PythonActivity.nativeSetEnv("ANDROID_ENTRYPOINT", entry_point);
         PythonActivity.nativeSetEnv("ANDROID_ARGUMENT", app_root_dir);
         PythonActivity.nativeSetEnv("ANDROID_APP_PATH", app_root_dir);
         PythonActivity.nativeSetEnv("ANDROID_PRIVATE", mFilesDirectory);
@@ -425,9 +442,10 @@ public class PythonActivity extends Activity {
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
+        String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);
         serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/main.pyo");
+        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -216,7 +216,9 @@ class Distribution(object):
                            'bootstrap': self.ctx.bootstrap.name,
                            'archs': [arch.arch for arch in self.ctx.archs],
                            'ndk_api': self.ctx.ndk_api,
-                           'recipes': self.ctx.recipe_build_order + self.ctx.python_modules},
+                           'recipes': self.ctx.recipe_build_order + self.ctx.python_modules,
+                           'hostpython': self.ctx.hostpython,
+                           'python_version': self.ctx.python_recipe.major_minor_version_string},
                           fileh)
 
 

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -344,7 +344,7 @@ class GuestPythonRecipe(TargetPythonRecipe):
         if self.major_minor_version_string[0] == '3':
             python_lib_name += 'm'
         shprint(sh.cp, join(python_build_dir, python_lib_name + '.so'),
-                'libs/{}'.format(arch.arch))
+                join(self.ctx.dist_dir, self.ctx.dist_name, 'libs', arch.arch))
 
         info('Renaming .so files to reflect cross-compile')
         self.reduce_object_file_names(join(dirn, 'site-packages'))

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -47,6 +47,8 @@ class Python2Recipe(GuestPythonRecipe):
                       '--prefix={prefix}',
                       '--exec-prefix={exec_prefix}')
 
+    compiled_extension = '.pyo'
+
     def prebuild_arch(self, arch):
         super(Python2Recipe, self).prebuild_arch(arch)
         patch_mark = join(self.get_build_dir(arch.arch), '.openssl-patched')


### PR DESCRIPTION
We already had before this feature for python2 (python2legacy now)  and we loosed it with the recently merged core update. Also we will be able to compile our python install files for python 3 (new feature for python3). But be aware that to achieve this we must modify a little our source code because as of python 3.5 the `.pyo extension` for compiled python files has been removed in favour of  `.pyc extension`, so it requires to modify `start.c` and `PythonActivity.java` files, which only contemplated the .pyo extension.

Notes:
  - the default behaviour will be to compile all python files to the corresponding compiled extension, so **this way the apk will run faster**
  - also we compile the code with the option `-00` which will strip the docs, so we **will generate lighter apks**
  - this change **affects** bootstraps: **sdl2, webview and service_only**

See also:
  - `PEP 488 -- Elimination of PYO files` (https://www.python.org/dev/peps/pep-0488/)
  - `PEP 3147 -- PYC Repository Directories` as to why a separate directory is used (https://www.python.org/dev/peps/pep-3147/)

Status: **I leave the `WIP` status because this may conflict with the sdl2 update by** @JonasT (#1528) and, probably, the merge conflicts will be aesier to solve here than in there, so...let @JonasT decide if we must remove the `WIP` status (be aware that this will also be an enhancement)

**Thanks to @tito which make me notice that we had loose that feature**