### PR TITLE
Fix getting empty "modules" directory when arch is not armeabi-v7a

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -263,8 +263,9 @@ class GuestPythonRecipe(TargetPythonRecipe):
             self.get_build_dir(arch.arch),
             'android-build',
             'build',
-            'lib.linux{}-arm-{}'.format(
+            'lib.linux{}-{}-{}'.format(
                 '2' if self.version[0] == '2' else '',
+                arch.command_prefix.split('-')[0],
                 self.major_minor_version_string
             ))
         module_filens = (glob.glob(join(modules_build_dir, '*.so')) +


### PR DESCRIPTION
In `create_python_bundle()`, copy source path of built modules (*.so) is hardcoded to `arm`. This results in an empty `modules` directory when build `arch` is other than `armeabi-v7a`.

This PR fixes the above issue; accordingly, the `modules` directory is generated as expected (when arch is `x86`, `x86_64`,`arm64-v8a`, etc).