### PR TITLE
Allow to override downloaded filename in recipie

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -102,6 +102,8 @@ class Recipe(with_metaclass(RecipeMeta)):
 
     archs = ['armeabi']  # Not currently implemented properly
 
+    download_filename = None
+
     @property
     def version(self):
         key = 'VERSION_' + self.name
@@ -311,7 +313,10 @@ class Recipe(with_metaclass(RecipeMeta)):
         shprint(sh.mkdir, '-p', join(self.ctx.packages_path, self.name))
 
         with current_directory(join(self.ctx.packages_path, self.name)):
-            filename = shprint(sh.basename, url).stdout[:-1].decode('utf-8')
+            if self.download_filename:
+                filename = self.download_filename
+            else:
+                filename = shprint(sh.basename, url).stdout[:-1].decode('utf-8')
 
             do_download = True
             marker_filename = '.mark-{}'.format(filename)
@@ -371,12 +376,14 @@ class Recipe(with_metaclass(RecipeMeta)):
         if self.url is None:
             info('Skipping {} unpack as no URL is set'.format(self.name))
             return
-
-        filename = shprint(
-            sh.basename, self.versioned_url).stdout[:-1].decode('utf-8')
-        ma = match(u'^(.+)#md5=([0-9a-f]{32})$', filename)
-        if ma:                  # fragmented URL?
-            filename = ma.group(1)
+        if self.download_filename:
+            filename = self.download_filename
+        else:
+            filename = shprint(
+                sh.basename, self.versioned_url).stdout[:-1].decode('utf-8')
+            ma = match(u'^(.+)#md5=([0-9a-f]{32})$', filename)
+            if ma:                  # fragmented URL?
+                filename = ma.group(1)
 
         with current_directory(build_dir):
             directory_name = self.get_build_dir(arch)


### PR DESCRIPTION
Sometimes filename is not present in url but it's set using Content-Disposition header.
As we need filename before http request this change allows to set custom filename for downloaded file.

For example zips generated by github are in form: https://codeload.github.com/kivy/python-for-android/zip/master and cannot be unpacked as they do not have `.zip` in name.