### PR TITLE
Feature/ticket1654 cffi unicode encode error

### DIFF
--- a/Dockerfile.py2
+++ b/Dockerfile.py2
@@ -19,6 +19,14 @@ FROM ubuntu:18.04
 
 ENV ANDROID_HOME="/opt/android"
 
+# configure locale
+RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
+    locales && \
+    locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 RUN apt -y update -qq \
     && apt -y install -qq --no-install-recommends curl unzip ca-certificates \
     && apt -y autoremove

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -6,7 +6,7 @@
 #     docker build --tag=p4a --file Dockerfile.py3 .
 #
 # Run with:
-#     docker run -it --rm p4apy3 /bin/sh -c '. venv/bin/activate && p4a apk --help'
+#     docker run -it --rm p4a /bin/sh -c '. venv/bin/activate && p4a apk --help'
 #
 # Or for interactive shell:
 #     docker run -it --rm p4a

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -19,6 +19,14 @@ FROM ubuntu:18.04
 
 ENV ANDROID_HOME="/opt/android"
 
+# configure locale
+RUN apt update -qq > /dev/null && apt install -qq --yes --no-install-recommends \
+    locales && \
+    locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 RUN apt -y update -qq \
     && apt -y install -qq --no-install-recommends curl unzip ca-certificates \
     && apt -y autoremove

--- a/ci/constants.py
+++ b/ci/constants.py
@@ -68,14 +68,15 @@ BROKEN_RECIPES_PYTHON3 = set([
     'enum34',
     # https://github.com/kivy/python-for-android/issues/1399
     'libglob',
-    # cannot find -lcrystax
-    'cffi', 'pycryptodome', 'pymuk', 'secp256k1',
+    # Could not fetch URL https://pypi.org/simple/pymuk/: 404 Client Error
+    'pymuk',
+    # build_dir = glob.glob('build/lib.*')[0]
+    # IndexError: list index out of range
+    'secp256k1',
     # https://github.com/kivy/python-for-android/issues/1404
     'cryptography',
     # https://github.com/kivy/python-for-android/issues/1294
     'ffmpeg', 'ffpyplayer',
-    # https://github.com/kivy/python-for-android/pull/1307 ?
-    'gevent',
     'icu',
     # https://github.com/kivy/python-for-android/issues/1354
     'kivent_core', 'kivent_cymunk', 'kivent_particles', 'kivent_polygen',

--- a/pythonforandroid/recipes/gevent/__init__.py
+++ b/pythonforandroid/recipes/gevent/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import CythonRecipe
 
 
 class GeventRecipe(CythonRecipe):
-    version = '1.3.7'
+    version = '1.4.0'
     url = 'https://pypi.python.org/packages/source/g/gevent/gevent-{version}.tar.gz'
     depends = ['librt', 'greenlet']
     patches = ["cross_compiling.patch"]

--- a/pythonforandroid/recipes/pycryptodome/__init__.py
+++ b/pythonforandroid/recipes/pycryptodome/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PycryptodomeRecipe(PythonRecipe):
-    version = '3.4.6'
+    version = '3.7.3'
     url = 'https://github.com/Legrandin/pycryptodome/archive/v{version}.tar.gz'
     depends = ['setuptools', 'cffi']
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,18 @@
+import unittest
+from mock import MagicMock
+from pythonforandroid import logger
+
+
+class TestShprint(unittest.TestCase):
+
+    def test_unicode_encode(self):
+        """
+        Makes sure `shprint()` can handle unicode command output.
+        Running the test with PYTHONIOENCODING=ASCII env would fail, refs:
+        https://github.com/kivy/python-for-android/issues/1654
+        """
+        expected_command_output = ["foo\xa0bar"]
+        command = MagicMock()
+        command.return_value = expected_command_output
+        output = logger.shprint(command, 'a1', k1='k1')
+        self.assertEqual(output, expected_command_output)


### PR DESCRIPTION
1)
Configure en_US.UTF-8 locale on Docker, closes #1654
Also unit tests how `shprint()` handles unicode command output.

2)
Update broken recipes list, refs #1514
Removed gevent, cffi and pycryptodome recipes from it since they now
compile fine. Also bumped few versions.