### PR TITLE
[WIP] Fix `configure` for python's recipes when building from macOS

### DIFF
--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -2,6 +2,7 @@ from os.path import join, exists
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.python import GuestPythonRecipe
 from pythonforandroid.logger import shprint
+from pythonforandroid.patching import is_darwin
 import sh
 
 
@@ -31,7 +32,8 @@ class Python2Recipe(GuestPythonRecipe):
                'patches/fix-filesystem-default-encoding.patch',
                'patches/fix-gethostbyaddr.patch',
                'patches/fix-posix-declarations.patch',
-               'patches/fix-pwd-gecos.patch']
+               'patches/fix-pwd-gecos.patch',
+               ('patches/fix-configure-darwin.patch', is_darwin)]
 
     configure_args = ('--host={android_host}',
                       '--build={android_build}',

--- a/pythonforandroid/recipes/python2/patches/fix-configure-darwin.patch
+++ b/pythonforandroid/recipes/python2/patches/fix-configure-darwin.patch
@@ -1,0 +1,40 @@
+--- Python-2.7.15/configure.orig	2018-04-30 00:47:33.000000000 +0200
++++ Python-2.7.15/configure	2019-02-06 00:44:09.636369760 +0100
+@@ -5481,7 +5481,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>
+ 	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ 	  INSTSONAME="$LDLIBRARY".$SOVERSION
+           ;;
+-    Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
++    Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*|Darwin*)
+ 	  LDLIBRARY='libpython$(VERSION).so'
+ 	  BLDLIBRARY='-L. -lpython$(VERSION)'
+ 	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+@@ -5514,7 +5514,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>
+ 	  BLDLIBRARY='-L. -lpython$(VERSION)'
+ 	  RUNSHARED=DLL_PATH=`pwd`:${DLL_PATH:-/atheos/sys/libs:/atheos/autolnk/lib}
+ 	  ;;
+-    Darwin*)
++    DDarwin*)
+     	LDLIBRARY='libpython$(VERSION).dylib'
+ 	BLDLIBRARY='-L. -lpython$(VERSION)'
+ 	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
+@@ -8594,6 +8594,9 @@ then
+ 			LDSHARED='ld -b'
+ 		fi ;;
+ 	OSF*) LDSHARED="ld -shared -expect_unresolved \"*\"";;
++	Darwin*|Linux*|GNU*|QNX*)
++		LDSHARED='$(CC) -shared'
++		LDCXXSHARED='$(CXX) -shared';;
+ 	Darwin/1.3*)
+ 		LDSHARED='$(CC) -bundle'
+ 		LDCXXSHARED='$(CXX) -bundle'
+@@ -8653,9 +8656,6 @@ then
+ 			BLDSHARED="$LDSHARED"
+ 		fi
+ 		;;
+-	Linux*|GNU*|QNX*)
+-		LDSHARED='$(CC) -shared'
+-		LDCXXSHARED='$(CXX) -shared';;
+ 	BSD/OS*/4*)
+ 		LDSHARED="gcc -shared"
+ 		LDCXXSHARED="g++ -shared";;

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,5 +1,6 @@
 from pythonforandroid.python import GuestPythonRecipe
 from pythonforandroid.recipe import Recipe
+from pythonforandroid.patching import is_darwin
 
 
 class Python3Recipe(GuestPythonRecipe):
@@ -21,7 +22,8 @@ class Python3Recipe(GuestPythonRecipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
-    patches = ["patches/fix-ctypes-util-find-library.patch"]
+    patches = ['patches/fix-ctypes-util-find-library.patch',
+               ('patches/fix-configure-darwin.patch', is_darwin)]
 
     depends = ['hostpython3']
     conflicts = ['python3crystax', 'python2', 'python2legacy']

--- a/pythonforandroid/recipes/python3/patches/fix-configure-darwin.patch
+++ b/pythonforandroid/recipes/python3/patches/fix-configure-darwin.patch
@@ -1,0 +1,72 @@
+--- Python-3.7.1/configure.orig	2018-10-20 08:04:19.000000000 +0200
++++ Python-3.7.1/configure	2019-02-06 00:56:36.200362640 +0100
+@@ -5916,7 +5916,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>
+ 	      PY3LIBRARY=libpython3.so
+ 	  fi
+           ;;
+-    Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
++    Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*|Darwin*)
+ 	  LDLIBRARY='libpython$(LDVERSION).so'
+ 	  BLDLIBRARY='-L. -lpython$(LDVERSION)'
+ 	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+@@ -5938,7 +5938,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>
+ 	  BLDLIBRARY='-Wl,+b,$(LIBDIR) -L. -lpython$(LDVERSION)'
+ 	  RUNSHARED=SHLIB_PATH=`pwd`${SHLIB_PATH:+:${SHLIB_PATH}}
+ 	  ;;
+-    Darwin*)
++    DDarwin*)
+     	LDLIBRARY='libpython$(LDVERSION).dylib'
+ 	BLDLIBRARY='-L. -lpython$(LDVERSION)'
+ 	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
+@@ -9252,6 +9252,9 @@ then
+ 			LDSHARED='$(CC) -b'
+ 			LDCXXSHARED='$(CXX) -b'
+ 		fi ;;
++	Darwin*|Linux*|GNU*|QNX*)
++		LDSHARED='$(CC) -shared'
++		LDCXXSHARED='$(CXX) -shared';;
+ 	Darwin/1.3*)
+ 		LDSHARED='$(CC) -bundle'
+ 		LDCXXSHARED='$(CXX) -bundle'
+@@ -9279,41 +9282,6 @@ then
+ 			LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+ 			LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+ 		fi ;;
+-	Darwin/*)
+-		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
+-		# This allows an extension to be used in any Python
+-
+-		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
+-				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
+-		dep_target_minor=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
+-				sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
+-		if test ${dep_target_major} -eq 10 && \
+-		   test ${dep_target_minor} -le 2
+-		then
+-			# building for OS X 10.0 through 10.2
+-			LDSHARED='$(CC) -bundle'
+-			LDCXXSHARED='$(CXX) -bundle'
+-			if test "$enable_framework" ; then
+-				# Link against the framework. All externals should be defined.
+-				BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+-				LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+-				LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+-			else
+-				# No framework, use the Python app as bundle-loader
+-				BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
+-				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+-				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+-			fi
+-		else
+-			# building for OS X 10.3 and later
+-			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
+-			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
+-			BLDSHARED="$LDSHARED"
+-		fi
+-		;;
+-	Linux*|GNU*|QNX*)
+-		LDSHARED='$(CC) -shared'
+-		LDCXXSHARED='$(CXX) -shared';;
+ 	FreeBSD*)
+ 		if [ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]
+ 		then


### PR DESCRIPTION
**This is a long shot**

This pr is made in order to try to solve the linkage problems that we have when using a macOS as a host system.

Here I migrate a macOS's patch from python2legacy's recipe that we need in order to successfully link when building from a macOS. I suspect that we still may need that for the new python recipes...so ...I think that this pr may solve the linkage problems that we currently have, described in  here #1647.

Unfortunately I couldn't test this (I haven't a macOS to test it)...so...

**this should not be merged unless we can confirm that actually solves the problem**