### PR TITLE
FIX: copy additional jar files into the correct libs directory

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -341,7 +341,7 @@ main.py that loads it.''')
             if not exists(jarname):
                 print('Requested jar does not exist: {}'.format(jarname))
                 sys.exit(-1)
-            shutil.copy(jarname, 'libs')
+            shutil.copy(jarname, 'src/main/libs')
             jars.append(basename(jarname))
 
     # If extra aar were requested, copy them into the libs directory


### PR DESCRIPTION
This fixes the issue where additional jar files specified in the buildozer spec at `android.add_jars` aren't copied to the correct build directory resulting in a failed build attempt.