### PR TITLE
Fix various issues with graphs and recipes

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -49,7 +49,10 @@ class Bootstrap(object):
     dist_name = None
     distribution = None
 
-    recipe_depends = ['sdl2']
+    # All bootstraps should include Python in some way:
+    recipe_depends = [
+        ("python2", "python2legacy", "python3", "python3crystax"),
+    ]
 
     can_be_chosen_automatically = True
     '''Determines whether the bootstrap can be chosen as one that
@@ -167,7 +170,7 @@ class Bootstrap(object):
                 for recipe in recipes:
                     try:
                         recipe = Recipe.get_recipe(recipe, ctx)
-                    except IOError:
+                    except ValueError:
                         conflicts = []
                     else:
                         conflicts = recipe.conflicts
@@ -175,7 +178,7 @@ class Bootstrap(object):
                             for conflict in conflicts]):
                         ok = False
                         break
-                if ok:
+                if ok and bs not in acceptable_bootstraps:
                     acceptable_bootstraps.append(bs)
         info('Found {} acceptable bootstraps: {}'.format(
             len(acceptable_bootstraps),

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -566,7 +566,8 @@ tools directory of the Android SDK.
 
     # --private is required unless for sdl2, where there's also --launcher
     ap.add_argument('--private', dest='private',
-                    help='the dir of user files',
+                    help='the directory with the app source code files' +
+                         ' (containing your main.py entrypoint)',
                     required=(get_bootstrap_name() != "sdl2"))
     ap.add_argument('--package', dest='package',
                     help=('The name of the java package the project will be'

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -8,7 +8,9 @@ import sh
 class SDL2GradleBootstrap(Bootstrap):
     name = 'sdl2'
 
-    recipe_depends = ['sdl2']
+    recipe_depends = list(
+        set(Bootstrap.recipe_depends).union({'sdl2'})
+    )
 
     def run_distribute(self):
         info_main("# Creating Android project ({})".format(self.name))

--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -9,7 +9,9 @@ class ServiceOnlyBootstrap(Bootstrap):
 
     name = 'service_only'
 
-    recipe_depends = ['genericndkbuild', ('python2', 'python3', 'python3crystax')]
+    recipe_depends = list(
+        set(Bootstrap.recipe_depends).union({'genericndkbuild'})
+    )
 
     def run_distribute(self):
         info_main('# Creating Android project from build and {} bootstrap'.format(

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -7,7 +7,9 @@ import sh
 class WebViewBootstrap(Bootstrap):
     name = 'webview'
 
-    recipe_depends = ['genericndkbuild', ('python2', 'python3', 'python3crystax')]
+    recipe_depends = list(
+        set(Bootstrap.recipe_depends).union({'genericndkbuild'})
+    )
 
     def run_distribute(self):
         info_main('# Creating Android project from build and {} bootstrap'.format(

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -614,7 +614,7 @@ class ToolchainCL(object):
             for name in sorted(Recipe.list_recipes(ctx)):
                 try:
                     recipe = Recipe.get_recipe(name, ctx)
-                except IOError:
+                except (IOError, ValueError):
                     warning('Recipe "{}" could not be loaded'.format(name))
                 except SyntaxError:
                     import traceback

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -3,6 +3,7 @@ from os.path import exists, join
 from os import getcwd, chdir, makedirs, walk, uname
 import io
 import json
+import sh
 import shutil
 import sys
 from fnmatch import fnmatch
@@ -132,6 +133,17 @@ def which(program, path_env):
                 return exe_file
 
     return None
+
+
+def get_virtualenv_executable():
+    virtualenv = None
+    if virtualenv is None:
+        virtualenv = sh.which('virtualenv2')
+    if virtualenv is None:
+        virtualenv = sh.which('virtualenv-2.7')
+    if virtualenv is None:
+        virtualenv = sh.which('virtualenv')
+    return virtualenv
 
 
 def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,24 +1,74 @@
 from pythonforandroid.build import Context
-from pythonforandroid.graph import get_recipe_order_and_bootstrap
+from pythonforandroid.graph import (
+    fix_deplist, get_recipe_order_and_bootstrap, obvious_conflict_checker,
+)
 from pythonforandroid.bootstrap import Bootstrap
+from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import BuildInterruptingException
 from itertools import product
 
+import mock
 import pytest
-
 
 ctx = Context()
 
 name_sets = [['python2'],
              ['kivy']]
 bootstraps = [None,
-              Bootstrap.get_bootstrap('pygame', ctx),
               Bootstrap.get_bootstrap('sdl2', ctx)]
 valid_combinations = list(product(name_sets, bootstraps))
 valid_combinations.extend(
     [(['python3crystax'], Bootstrap.get_bootstrap('sdl2', ctx)),
-     (['kivy', 'python3crystax'], Bootstrap.get_bootstrap('sdl2', ctx))])
-invalid_combinations = [[['python2', 'python3crystax'], None]]
+     (['kivy', 'python3crystax'], Bootstrap.get_bootstrap('sdl2', ctx)),
+     (['flask'], Bootstrap.get_bootstrap('webview', ctx)),
+     (['pysdl2'], None),  # auto-detect bootstrap! important corner case
+    ]
+)
+invalid_combinations = [
+    [['python2', 'python3crystax'], None],
+    [['pysdl2', 'genericndkbuild'], None],
+]
+invalid_combinations_simple = list(invalid_combinations)
+# NOTE !! keep in mind when setting invalid_combinations_simple:
+#
+# This is used to test obvious_conflict_checker(), which only
+# catches CERTAIN conflicts:
+#
+# This must be a list of conflicts where the conflict is ONLY in
+# non-tuple/non-ambiguous dependencies, e.g.:
+#
+#     dependencies_1st = ["python2", "pillow"]
+#     dependencies_2nd = ["python3crystax", "pillow"]
+#
+# This however won't work:
+#
+#     dependencies_1st = [("python2", "python3"), "pillow"]
+#     dependencies_2nd = [("python2legacy", "python3crystax"), "pillow"]
+#
+# (This is simply because the conflict checker doesn't resolve this to
+# keep the code ismple enough)
+
+
+def get_fake_recipe(name, depends=None, conflicts=None):
+    recipe = mock.Mock()
+    recipe.name = name
+    recipe.get_opt_depends_in_list = lambda: []
+    recipe.get_dir_name = lambda: name
+    recipe.depends = list(depends or [])
+    recipe.conflicts = list(conflicts or [])
+    return recipe
+
+
+def register_fake_recipes_for_test(monkeypatch, recipe_list):
+    _orig_get_recipe = Recipe.get_recipe
+
+    def mock_get_recipe(name, ctx):
+        for recipe in recipe_list:
+            if recipe.name == name:
+                return recipe
+        return _orig_get_recipe(name, ctx)
+    # Note: staticmethod() needed for python ONLY, don't ask me why:
+    monkeypatch.setattr(Recipe, 'get_recipe', staticmethod(mock_get_recipe))
 
 
 @pytest.mark.parametrize('names,bootstrap', valid_combinations)
@@ -30,16 +80,114 @@ def test_valid_recipe_order_and_bootstrap(names, bootstrap):
 def test_invalid_recipe_order_and_bootstrap(names, bootstrap):
     with pytest.raises(BuildInterruptingException) as e_info:
         get_recipe_order_and_bootstrap(ctx, names, bootstrap)
-    assert e_info.value.message == (
-        "Didn't find any valid dependency graphs. "
-        "This means that some of your requirements pull in conflicting dependencies."
+    assert "conflict" in e_info.value.message.lower()
+
+
+@pytest.mark.parametrize('names,bootstrap', valid_combinations)
+def test_valid_obvious_conflict_checker(names, bootstrap):
+    # Note: obvious_conflict_checker is stricter on input
+    # (needs fix_deplist) than get_recipe_order_and_bootstrap!
+    obvious_conflict_checker(ctx, fix_deplist(names))
+
+
+@pytest.mark.parametrize('names,bootstrap',
+                         invalid_combinations_simple  # see above for why this
+                        )                             # is a separate list
+def test_invalid_obvious_conflict_checker(names, bootstrap):
+    # Note: obvious_conflict_checker is stricter on input
+    # (needs fix_deplist) than get_recipe_order_and_bootstrap!
+    with pytest.raises(BuildInterruptingException) as e_info:
+        obvious_conflict_checker(ctx, fix_deplist(names))
+    assert "conflict" in e_info.value.message.lower()
+
+
+def test_misc_obvious_conflict_checker(monkeypatch):
+    # Check that the assert about wrong input data is hit:
+    with pytest.raises(AssertionError) as e_info:
+        obvious_conflict_checker(
+            ctx,
+            ["this_is_invalid"]
+            # (invalid because it isn't properly nested as tuple)
+        )
+
+    # Test that non-recipe dependencies work in overall:
+    obvious_conflict_checker(
+        ctx, fix_deplist(["python3", "notarecipelibrary"])
     )
+
+    # Test that a conflict with a non-recipe dependency works:
+    # This is currently not used, so we need a custom test recipe:
+    # To get that, we simply modify one!
+    with monkeypatch.context() as m:
+        register_fake_recipes_for_test(m, [
+            get_fake_recipe("recipe1", conflicts=[("fakelib")]),
+        ])
+        with pytest.raises(BuildInterruptingException) as e_info:
+            obvious_conflict_checker(ctx, fix_deplist(["recipe1", "fakelib"]))
+        assert "conflict" in e_info.value.message.lower()
+
+    # Test a case where a recipe pulls in a conditional tuple
+    # of additional dependencies. This is e.g. done for ('python3',
+    # 'python2', ...) but most recipes don't depend on this anymore,
+    # so we need to add a manual test for this case:
+    with monkeypatch.context() as m:
+        register_fake_recipes_for_test(m, [
+            get_fake_recipe("recipe1", depends=[("libffi", "Pillow")]),
+        ])
+        obvious_conflict_checker(ctx, fix_deplist(["recipe1"]))
+
+
+def test_indirectconflict_obvious_conflict_checker(monkeypatch):
+    # Test a case where there's an indirect conflict, which also
+    # makes sure the error message correctly blames the OUTER recipes
+    # as original conflict source:
+    with monkeypatch.context() as m:
+        register_fake_recipes_for_test(m, [
+            get_fake_recipe("outerrecipe1", depends=["innerrecipe1"]),
+            get_fake_recipe("outerrecipe2", depends=["innerrecipe2"]),
+            get_fake_recipe("innerrecipe1"),
+            get_fake_recipe("innerrecipe2", conflicts=["innerrecipe1"]),
+        ])
+        with pytest.raises(BuildInterruptingException) as e_info:
+            obvious_conflict_checker(
+                ctx,
+                fix_deplist(["outerrecipe1", "outerrecipe2"])
+            )
+        assert ("conflict" in e_info.value.message.lower() and
+                "outerrecipe1" in e_info.value.message.lower() and
+                "outerrecipe2" in e_info.value.message.lower())
+
+
+def test_multichoice_obvious_conflict_checker(monkeypatch):
+    # Test a case where there's a conflict with a multi-choice tuple:
+    with monkeypatch.context() as m:
+        register_fake_recipes_for_test(m, [
+            get_fake_recipe("recipe1", conflicts=["lib1", "lib2"]),
+            get_fake_recipe("recipe2", depends=[("lib1", "lib2")]),
+        ])
+        with pytest.raises(BuildInterruptingException) as e_info:
+            obvious_conflict_checker(
+                ctx,
+                fix_deplist([("lib1", "lib2"), "recipe1"])
+            )
+        assert "conflict" in e_info.value.message.lower()
 
 
 def test_bootstrap_dependency_addition():
     build_order, python_modules, bs = get_recipe_order_and_bootstrap(
         ctx, ['kivy'], None)
     assert (('hostpython2' in build_order) or ('hostpython3' in build_order))
+
+
+def test_graph_deplist_transformation():
+    test_pairs = [
+        (["Pillow", ('python2', 'python3')],
+         [('pillow',), ('python2', 'python3')]),
+        (["Pillow", ('python2',)],
+         [('pillow',), ('python2',)]),
+    ]
+    for (before_list, after_list) in test_pairs:
+        assert fix_deplist(before_list) == after_list
 
 
 def test_bootstrap_dependency_addition2():

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -37,7 +37,7 @@ class TestRecipe(unittest.TestCase):
         self.assertTrue(isinstance(recipe, Recipe))
         self.assertEqual(recipe.name, recipe_name)
         recipe_name = 'does_not_exist'
-        with self.assertRaises(IOError) as e:
+        with self.assertRaises(ValueError) as e:
             Recipe.get_recipe(recipe_name, ctx)
         self.assertEqual(
             e.exception.args[0], 'Recipe does not exist: {}'.format(recipe_name))


### PR DESCRIPTION
- fix graph depending on capitalization of dependency/recipe names when pip doesn't
- fix graph giving no useful errors for conflicts (now it gives them sometimes)
- fix graph entering infinite loop when no bootstrap is found
- fix recipe not being obtainable irregardless of capitalization
- fix recipe IOError-on-doesn't-exist not distinguishable from
  recipe-exists-but-code-messes-up-and-causes-unintentional-IOError.
  a non-existent recipe will now cause a ValueError
- fix the bootstraps' own dependencies being wrong and unused
- change preferred default from `python2` + `sdl2` to `python3` + `sdl2`
- possibly other minor fixes I forgot about

(some of these fixes are required for #1625 / project's `setup.py` to be reasonably used)