### PR TITLE
Speed up Python and NumPy compilation process

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -4,6 +4,7 @@ build our python3 and python2 recipes and his corresponding hostpython recipes.
 '''
 
 from os.path import dirname, exists, join
+from multiprocessing import cpu_count
 from shutil import copy2
 from os import environ
 import subprocess
@@ -250,7 +251,7 @@ class GuestPythonRecipe(TargetPythonRecipe):
                 py_version = self.major_minor_version_string
                 if self.major_minor_version_string[0] == '3':
                     py_version += 'm'
-                shprint(sh.make, 'all',
+                shprint(sh.make, 'all', '-j', str(cpu_count()),
                         'INSTSONAME=libpython{version}.so'.format(
                             version=py_version), _env=env)
 
@@ -420,7 +421,7 @@ class HostPythonRecipe(Recipe):
                 shprint(sh.cp, join('Modules', 'Setup.dist'),
                         join(build_dir, 'Modules', 'Setup'))
 
-                result = shprint(sh.make, '-C', build_dir)
+                result = shprint(sh.make, '-j', str(cpu_count()), '-C', build_dir)
         else:
             info('Skipping {name} ({version}) build, as it has already '
                  'been completed'.format(name=self.name, version=self.version))

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -1,4 +1,5 @@
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from multiprocessing import cpu_count
 from os.path import join
 
 
@@ -7,7 +8,6 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
     version = '1.15.1'
     url = 'https://pypi.python.org/packages/source/n/numpy/numpy-{version}.zip'
     site_packages_name = 'numpy'
-
     depends = [('python2', 'python3', 'python3crystax')]
 
     patches = [
@@ -17,6 +17,16 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
         join('patches', 'lib.patch'),
         join('patches', 'python-fixes.patch')
     ]
+
+    def build_compiled_components(self, arch):
+        self.setup_extra_args = ['-j', str(cpu_count())]
+        super(NumpyRecipe, self).build_compiled_components(arch)
+        self.setup_extra_args = []
+
+    def rebuild_compiled_components(self, arch, env):
+        self.setup_extra_args = ['-j', str(cpu_count())]
+        super(NumpyRecipe, self).rebuild_compiled_components(arch, env)
+        self.setup_extra_args = []
 
     def get_recipe_env(self, arch):
         env = super(NumpyRecipe, self).get_recipe_env(arch)
@@ -43,9 +53,6 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
         if flags not in env['LD']:
             env['LD'] += flags + ' -shared'
         return env
-
-    def prebuild_arch(self, arch):
-        super(NumpyRecipe, self).prebuild_arch(arch)
 
 
 recipe = NumpyRecipe()


### PR DESCRIPTION
Uses `-j` flag on target/host python as well as numpy to run compilation
in parallel. In Python an optimum number of jobs is guessed if the flag
is used alone. In NumPy it must be explicitly set.