### PR TITLE
Rename misguided shadowing --blacklist to --blacklist-requirements

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -245,8 +245,8 @@ options (this list may not be exhaustive):
 - ``--resource``: A key=value pair to add in the string.xml resource file.
 
 
-Blacklist (APK size optimization)
----------------------------------
+Requirements blacklist (APK size optimization)
+----------------------------------------------
 
 To optimize the size of the `.apk` file that p4a builds for you,
 you can **blacklist** certain core components. Per default, p4a
@@ -254,9 +254,9 @@ will add python *with batteries included* as would be expected on
 desktop, including openssl, sqlite3 and other components you may
 not use.
 
-To blacklist an item, specify the ``--blacklist`` option::
+To blacklist an item, specify the ``--blacklist-requirements`` option::
 
-    p4a apk ... --blacklist=sqlite3
+    p4a apk ... --blacklist-requirements=sqlite3
 
 At the moment, the following core components can be blacklisted
 (if you don't want to use them) to decrease APK size:

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -171,7 +171,7 @@ def build_dist_from_args(ctx, dist, args):
     """Parses out any bootstrap related arguments, and uses them to build
     a dist."""
     bs = Bootstrap.get_bootstrap(args.bootstrap, ctx)
-    blacklist = getattr(args, "blacklist", "").split(",")
+    blacklist = getattr(args, "blacklist_requirements", "").split(",")
     if len(blacklist) == 1 and blacklist[0] == "":
         blacklist = []
     build_order, python_modules, bs = (
@@ -310,10 +310,10 @@ class ToolchainCL(object):
             default='')
 
         generic_parser.add_argument(
-            '--blacklist',
+            '--blacklist-requirements',
             help=('Blacklist an internal recipe from use. Allows '
                   'disabling Python 3 core modules to save size'),
-            dest="blacklist",
+            dest="blacklist_requirements",
             default='')
 
         generic_parser.add_argument(


### PR DESCRIPTION
Rename misguided shadowing --blacklist to --blacklist-requirements.

Merging this only makes sense if you want to keep the blacklist functionality of course, see discussion in #1683