### PR TITLE
Made the activity launch mode default to singleTask

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -677,7 +677,9 @@ tools directory of the Android SDK.
                           'the appropriate environment variables.'))
     ap.add_argument('--add-activity', dest='add_activity', action='append',
                     help='Add this Java class as an Activity to the manifest.')
-    ap.add_argument('--activity-launch-mode', dest='activity_launch_mode',
+    ap.add_argument('--activity-launch-mode',
+                    dest='activity_launch_mode',
+                    default='singleTask',
                     help='Set the launch mode of the main activity in the manifest.')
     ap.add_argument('--allow-backup', dest='allow_backup', default='true',
                     help="if set to 'false', then android won't backup the application.")


### PR DESCRIPTION
Fixes https://github.com/kivy/python-for-android/issues/1271.

Using singleTask seems appropriate to make sure that our activity is not recreated, so new intents are passed to the existing activity if possible. Doc at https://developer.android.com/guide/topics/manifest/activity-element.