### PR TITLE
Fix loadLibraries() failing for 64bit arch

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
@@ -144,7 +144,8 @@ public class PythonService extends Service implements Runnable {
     public void run(){
         String app_root =  getFilesDir().getAbsolutePath() + "/app";
         File app_root_file = new File(app_root);
-        PythonUtil.loadLibraries(app_root_file);
+        PythonUtil.loadLibraries(app_root_file,
+            new File(getApplicationInfo().nativeLibraryDir));
         this.mService = this;
         nativeStart(
             androidPrivate, androidArgument,

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -30,11 +30,7 @@ public class PythonUtil {
         }
     }
 
-    protected static ArrayList<String> getLibraries(File filesDir) {
-
-        String libsDirPath = filesDir.getParentFile().getParentFile().getAbsolutePath() + "/lib/";
-        File libsDir = new File(libsDirPath);
-
+    protected static ArrayList<String> getLibraries(File libsDir) {
         ArrayList<String> libsList = new ArrayList<String>();
         addLibraryIfExists(libsList, "crystax", libsDir);
         addLibraryIfExists(libsList, "sqlite3", libsDir);
@@ -49,14 +45,13 @@ public class PythonUtil {
         return libsList;
     }
 
-	public static void loadLibraries(File filesDir) {
-
+    public static void loadLibraries(File filesDir, File libsDir) {
         String filesDirPath = filesDir.getAbsolutePath();
         boolean foundPython = false;
 
-		for (String lib : getLibraries(filesDir)) {
+        for (String lib : getLibraries(libsDir)) {
             Log.v(TAG, "Loading library: " + lib);
-		    try {
+            try {
                 System.loadLibrary(lib);
                 if (lib.startsWith("python")) {
                     foundPython = true;

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -83,7 +83,8 @@ public class PythonActivity extends SDLActivity {
     public void loadLibraries() {
         String app_root = new String(getAppRoot());
         File app_root_file = new File(app_root);
-        PythonUtil.loadLibraries(app_root_file);
+        PythonUtil.loadLibraries(app_root_file,
+            new File(getApplicationInfo().nativeLibraryDir));
     }
 
     public void recursiveDelete(File f) {

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -29,11 +29,7 @@ public class PythonUtil {
         }
     }
 
-    protected static ArrayList<String> getLibraries(File filesDir) {
-
-        String libsDirPath = filesDir.getParentFile().getParentFile().getAbsolutePath() + "/lib/";
-        File libsDir = new File(libsDirPath);
-
+    protected static ArrayList<String> getLibraries(File libsDir) {
         ArrayList<String> libsList = new ArrayList<String>();
         addLibraryIfExists(libsList, "crystax", libsDir);
         addLibraryIfExists(libsList, "sqlite3", libsDir);
@@ -52,14 +48,13 @@ public class PythonUtil {
         return libsList;
     }
 
-    public static void loadLibraries(File filesDir) {
-
+    public static void loadLibraries(File filesDir, File libsDir) {
         String filesDirPath = filesDir.getAbsolutePath();
         boolean foundPython = false;
 
-		for (String lib : getLibraries(filesDir)) {
+        for (String lib : getLibraries(libsDir)) {
             Log.v(TAG, "Loading library: " + lib);
-		    try {
+            try {
                 System.loadLibrary(lib);
                 if (lib.startsWith("python")) {
                     foundPython = true;

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -201,7 +201,8 @@ public class PythonActivity extends Activity {
     public void loadLibraries() {
         String app_root = new String(getAppRoot());
         File app_root_file = new File(app_root);
-        PythonUtil.loadLibraries(app_root_file);
+        PythonUtil.loadLibraries(app_root_file,
+            new File(getApplicationInfo().nativeLibraryDir));
     }
 
     public void recursiveDelete(File f) {

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -232,7 +232,8 @@ public class PythonActivity extends Activity {
     public void loadLibraries() {
         String app_root = new String(getAppRoot());
         File app_root_file = new File(app_root);
-        PythonUtil.loadLibraries(app_root_file);
+        PythonUtil.loadLibraries(app_root_file,
+            new File(getApplicationInfo().nativeLibraryDir));
     }
 
     public void recursiveDelete(File f) {


### PR DESCRIPTION
`loadLibraries()` fails in loading native libs when `arch` is `arm64-v8a` or `x86_64`.

**Explanation**

On 64-bit Android, the path obtained by `getFilesDir().getParentFile().getAbsolutePath() + "/lib"` (e.g. `/data/data/<package>/lib`) is not available ([ref.](https://stackoverflow.com/questions/41709129/lib-directory-missing-after-installing-64-bit-android-application); I did verify this on my 64-bit Android devices).  For the same reason, `libsDirPath` in `getLibraries()` below is resolved to a non-existent path:
https://github.com/kivy/python-for-android/blob/e7c11179d4a50ed1f1ca3948c8a64c6990152d1c/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java#L34-L38

As a result, in `addLibraryIfExists()`, a `NullPointerException` is thrown at `files.length`. (Note that `listFiles()` returns `null` for an invalid directory path per this [ref](https://developer.android.com/reference/java/io/File.html#listFiles()).)
https://github.com/kivy/python-for-android/blob/e7c11179d4a50ed1f1ca3948c8a64c6990152d1c/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java#L17-L21
Although this exception is being caught, native libs (libSDL.so, libmain.so, etc.) are not loaded, so Android crashes anyway:
```
02-10 21:16:01.635 17125 17125 W System.err: Attempt to get length of null array
02-10 21:16:01.667 17125 17125 E art     : No implementation found for void org.libsdl.app.SDLActivity.nativeSetenv(java.lang.String, java.lang.String) (tried Java_org_libsdl_app_SDLActivity_nativeSetenv and Java_org_libsdl_app_SDLActivity_nativeSetenv__Ljava_lang_String_2Ljava_lang_String_2)
02-10 21:16:01.667 17125 17125 D AndroidRuntime: Shutting down VM
02-10 21:16:01.668 17125 17125 E AndroidRuntime: FATAL EXCEPTION: main
```

**Fix**

Use `getApplicationInfo().nativeLibraryDir` instead, which is [officially documented](https://developer.android.com/reference/android/content/pm/ApplicationInfo.html#nativeLibraryDir).
