### PR TITLE
Fix libffi/ctypes - wrong libffi headers when building python

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -178,6 +178,10 @@ class GuestPythonRecipe(TargetPythonRecipe):
         if 'libffi' in self.ctx.recipe_build_order:
             info('Activating flags for libffi')
             recipe = Recipe.get_recipe('libffi', self.ctx)
+            # In order to force the correct linkage for our libffi library, we
+            # set the following variable to point where is our libffi.pc file,
+            # because the python build system uses pkg-config to configure it.
+            env['PKG_CONFIG_PATH'] = recipe.get_build_dir(arch.arch)
             add_flags(' -I' + ' -I'.join(recipe.get_include_dirs(arch)),
                       ' -L' + join(recipe.get_build_dir(arch.arch), '.libs'),
                       ' -lffi')

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -179,8 +179,8 @@ class GuestPythonRecipe(TargetPythonRecipe):
             info('Activating flags for libffi')
             recipe = Recipe.get_recipe('libffi', self.ctx)
             add_flags(' -I' + ' -I'.join(recipe.get_include_dirs(arch)),
-                      ' -L' + join(recipe.get_build_dir(arch.arch),
-                                   recipe.get_host(arch), '.libs'), ' -lffi')
+                      ' -L' + join(recipe.get_build_dir(arch.arch), '.libs'),
+                      ' -lffi')
 
         if 'openssl' in self.ctx.recipe_build_order:
             info('Activating flags for openssl')

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -17,7 +17,11 @@ class LibffiRecipe(Recipe):
     version = '3.2.1'
     url = 'https://github.com/libffi/libffi/archive/v{version}.tar.gz'
 
-    patches = ['remove-version-info.patch']
+    patches = ['remove-version-info.patch',
+               # This patch below is already included into libffi's master
+               # branch and included in the pre-release 3.3rc0...so we should
+               # remove this when we update the version number for libffi
+               'fix-includedir.patch']
 
     def should_build(self, arch):
         return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
@@ -30,7 +34,7 @@ class LibffiRecipe(Recipe):
             shprint(sh.Command('autoreconf'), '-vif', _env=env)
             shprint(sh.Command('./configure'),
                     '--host=' + arch.command_prefix,
-                    '--prefix=' + self.ctx.get_python_install_dir(),
+                    '--prefix=' + self.get_build_dir(arch.arch),
                     '--disable-builddir',
                     '--enable-shared', _env=env)
             # '--with-sysroot={}'.format(self.ctx.ndk_platform),

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -19,21 +19,6 @@ class LibffiRecipe(Recipe):
 
     patches = ['remove-version-info.patch']
 
-    def get_host(self, arch):
-        with current_directory(self.get_build_dir(arch.arch)):
-            host = None
-            with open('Makefile') as f:
-                for line in f:
-                    if line.startswith('host = '):
-                        host = line.strip()[7:]
-                        break
-
-            if not host or not exists(host):
-                raise RuntimeError('failed to find build output! ({})'
-                                   .format(host))
-
-            return host
-
     def should_build(self, arch):
         return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
 
@@ -46,6 +31,7 @@ class LibffiRecipe(Recipe):
             shprint(sh.Command('./configure'),
                     '--host=' + arch.command_prefix,
                     '--prefix=' + self.ctx.get_python_install_dir(),
+                    '--disable-builddir',
                     '--enable-shared', _env=env)
             # '--with-sysroot={}'.format(self.ctx.ndk_platform),
             # '--target={}'.format(arch.toolchain_prefix),
@@ -62,7 +48,7 @@ class LibffiRecipe(Recipe):
                 info("make libffi.la failed as expected")
             cc = sh.Command(env['CC'].split()[0])
             cflags = env['CC'].split()[1:]
-            host_build = join(self.get_build_dir(arch.arch), self.get_host(arch))
+            host_build = self.get_build_dir(arch.arch)
 
             arch_flags = ''
             if '-march=' in env['CFLAGS']:
@@ -91,8 +77,7 @@ class LibffiRecipe(Recipe):
                     join(host_build, '.libs', 'libffi.so'))
 
     def get_include_dirs(self, arch):
-        return [join(self.get_build_dir(arch.arch), self.get_host(arch),
-                     'include')]
+        return [join(self.get_build_dir(arch.arch), 'include')]
 
 
 recipe = LibffiRecipe()

--- a/pythonforandroid/recipes/libffi/fix-includedir.patch
+++ b/pythonforandroid/recipes/libffi/fix-includedir.patch
@@ -1,0 +1,34 @@
+From 982b89c01aca99c7bc229914fc1521f96930919b Mon Sep 17 00:00:00 2001
+From: Yen Chi Hsuan <yan12125@gmail.com>
+Date: Sun, 13 Nov 2016 19:17:19 +0800
+Subject: [PATCH] Install public headers in the standard path
+
+---
+ include/Makefile.am | 3 +--
+ libffi.pc.in        | 2 +-
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/include/Makefile.am b/include/Makefile.am
+index bb241e88..c59df9fb 100644
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -6,5 +6,4 @@ DISTCLEANFILES=ffitarget.h
+ noinst_HEADERS=ffi_common.h ffi_cfi.h
+ EXTRA_DIST=ffi.h.in
+
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
+-nodist_includes_HEADERS = ffi.h ffitarget.h
++nodist_include_HEADERS = ffi.h ffitarget.h
+diff --git a/libffi.pc.in b/libffi.pc.in
+index edf6fde5..6fad83b4 100644
+--- a/libffi.pc.in
++++ b/libffi.pc.in
+@@ -2,7 +2,7 @@ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ toolexeclibdir=@toolexeclibdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=@includedir@
+
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -56,6 +56,11 @@ class Python2Recipe(GuestPythonRecipe):
 
     def set_libs_flags(self, env, arch):
         env = super(Python2Recipe, self).set_libs_flags(env, arch)
+        if 'libffi' in self.ctx.recipe_build_order:
+            # For python2 we need to tell configure that we want to use our
+            # compiled libffi, this step is not necessary for python3.
+            self.configure_args += ('--with-system-ffi',)
+
         if 'openssl' in self.ctx.recipe_build_order:
             recipe = Recipe.get_recipe('openssl', self.ctx)
             openssl_build = recipe.get_build_dir(arch.arch)


### PR DESCRIPTION
It has been reported of errors with `ctypes`, even when the `ctypes` module seems to be built fine.
@tito is one of the affected by this and he found that, in some system configuration, python could be:

```compiled with the headers of the system libffi, but runs with the target libffi```

That will end in an app crash...

So...this pr makes that the python build make use of our libffi headers.

This would be a third solution to add to the ones proposed by @tito in #1605

**This solution avoids to patch python3 and will also work for python2**

!!!So many thanks @tito to found where the problem started :smile:!!!