### PR TITLE
Fix compile error of recipe "android" for non-sdl bootstrap build

### DIFF
--- a/pythonforandroid/recipes/android/src/setup.py
+++ b/pythonforandroid/recipes/android/src/setup.py
@@ -6,7 +6,7 @@ lib_dict = {
     'pygame': ['sdl'],
     'sdl2': ['SDL2', 'SDL2_image', 'SDL2_mixer', 'SDL2_ttf']
 }
-sdl_libs = lib_dict[os.environ['BOOTSTRAP']]
+sdl_libs = lib_dict.get(os.environ['BOOTSTRAP'], [])
 
 renpy_sound = Extension('android._android_sound',
                         ['android/_android_sound.c', 'android/_android_sound_jni.c', ],


### PR DESCRIPTION
Building an apk with `--bootstrap=webview` breaks at `pythonforandroid/recipes/android/src/setup.py` as follows:
```
$ p4a apk --private ./myapp --package=org.example.myapp --name myapp --version 0.1 --bootstrap=webview --requirements=python2 --arch=armeabi-v7a --debug
```
(snip)
```
  RAN: /home/a/.local/share/python-for-android/build/other_builds/hostpython2/desktop/hostpython2/native-build/python setup.py build_ext -v

  STDOUT:
Traceback (most recent call last):
  File "setup.py", line 9, in <module>
    sdl_libs = lib_dict[os.environ['BOOTSTRAP']]
KeyError: 'webview'
```

This PR is to get around the `KeyError` that happens in **any** non-SDL bootstrap modes.
