### PR TITLE
Fix setenv() of non-SDL2 bootstrap

### DIFF
--- a/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
+++ b/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
@@ -468,7 +468,7 @@ void Java_org_kivy_android_PythonActivity_nativeSetenv(
     const char *utfname = (*env)->GetStringUTFChars(env, name, NULL);
     const char *utfvalue = (*env)->GetStringUTFChars(env, value, NULL);
 
-    SDL_setenv(utfname, utfvalue, 1);
+    setenv(utfname, utfvalue, 1);
 
     (*env)->ReleaseStringUTFChars(env, name, utfname);
     (*env)->ReleaseStringUTFChars(env, value, utfvalue);


### PR DESCRIPTION
Fixes #1702.  This is regression related to #1690.  For non-SDL2 bootstrap, we should not use `SDL_setenv()` here; instead, use the plain `setenv()` as previously.  Sorry that I missed testing this bootstrap case.

Before fix:
```
/home/a/.local/share/python-for-android/build/bootstrap_builds/webview-python2/jni/application/src/start.c:471: error: undefined reference to 'SDL_setenv'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
After fix: No compile errors regarding this issue.

