### PR TITLE
Fix zope_interface and add python3 compatibility

### DIFF
--- a/pythonforandroid/recipes/zope_interface/__init__.py
+++ b/pythonforandroid/recipes/zope_interface/__init__.py
@@ -1,5 +1,6 @@
 from pythonforandroid.recipe import PythonRecipe
 from pythonforandroid.toolchain import current_directory
+from os.path import join
 import sh
 
 
@@ -9,9 +10,17 @@ class ZopeInterfaceRecipe(PythonRecipe):
     version = '4.1.3'
     url = 'https://pypi.python.org/packages/source/z/zope.interface/zope.interface-{version}.tar.gz'
     site_packages_name = 'zope.interface'
-
-    depends = [('python2', 'python3crystax')]
+    depends = ['setuptools']
     patches = ['no_tests.patch']
+
+    def build_arch(self, arch):
+        super(ZopeInterfaceRecipe, self).build_arch(arch)
+        # The zope.interface module lacks of the __init__.py file in one of his
+        # folders (once is installed), that leads into an ImportError.
+        # Here we intentionally apply a patch to solve that, so, in case that
+        # this is solved in the future an error will be triggered
+        zope_install = join(self.ctx.get_site_packages_dir(arch.arch), 'zope')
+        self.apply_patch('fix-init.patch', arch.arch, build_dir=zope_install)
 
     def prebuild_arch(self, arch):
         super(ZopeInterfaceRecipe, self).prebuild_arch(arch)

--- a/pythonforandroid/recipes/zope_interface/fix-init.patch
+++ b/pythonforandroid/recipes/zope_interface/fix-init.patch
@@ -1,0 +1,9 @@
+The zope.interface module lacks of the __init__.py file in `zope` folder
+(once is installed), this patch creates that missing file. This seems to be
+caused during the installation process because that file exists in source
+files.
+diff -Naurp zope.orig/__init__.py zope/__init__.py
+--- zope.orig/__init__.py	1970-01-01 01:00:00.000000000 +0100
++++ zope/__init__.py	2019-02-05 11:29:22.666757227 +0100
+@@ -0,0 +1 @@
++ 


### PR DESCRIPTION
The `zope.interface` module lacks of the `__init__.py` file in one of his folders, that leads into:

`ImportError: No module named zope.interface`