### PR TITLE
Added warning for arguments containing carriage returns. This happens…

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -229,6 +229,7 @@ class ToolchainCL(object):
     def __init__(self):
 
         argv = sys.argv
+        self.warn_on_carriage_return_args(argv)
         # Buildozer used to pass these arguments in a now-invalid order
         # If that happens, apply this fix
         # This fix will be removed once a fixed buildozer is released
@@ -574,6 +575,12 @@ class ToolchainCL(object):
 
         # Each subparser corresponds to a method
         getattr(self, args.subparser_name.replace('-', '_'))(args)
+
+    def warn_on_carriage_return_args(self, args):
+        for check_arg in args:
+            if '\r' in check_arg:
+                warning("Argument '" + str(check_arg.replace('\r', '')) + "' contains a carriage return (\\r).")
+                warning("Invoking this program via scripts which use CRLF instead of LF line endings will have undefined behaviour.")
 
     def warn_on_deprecated_args(self, args):
         """

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -576,10 +576,11 @@ class ToolchainCL(object):
         # Each subparser corresponds to a method
         getattr(self, args.subparser_name.replace('-', '_'))(args)
 
-    def warn_on_carriage_return_args(self, args):
+    @staticmethod
+    def warn_on_carriage_return_args(args):
         for check_arg in args:
             if '\r' in check_arg:
-                warning("Argument '" + str(check_arg.replace('\r', '')) + "' contains a carriage return (\\r).")
+                warning("Argument '{}' contains a carriage return (\\r).".format(str(check_arg.replace('\r', ''))))
                 warning("Invoking this program via scripts which use CRLF instead of LF line endings will have undefined behaviour.")
 
     def warn_on_deprecated_args(self, args):


### PR DESCRIPTION
… if a shell script was written in Windows but executed in Linux, as may be the case with bash for Windows.

Example of undefined behaviour: 

- sh script to invoke p4a is written in windows and run in windows bash.
- In this script, the last argument to p4a is `--requirements=python3,kivy,numpy`, which causes the last package to be `numpy\r` due to the CRLF at the end of the line. This might get through to pip but not have any associated p4a recipes, leading to many red herrings and wild goose chases.

The solution to this was straightforward (change my text editor to use LF instad of CRLF), but this behaviour was difficult and time-consuming to debug. Although this problem is not due to python-for-android, I decided to open this PR regardless as it would improve developer quality of life.
