### PR TITLE
Fix linux hardcoded entry in archs.py

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -1,5 +1,5 @@
 from distutils.spawn import find_executable
-from os import environ, uname
+from os import environ
 from os.path import (exists, join, dirname, split)
 from glob import glob
 import sys
@@ -172,8 +172,8 @@ class Arch(object):
             'host' + self.ctx.python_recipe.name, self.ctx)
         env['BUILDLIB_PATH'] = join(
             hostpython_recipe.get_build_dir(self.arch),
-            'build', 'lib.linux-{}-{}'.format(
-                uname()[-1], self.ctx.python_recipe.major_minor_version_string)
+            'build', 'lib.{}-{}'.format(
+                build_platform, self.ctx.python_recipe.major_minor_version_string)
         )
 
         env['PATH'] = environ['PATH']


### PR DESCRIPTION
I forgot to include this in pr `Fix hardcoded entries (build platform) for core modules: archs and python` (#1597)

References: `Fix build platform hardcoded flags for archs.py` (f570def)