### PR TITLE
Make testapps use python3 per default and adapt to `blacklist-requirements`

### DIFF
--- a/testapps/setup_keyboard.py
+++ b/testapps/setup_keyboard.py
@@ -3,8 +3,10 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'sdl2,pyjnius,kivy,python2',
-                   'android-api': 19,
+                   'requirements': 'sdl2,pyjnius,kivy,python3',
+                   'blacklist-requirements': 'openssl,sqlite3',
+                   'android-api': 27,
+                   'ndk-api': 21,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest',
                    'ndk-version': '10.3.2',

--- a/testapps/setup_testapp_flask.py
+++ b/testapps/setup_testapp_flask.py
@@ -3,7 +3,8 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'python2,flask,pyjnius',
+                   'requirements': 'python3,flask,pyjnius',
+                   'blacklist-requirements': 'openssl,sqlite3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',

--- a/testapps/setup_testapp_python3.py
+++ b/testapps/setup_testapp_python3.py
@@ -2,7 +2,8 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'requirements': 'libffi,sdl2,numpy,pyjnius,kivy,python3',
+options = {'apk': {'requirements': 'sdl2,numpy,pyjnius,kivy,python3',
+                   'blacklist-requirements': 'openssl,sqlite3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_googlendk',

--- a/testapps/setup_testapp_python3_sqlite_openssl.py
+++ b/testapps/setup_testapp_python3_sqlite_openssl.py
@@ -2,8 +2,7 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'requirements': 'libffi,openssl,sqlite3,requests,peewee,'
-                                   'sdl2,pyjnius,kivy,python3',
+options = {'apk': {'requirements': 'requests,peewee,sdl2,pyjnius,kivy,python3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_python3_sqlite_openssl_googlendk',

--- a/testapps/setup_testapp_python_encryption.py
+++ b/testapps/setup_testapp_python_encryption.py
@@ -2,9 +2,10 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-options = {'apk': {'requirements': 'libffi,openssl,sdl2,pyjnius,kivy,python2,'
-                                   'cryptography,pycrypto,scrypt,m2crypto,'
-                                   'pysha3,pycryptodome,libtorrent',
+options = {'apk': {'requirements': 'sdl2,pyjnius,kivy,python3,cryptography,'
+                                   'pycrypto,scrypt,m2crypto,pysha3,'
+                                   'pycryptodome,libtorrent',
+                   'blacklist-requirements': 'sqlite3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'dist-name': 'bdisttest_encryption',

--- a/testapps/setup_testapp_service.py
+++ b/testapps/setup_testapp_service.py
@@ -3,7 +3,8 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'python2,genericndkbuild,pyjnius',
+                   'requirements': 'python3,genericndkbuild,pyjnius',
+                   'blacklist-requirements': 'openssl,sqlite3',
                    'android-api': 27,
                    'ndk-api': 21,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',

--- a/testapps/setup_vispy.py
+++ b/testapps/setup_vispy.py
@@ -3,8 +3,10 @@ from distutils.core import setup
 from setuptools import find_packages
 
 options = {'apk': {'debug': None,
-                   'requirements': 'vispy',
-                   'android-api': 19,
+                   'requirements': 'python3,vispy',
+                   'blacklist-requirements': 'openssl,sqlite3',
+                   'android-api': 27,
+                   'ndk-api': 21,
                    'ndk-dir': '/home/asandy/android/crystax-ndk-10.3.2',
                    'dist-name': 'bdisttest',
                    'ndk-version': '10.3.2',


### PR DESCRIPTION
This complements @JonasT work in pull requests #1683 and #1689 and goes a little further

**Note:** This only affects those tests that are not python2's specific