### PR TITLE
Fix C code being wrong for python2 in start.c (char * to wchar_t *)

### DIFF
--- a/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
+++ b/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
@@ -152,7 +152,11 @@ int main(int argc, char *argv[]) {
   Py_NoSiteFlag=1;
 #endif
 
+#if PY_MAJOR_VERSION < 3
+  Py_SetProgramName("android_python");
+#else
   Py_SetProgramName(L"android_python");
+#endif
 
 #if PY_MAJOR_VERSION >= 3
   /* our logging module for android


### PR DESCRIPTION
Avoids warning for python2 when compiling libmain.so: `incompatible pointer types passing 'unsigned int [15]' to parameter of type 'char *' [-Wincompatible-pointer-types]`

**¡¡¡Thanks @inclement to find this issue!!!**