### PR TITLE
Made build.py stop running if compileall failed

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -260,7 +260,13 @@ def compile_dir(dfn, optimize_python=True):
     if optimize_python:
         # -OO = strip docstrings
         args.insert(1, '-OO')
-    subprocess.call(args)
+    return_code = subprocess.call(args)
+
+    if return_code != 0:
+        print('Error while running "{}"'.format(' '.join(args)))
+        print('This probably means one of your Python files has a syntax '
+              'error, see logs above')
+        exit(1)
 
 
 def make_package(args):


### PR DESCRIPTION
Fixes https://github.com/kivy/python-for-android/issues/1009

This is important because if the compileall fails, no .pyc is generated and the file will be missing in the APK.