### PR TITLE
Fix librt recipe requires that NDK folder is writable

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -1,8 +1,9 @@
-from os.path import (exists, join, dirname, split)
-from os import environ, uname
-from glob import glob
-import sys
 from distutils.spawn import find_executable
+from os import environ, uname
+from os.path import (exists, join, dirname, split)
+from glob import glob
+import shlex
+import sys
 
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import BuildInterruptingException, build_platform
@@ -19,6 +20,12 @@ class Arch(object):
     def __init__(self, ctx):
         super(Arch, self).__init__()
         self.ctx = ctx
+
+        # Allows injecting additional linker paths used by any recipe.
+        # This can also be modified by recipes (like the librt recipe)
+        # to make sure that some sort of global resource is available &
+        # linked for all others.
+        self.extra_global_link_paths = []
 
     def __str__(self):
         return self.arch
@@ -56,7 +63,13 @@ class Arch(object):
             cflags.append('-gcc-toolchain {}'.format(toolchain))
 
         env['CFLAGS'] = ' '.join(cflags)
-        env['LDFLAGS'] = ' '
+
+        # Link the extra global link paths first before anything else
+        # (such that overriding system libraries with them is possible)
+        env['LDFLAGS'] = ' ' + " ".join([
+            "-L" + shlex.quote(l)
+            for l in self.extra_global_link_paths
+        ]) + ' '
 
         sysroot = join(self.ctx._ndk_dir, 'sysroot')
         if exists(sysroot):


### PR DESCRIPTION
This fixes that the librt recipe requires the NDK folder to be writable. The NDK folder can be installed system-wide and may not be writable, so without this fix the librt build crashes in such an environment. This fixes #1621 

Fixes the build for me! Feel free to test & merge! (or to tell me what to change)