### PR TITLE
Create a `dumb` librt recipe and refactor the affected recipes to make use of this

### DIFF
--- a/pythonforandroid/recipes/gevent/__init__.py
+++ b/pythonforandroid/recipes/gevent/__init__.py
@@ -1,30 +1,13 @@
 import re
-import os
-import sh
-from pythonforandroid.logger import info, shprint
+from pythonforandroid.logger import info
 from pythonforandroid.recipe import CythonRecipe
 
 
 class GeventRecipe(CythonRecipe):
     version = '1.3.7'
     url = 'https://pypi.python.org/packages/source/g/gevent/gevent-{version}.tar.gz'
-    depends = ['greenlet']
+    depends = ['librt', 'greenlet']
     patches = ["cross_compiling.patch"]
-
-    def build_cython_components(self, arch):
-        """
-        Hack to make it link properly to librt, inserted automatically by the
-        installer (Note: the librt doesn't exist in android but it is
-        integrated into libc, so we create a symbolic link which we will
-        remove when our build finishes)
-        """
-        link_c = os.path.join(self.ctx.ndk_platform, 'usr', 'lib', 'libc')
-        link_rt = os.path.join(self.ctx.ndk_platform, 'usr', 'lib', 'librt')
-        shprint(sh.ln, '-sf', link_c + '.so', link_rt + '.so')
-        shprint(sh.ln, '-sf', link_c + '.a', link_rt + '.a')
-        super(GeventRecipe, self).build_cython_components(arch)
-        shprint(sh.rm, link_rt + '.so')
-        shprint(sh.rm, link_rt + '.a')
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         """

--- a/pythonforandroid/recipes/librt/__init__.py
+++ b/pythonforandroid/recipes/librt/__init__.py
@@ -1,0 +1,36 @@
+import sh
+from os.path import join
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.logger import shprint
+
+
+class LibRt(Recipe):
+    '''
+    This is a dumb recipe. We may need this because some recipes inserted some
+    flags `-lrt` without our control, case of:
+
+        - :class:`~pythonforandroid.recipes.gevent.GeventRecipe`
+        - :class:`~pythonforandroid.recipes.lxml.LXMLRecipe`
+
+    .. note:: the librt doesn't exist in android but it is integrated into
+        libc, so we create a symbolic link which we will remove when our build
+        finishes'''
+
+    @property
+    def libc_path(self):
+        return join(self.ctx.ndk_platform, 'usr', 'lib', 'libc')
+
+    @property
+    def librt_path(self):
+        return join(self.ctx.ndk_platform, 'usr', 'lib', 'librt')
+
+    def build_arch(self, arch):
+        shprint(sh.ln, '-sf', self.libc_path + '.so', self.librt_path + '.so')
+        shprint(sh.ln, '-sf', self.libc_path + '.a', self.librt_path + '.a')
+
+    def postbuild_arch(self, arch):
+        shprint(sh.rm, self.librt_path + '.so')
+        shprint(sh.rm, self.librt_path + '.a')
+
+
+recipe = LibRt()

--- a/pythonforandroid/recipes/lxml/__init__.py
+++ b/pythonforandroid/recipes/lxml/__init__.py
@@ -1,14 +1,12 @@
 from pythonforandroid.recipe import Recipe, CompiledComponentsPythonRecipe
-from pythonforandroid.logger import shprint
 from os.path import exists, join
 from os import uname
-import sh
 
 
 class LXMLRecipe(CompiledComponentsPythonRecipe):
     version = '4.2.5'
     url = 'https://pypi.python.org/packages/source/l/lxml/lxml-{version}.tar.gz'  # noqa
-    depends = ['libxml2', 'libxslt', 'setuptools']
+    depends = ['librt', 'libxml2', 'libxslt', 'setuptools']
     name = 'lxml'
 
     call_hostpython_via_targetpython = False  # Due to setuptools
@@ -24,21 +22,6 @@ class LXMLRecipe(CompiledComponentsPythonRecipe):
         py_libs = ['_elementpath.so', 'builder.so', 'etree.so', 'objectify.so']
 
         return not all([exists(join(build_dir, lib)) for lib in py_libs])
-
-    def build_compiled_components(self, arch):
-        # Hack to make it link properly to librt, inserted automatically by the
-        # installer (Note: the librt doesn't exist in android but it is
-        # integrated into libc, so we create a symbolic link which we will
-        # remove when our build finishes)
-        link_c = join(self.ctx.ndk_platform, 'usr', 'lib', 'libc')
-        link_rt = join(self.ctx.ndk_platform, 'usr', 'lib', 'librt')
-        shprint(sh.ln, '-sf', link_c + '.so', link_rt + '.so')
-        shprint(sh.ln, '-sf', link_c + '.a', link_rt + '.a')
-
-        super(LXMLRecipe, self).build_compiled_components(arch)
-
-        shprint(sh.rm, '-r', link_rt + '.so')
-        shprint(sh.rm, '-r', link_rt + '.a')
 
     def get_recipe_env(self, arch):
         env = super(LXMLRecipe, self).get_recipe_env(arch)


### PR DESCRIPTION
Because some recipes inserts flags without our control (`-lrt`) and this is a problem because librt does not exist in android, but has been integrated into libc, so, this recipe create a temporary symbolic link from libc to librt so the compilation can find the necessary `symbols/functions` to finish the compilation

Note: Once we end the build we will remove the created symbolic link

¡¡¡Thanks @AndreMiras, for this idea of "dumb" librt recipe!!!