### PR TITLE
Removed argument to cp that doesn't exist on macOS

### DIFF
--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -1,7 +1,7 @@
 from os.path import exists, join
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import info, shprint
-from pythonforandroid.util import current_directory
+from pythonforandroid.util import current_directory, ensure_dir
 from glob import glob
 import sh
 
@@ -87,8 +87,10 @@ class LibffiRecipe(Recipe):
             with current_directory(host_build):
                 shprint(cc, *cflags, _env=env)
 
-            shprint(sh.cp, '-t', self.ctx.get_libs_dir(arch.arch),
-                    join(host_build, '.libs', 'libffi.so'))
+            ensure_dir(self.ctx.get_libs_dir(arch.arch))
+            shprint(sh.cp,
+                    join(host_build, '.libs', 'libffi.so'),
+                    self.ctx.get_libs_dir(arch.arch))
 
     def get_include_dirs(self, arch):
         return [join(self.get_build_dir(arch.arch), self.get_host(arch),


### PR DESCRIPTION
Fixes https://github.com/kivy/python-for-android/issues/1569