### PR TITLE
Retry on download hiccups, refs #1306

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 before_install:
-  - sudo apt update -qq
-  - sudo apt install -qq --no-install-recommends python2.7 python3
+  - travis_retry sudo apt update -qq
+  - travis_retry sudo apt install -qq --no-install-recommends python2.7 python3
   - sudo pip install tox>=2.0
   # https://github.com/travis-ci/travis-ci/issues/6069#issuecomment-266546552
   - git remote set-branches --add origin master

--- a/Dockerfile.py2
+++ b/Dockerfile.py2
@@ -20,10 +20,14 @@ FROM ubuntu:18.04
 ENV ANDROID_HOME="/opt/android"
 
 RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends curl unzip \
-    && apt -y autoremove \
-    && apt -y clean
+    && apt -y install -qq --no-install-recommends curl unzip ca-certificates \
+    && apt -y autoremove
 
+# retry helper script, refs:
+# https://github.com/kivy/python-for-android/issues/1306
+ENV RETRY="retry -t 3 --"
+RUN curl https://raw.githubusercontent.com/kadwanev/retry/1.0.1/retry \
+    --output /usr/local/bin/retry && chmod +x /usr/local/bin/retry
 
 ENV ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk"
 ENV ANDROID_NDK_VERSION="17c"
@@ -34,7 +38,7 @@ ENV ANDROID_NDK_ARCHIVE="android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip"
 ENV ANDROID_NDK_DL_URL="https://dl.google.com/android/repository/${ANDROID_NDK_ARCHIVE}"
 
 # download and install Android NDK
-RUN curl --location --progress-bar --insecure \
+RUN ${RETRY} curl --location --progress-bar --insecure \
         "${ANDROID_NDK_DL_URL}" \
         --output "${ANDROID_NDK_ARCHIVE}" \
     && mkdir --parents "${ANDROID_NDK_HOME_V}" \
@@ -52,7 +56,7 @@ ENV ANDROID_SDK_TOOLS_ARCHIVE="sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip"
 ENV ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
 
 # download and install Android SDK
-RUN curl --location --progress-bar --insecure \
+RUN ${RETRY} curl --location --progress-bar --insecure \
         "${ANDROID_SDK_TOOLS_DL_URL}" \
         --output "${ANDROID_SDK_TOOLS_ARCHIVE}" \
     && mkdir --parents "${ANDROID_SDK_HOME}" \
@@ -65,10 +69,8 @@ RUN mkdir --parents "${ANDROID_SDK_HOME}/.android/" \
         > "${ANDROID_SDK_HOME}/.android/repositories.cfg"
 
 # accept Android licenses (JDK necessary!)
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends openjdk-8-jdk \
-    && apt -y autoremove \
-    && apt -y clean
+RUN ${RETRY} apt -y install -qq --no-install-recommends openjdk-8-jdk \
+    && apt -y autoremove
 RUN yes | "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" > /dev/null
 
 # download platforms, API, build tools
@@ -84,27 +86,23 @@ ENV WORK_DIR="${HOME_DIR}" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
 
 # install system dependencies
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
+RUN ${RETRY} apt -y install -qq --no-install-recommends \
         python virtualenv python-pip wget lbzip2 patch sudo \
-    && apt -y autoremove \
-    && apt -y clean
+    && apt -y autoremove
 
 # build dependencies
 # https://buildozer.readthedocs.io/en/latest/installation.html#android-on-ubuntu-16-04-64bit
 RUN dpkg --add-architecture i386 \
-    && apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
+    && ${RETRY} apt -y update -qq \
+    && ${RETRY} apt -y install -qq --no-install-recommends \
         build-essential ccache git python2.7 python2.7-dev \
         libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
         libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 \
         zip zlib1g-dev zlib1g:i386 \
-    && apt -y autoremove \
-    && apt -y clean
+    && apt -y autoremove
 
 # specific recipes dependencies (e.g. libffi requires autoreconf binary)
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
+RUN ${RETRY} apt -y install -qq --no-install-recommends \
         libffi-dev autoconf automake cmake gettext libltdl-dev libtool pkg-config \
     && apt -y autoremove \
     && apt -y clean


### PR DESCRIPTION
Also removed `apt -y clean` layer optimization introduced in df60061.
That way we could skip running `apt -y update` too many times which also
seems to have some issues recently on Travis.