### PR TITLE
Speed up Docker chown via COPY parameter

### DIFF
--- a/Dockerfile.py2
+++ b/Dockerfile.py2
@@ -119,10 +119,8 @@ RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN pip install --upgrade cython==0.28.6
 
 WORKDIR ${WORK_DIR}
-COPY . ${WORK_DIR}
-
-# user needs ownership/write access to these directories
-RUN chown --recursive ${USER} ${WORK_DIR} ${ANDROID_SDK_HOME}
+COPY --chown=user:user . ${WORK_DIR}
+RUN chown --recursive ${USER} ${ANDROID_SDK_HOME}
 USER ${USER}
 
 # install python-for-android from current branch

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -119,10 +119,8 @@ RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN pip3 install --upgrade cython==0.28.6
 
 WORKDIR ${WORK_DIR}
-COPY . ${WORK_DIR}
-
-# user needs ownership/write access to these directories
-RUN chown --recursive ${USER} ${WORK_DIR} ${ANDROID_SDK_HOME}
+COPY --chown=user:user . ${WORK_DIR}
+RUN chown --recursive ${USER} ${ANDROID_SDK_HOME}
 USER ${USER}
 
 # install python-for-android from current branch


### PR DESCRIPTION
For some reason running the `chown` command explicitly is hanging on
Docker. Using the `--chown` parameter in the `COPY` command is faster.
However that new method has a couple of drawbacks:
1) it was introduced in a recent Docker version 17+
2) it doesn't accept variables as argument, only hardcoded values

Also note that we don't need to chmod `ANDROID_SDK_HOME` anymore.