### PR TITLE
Made recipe graph resolution respect opt_depends

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -237,6 +237,12 @@ class Recipe(with_metaclass(RecipeMeta)):
                 recipes.append(recipe)
         return sorted(recipes)
 
+    def get_opt_depends_in_list(self, recipes):
+        '''Given a list of recipe names, returns those that are also in
+        self.opt_depends.
+        '''
+        return [recipe for recipe in recipes if recipe in self.opt_depends]
+
     def get_build_container_dir(self, arch):
         '''Given the arch name, returns the directory where it will be
         built.


### PR DESCRIPTION
This should fix the recipe ordering issue reported in https://github.com/kivy/python-for-android/issues/1590 and elsewhere.

I wanted to add a test case for this but couldn't actually find an input to the graph that resulted in an invalid ordering unless opt_depends were respected. The reason is that openssl and sqlite3 both have no dependencies, so the graph is already guaranteed (I think) to schedule them to be built before python3.

Nevertheless, opt_depends support was definitely broken and this should fix it. It must have been broken for a very long time, since I replaced the graph resolution. I guess complex opt_depends requirements don't come up that often.