### PR TITLE
Downgrade to pycryptodome==3.6.3

### DIFF
--- a/pythonforandroid/recipes/pycryptodome/__init__.py
+++ b/pythonforandroid/recipes/pycryptodome/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PycryptodomeRecipe(PythonRecipe):
-    version = '3.7.3'
+    version = '3.6.3'
     url = 'https://github.com/Legrandin/pycryptodome/archive/v{version}.tar.gz'
     depends = ['setuptools', 'cffi']
 


### PR DESCRIPTION
The latest version was leading to compilation errors.
Tested OK with:
```
python setup_testapp_python3.py apk --sdk-dir $ANDROID_SDK_HOME
--ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements
python3,kivy,pycryptodome==3.6.3
```