### PR TITLE
Fix ctypes.util.find_library() not finding any libraries on Android

### DIFF
--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -21,6 +21,8 @@ class Python3Recipe(GuestPythonRecipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
+    patches = ["patches/fix-ctypes-util-find-library.patch"]
+
     depends = ['hostpython3']
     conflicts = ['python3crystax', 'python2', 'python2legacy']
 

--- a/pythonforandroid/recipes/python3/patches/fix-ctypes-util-find-library.patch
+++ b/pythonforandroid/recipes/python3/patches/fix-ctypes-util-find-library.patch
@@ -1,0 +1,23 @@
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -67,4 +67,19 @@
+                 return fname
+         return None
+ 
++# This patch overrides the find_library to look in the right places on
++# Android
++if True:
++    def find_library(name):
++        # Check the user app libs and system libraries directory:
++        app_root = os.path.normpath(os.path.abspath('../../'))
++        lib_search_dirs = [os.path.join(app_root, 'lib'), "/system/lib"]
++        for lib_dir in lib_search_dirs:
++            for filename in os.listdir(lib_dir):
++                if filename.endswith('.so') and (
++                        filename.startswith("lib" + name + ".") or
++                        filename.startswith(name + ".")):
++                    return os.path.join(lib_dir, filename)
++        return None
++
+ elif os.name == "posix" and sys.platform == "darwin":


### PR DESCRIPTION
This is finally my long-delayed followup to #1517 to fix `ctypes.util.find_library()` for Python 3. It should fix the last somewhat showstopper bug to using Python 3 & ctypes out of the box on p4a master :heart: 

done & tested (with real world python3 app that uses ctypes)