### PR TITLE
Fix strip in bootstrap

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -278,6 +278,8 @@ class Bootstrap(object):
 
         logger.info('Stripping libraries in private dir')
         for filen in filens.split('\n'):
+            if not filen:
+                continue  # skip the last ''
             try:
                 strip(filen, _env=env)
             except sh.ErrorReturnCode_1:

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -263,11 +263,11 @@ class Bootstrap(object):
             info('Python was loaded from CrystaX, skipping strip')
             return
         env = arch.get_env()
-        strip = which('arm-linux-androideabi-strip', env['PATH'])
+        strip = env['STRIP'].split(' ')[0]
         if strip is None:
             warning('Can\'t find strip in PATH...')
             return
-        strip = sh.Command(strip)
+        strip = sh.Command(strip).bake('--strip-unneeded')
 
         libs_dir = join(self.dist_dir, '_python_bundle',
                         '_python_bundle', 'modules')

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -10,7 +10,7 @@ import shutil
 from pythonforandroid.logger import (warning, shprint, info, logger,
                                      debug)
 from pythonforandroid.util import (current_directory, ensure_dir,
-                                   temp_directory, which)
+                                   temp_directory)
 from pythonforandroid.recipe import Recipe
 
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -265,7 +265,9 @@ class Bootstrap(object):
             return
         env = arch.get_env()
         tokens = shlex.split(env['STRIP'])
-        strip = sh.Command(tokens[0]).bake(tokens[1:])
+        strip = sh.Command(tokens[0])
+        if len(tokens) > 1:
+            strip = strip.bake(tokens[1:])
 
         libs_dir = join(self.dist_dir, '_python_bundle',
                         '_python_bundle', 'modules')

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -1,6 +1,7 @@
 from os.path import (join, dirname, isdir, normpath, splitext, basename)
 from os import listdir, walk, sep
 import sh
+import shlex
 import glob
 import importlib
 import os
@@ -263,8 +264,8 @@ class Bootstrap(object):
             info('Python was loaded from CrystaX, skipping strip')
             return
         env = arch.get_env()
-        tokens = env['STRIP'].split(' ')
-        strip = reduce(lambda cmd, t: cmd.bake(t), tokens, sh.Command(tokens.pop(0)))
+        tokens = shlex.split(env['STRIP'])
+        strip = sh.Command(tokens[0]).bake(tokens[1:])
 
         libs_dir = join(self.dist_dir, '_python_bundle',
                         '_python_bundle', 'modules')

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -263,11 +263,8 @@ class Bootstrap(object):
             info('Python was loaded from CrystaX, skipping strip')
             return
         env = arch.get_env()
-        strip = env['STRIP'].split(' ')[0]
-        if strip is None:
-            warning('Can\'t find strip in PATH...')
-            return
-        strip = sh.Command(strip).bake('--strip-unneeded')
+        tokens = env['STRIP'].split(' ')
+        strip = reduce(lambda cmd, t: cmd.bake(t), tokens, sh.Command(tokens.pop(0)))
 
         libs_dir = join(self.dist_dir, '_python_bundle',
                         '_python_bundle', 'modules')


### PR DESCRIPTION
Due to hardcoding, the arch-dependent `strip` command is not invoked when building for `arch` other than `--arch=armeabi-v7a` (e.g. `strip` not detected when `--arch=x86`).

This PR fixes

- the problem above, and
- the case of applying `strip` erroneously when the file name is `''` (an empty string).