### PR TITLE
Fixes ifaddrs recipe, closes #1398

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -23,8 +23,6 @@ BROKEN_RECIPES_PYTHON2 = set([
     'flask',
     'groestlcoin_hash',
     'hostpython3crystax',
-    # https://github.com/kivy/python-for-android/issues/1398
-    'ifaddrs',
     # https://github.com/kivy/python-for-android/issues/1354
     'kivent_core', 'kivent_cymunk', 'kivent_particles', 'kivent_polygen',
     'kiwisolver',
@@ -68,8 +66,6 @@ BROKEN_RECIPES_PYTHON3 = set([
     # enum34 is not compatible with Python 3.6 standard library
     # https://stackoverflow.com/a/45716067/185510
     'enum34',
-    # https://github.com/kivy/python-for-android/issues/1398
-    'ifaddrs',
     # https://github.com/kivy/python-for-android/issues/1399
     'libglob',
     # cannot find -lcrystax

--- a/pythonforandroid/recipes/ifaddrs/__init__.py
+++ b/pythonforandroid/recipes/ifaddrs/__init__.py
@@ -8,19 +8,13 @@ from pythonforandroid.toolchain import current_directory
 
 
 class IFAddrRecipe(CompiledComponentsPythonRecipe):
-    version = 'master'
-    url = 'git+https://github.com/morristech/android-ifaddrs.git'
+    version = '8f9a87c'
+    url = 'https://github.com/morristech/android-ifaddrs/archive/{version}.zip'
     depends = [('hostpython2', 'hostpython3')]
 
     call_hostpython_via_targetpython = False
     site_packages_name = 'ifaddrs'
     generated_libraries = ['libifaddrs.so']
-
-    def should_build(self, arch):
-        """It's faster to build than check"""
-        return not (
-            exists(join(self.ctx.libs_dir, arch.arch, 'libifaddrs.so'))
-            and exists(join(self.ctx.get_python_install_dir(), 'lib' "libifaddrs.so")))
 
     def prebuild_arch(self, arch):
         """Make the build and target directories"""
@@ -39,30 +33,22 @@ class IFAddrRecipe(CompiledComponentsPythonRecipe):
             if not exists(path):
                 info("creating {}".format(path))
                 shprint(sh.mkdir, '-p', path)
-        cli = env['CC'].split()
-        cc = sh.Command(cli[0])
+        cli = env['CC'].split()[0]
+        # makes sure first CC command is the compiler rather than ccache, refs:
+        # https://github.com/kivy/python-for-android/issues/1398
+        if 'ccache' in cli:
+            cli = env['CC'].split()[1]
+        cc = sh.Command(cli)
 
         with current_directory(self.get_build_dir(arch.arch)):
             cflags = env['CFLAGS'].split()
             cflags.extend(['-I.', '-c', '-l.', 'ifaddrs.c', '-I.'])
             shprint(cc, *cflags, _env=env)
-
             cflags = env['CFLAGS'].split()
             cflags.extend(['-shared', '-I.', 'ifaddrs.o', '-o', 'libifaddrs.so'])
             cflags.extend(env['LDFLAGS'].split())
             shprint(cc, *cflags, _env=env)
-
             shprint(sh.cp, 'libifaddrs.so', self.ctx.get_libs_dir(arch.arch))
-            shprint(sh.cp, "libifaddrs.so", join(self.ctx.get_python_install_dir(), 'lib'))
-            # drop header in to the Python include directory
-            python_version = self.ctx.python_recipe.version[0:3]
-            shprint(sh.cp, "ifaddrs.h",
-                    join(
-                        self.ctx.get_python_install_dir(),
-                        'include/python{}'.format(python_version))
-           )
-            include_path = join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include')
-            shprint(sh.cp, "ifaddrs.h", include_path)
 
 
 recipe = IFAddrRecipe()


### PR DESCRIPTION
Makes sure the compiler is being used rather than ccache alone.
Also pin the commit version and use zip download rather than git clone.