### PR TITLE
Implement --blacklist option and include more modules/recipes by default

### DIFF
--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -12,8 +12,8 @@ Runtime permissions
 With API level >= 21, you will need to request runtime permissions
 to access the SD card, the camera, and other things.
 
-This can be done through the `android` module, just add it to
-your `--requirements` (as `android`) and then use it in your app like this::
+This can be done through the `android` module which is *available per default*
+unless you blacklist it. Use it in your app like this::
 
       from android.permissions import request_permission, Permission
       request_permission(Permission.WRITE_EXTERNAL_STORAGE)
@@ -34,8 +34,8 @@ longer than necessary (with your app already being loaded) due to a
 limitation with the way we check if the app has properly started.
 In this case, the splash screen overlaps the app gui for a short time.
 
-To dismiss the loading screen explicitely in your code, add p4a's `android`
-module to your `--requirements` and use this::
+To dismiss the loading screen explicitely in your code, use the `android`
+module::
 
   from android import hide_loading_screen
   hide_loading_screen()
@@ -92,14 +92,14 @@ Under SDL2, you can handle the `appropriate events <https://wiki.libsdl.org/SDL_
 Advanced Android API use
 ------------------------
 
+.. _reference-label-for-android-module:
+
 `android` for Android API access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As mentioned above, the ``android`` Python module provides a simple 
-wrapper around many native Android APIS, and it can be included by
-adding it to your requirements, e.g. :code:`--requirements=kivy,android`.
-It is not automatically included by Kivy unless you use the old (Pygame)
-bootstrap.
+wrapper around many native Android APIS, and it is *included per default*
+unless you blacklist it.
 
 The available functionality of this module is not separately documented.
 You can read the source `on
@@ -136,7 +136,7 @@ This is obviously *much* less verbose than with Pyjnius!
 
 
 `Pyjnius` - raw lowlevel API access
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pyjnius lets you call the Android API directly from Python Pyjnius is
 works by dynamically wrapping Java classes, so you don't have to wait

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -243,3 +243,25 @@ options (this list may not be exhaustive):
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--compile-pyo``: Optimise .py files to .pyo.
 - ``--resource``: A key=value pair to add in the string.xml resource file.
+
+
+Blacklist (APK size optimization)
+---------------------------------
+
+To optimize the size of the `.apk` file that p4a builds for you,
+you can **blacklist** certain core components. Per default, p4a
+will add python *with batteries included* as would be expected on
+desktop, including openssl, sqlite3 and other components you may
+not use.
+
+To blacklist an item, specify the ``--blacklist`` option::
+
+    p4a apk ... --blacklist=sqlite3
+
+At the moment, the following core components can be blacklisted
+(if you don't want to use them) to decrease APK size:
+
+- ``android``  disables p4a's android module (see :ref:`reference-label-for-android-module`)
+- ``libffi``  disables ctypes stdlib module
+- ``openssl``   disables ssl stdlib module
+- ``sqlite3``   disables sqlite3 stdlib module

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -149,18 +149,34 @@ You have the possibility to configure on any command the PATH to the SDK, NDK an
 Usage
 -----
 
-Build a Kivy application
-~~~~~~~~~~~~~~~~~~~~~~~~
+Build a Kivy or SDL2 application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To build your application, you need to have a name, version, a package
-identifier, and explicitly write the bootstrap you want to use, as
-well as the requirements::
+To build your application, you need to specify name, version, a package
+identifier, the bootstrap you want to use (`sdl2` for kivy or sdl2 apps)
+and the requirements::
 
-    p4a apk --private $HOME/code/myapp --package=org.example.myapp --name "My application" --version 0.1 --bootstrap=sdl2 --requirements=python2,kivy
+    p4a apk --private $HOME/code/myapp --package=org.example.myapp --name "My application" --version 0.1 --bootstrap=sdl2 --requirements=python3,kivy
 
-This will first build a distribution that contains `python2` and `kivy`, and using a SDL2 bootstrap. Python2 is here explicitely written as kivy can work with python2 or python3.
+**Note on `--requirements`: you must add all
+libraries/dependencies your app needs to run.**
+Example: `--requirements=python3,kivy,vispy`. For an SDL2 app,
+`kivy` is not needed, but you need to add any wrappers you might
+use (e.g. `pysdl2`).
 
-You can also use ``--bootstrap=pygame``, but this bootstrap is deprecated for use with Kivy and SDL2 is preferred.
+This `p4a apk ...` command builds a distribution with `python3`,
+`kivy`, and everything else you specified in the requirements.
+It will be packaged using a SDL2 bootstrap, and produce
+an `.apk` file.
+
+*Compatibility notes:*
+
+- While python2 is still supported by python-for-android,
+  it will possibly no longer receive patches by the python creators
+  themselves in 2020. Migration to Python 3 is recommended!
+
+- You can also use ``--bootstrap=pygame``, but this bootstrap
+  is deprecated and not well-tested.
 
 Build a WebView application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -171,25 +187,13 @@ well as the requirements::
 
     p4a apk --private $HOME/code/myapp --package=org.example.myapp --name "My WebView Application" --version 0.1 --bootstrap=webview --requirements=flask --port=5000
 
+**Please note as with kivy/SDL2, you need to specify all your
+additional requirements/depenencies.**
+
 You can also replace flask with another web framework.
 
 Replace ``--port=5000`` with the port on which your app will serve a
 website. The default for Flask is 5000.
-
-Build an SDL2 based application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This includes e.g. `PySDL2
-<https://pysdl2.readthedocs.io/en/latest/>`__.
-
-To build your application, you need to have a name, version, a package
-identifier, and explicitly write the sdl2 bootstrap, as well as the
-requirements::
-
-    p4a apk --private $HOME/code/myapp --package=org.example.myapp --name "My SDL2 application" --version 0.1 --bootstrap=sdl2 --requirements=your_requirements
-
-Add your required modules in place of ``your_requirements``,
-e.g. ``--requirements=pysdl2`` or ``--requirements=vispy``.
 
 Other options
 ~~~~~~~~~~~~~
@@ -198,7 +202,7 @@ You can pass other command line arguments to control app behaviours
 such as orientation, wakelock and app permissions. See
 :ref:`bootstrap_build_options`.
 
-    
+
 
 Rebuild everything
 ~~~~~~~~~~~~~~~~~~
@@ -206,11 +210,11 @@ Rebuild everything
 If anything goes wrong and you want to clean the downloads and builds to retry everything, run::
 
     p4a clean_all
-    
+
 If you just want to clean the builds to avoid redownloading dependencies, run::
 
     p4a clean_builds && p4a clean_dists
-    
+
 Getting help
 ~~~~~~~~~~~~
 
@@ -269,7 +273,7 @@ You can list the available distributions::
 And clean all of them::
 
     p4a clean_dists
-    
+
 Configuration file
 ~~~~~~~~~~~~~~~~~~
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -52,6 +52,7 @@ class Bootstrap(object):
     # All bootstraps should include Python in some way:
     recipe_depends = [
         ("python2", "python2legacy", "python3", "python3crystax"),
+        'android',
     ]
 
     can_be_chosen_automatically = True

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -23,7 +23,7 @@ class Python3Recipe(GuestPythonRecipe):
 
     patches = ["patches/fix-ctypes-util-find-library.patch"]
 
-    depends = ['hostpython3']
+    depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
     conflicts = ['python3crystax', 'python2', 'python2legacy']
 
     configure_args = (


### PR DESCRIPTION
This is another subpart split out of my misguidedly oversized #1625 (`setup.py`) pull request.

Changes:

- Adds `--blacklist` option that prevents recipes/packages from being added even though they are in the `depends` of recipes or otherwise added
- Makes the following modules included per default: `android` (via `bootstrap.py` dependency of all bootstraps), `openssl`/`libffi`/`sqlite3` (via `python3` recipe dependency)
- Documents `--blacklist` option and that `android` is now included by default
- Cleans up the packaging kivy/sdl2 apps part in the Quickstart section a little