### PR TITLE
Consider arch when looking for compatible dist.

### DIFF
--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -96,10 +96,10 @@ class Distribution(object):
         _possible_dists = []
         for dist in possible_dists:
             if ((ndk_api is not None and dist.ndk_api != ndk_api)
-                or dist.ndk_api is None or dist.archs is None):
+                    or dist.ndk_api is None or dist.archs is None):
                 continue
             if (set(recipes).issubset(set(dist.recipes))
-                and set(archs).issubset(set(dist.archs))):
+                    and set(archs).issubset(set(dist.archs))):
                 _possible_dists.append(dist)
 
         possible_dists = _possible_dists

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -162,6 +162,7 @@ def dist_from_args(ctx, args):
         name=args.dist_name,
         recipes=split_argument_list(args.requirements),
         ndk_api=args.ndk_api,
+        archs=split_argument_list(args.arch),
         force_build=args.force_build,
         require_perfect_match=args.require_perfect_match,
         allow_replace_dist=args.allow_replace_dist)
@@ -792,9 +793,9 @@ class ToolchainCL(object):
 
     @property
     def _dist(self):
-        ctx = self.ctx
-        dist = dist_from_args(ctx, self.args)
-        return dist
+        if (not hasattr(self, 'dist') or self.dist is None):
+            self.dist = dist_from_args(self.ctx, self.args)
+        return self.dist
 
     @require_prebuilt_dist
     def apk(self, args):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -570,6 +570,7 @@ class ToolchainCL(object):
         self.ctx.java_build_tool = args.java_build_tool
 
         self._archs = split_argument_list(args.arch)
+        self._cached_dist = None
 
         self.ctx.local_recipes = args.local_recipes
         self.ctx.copy_libs = args.copy_libs
@@ -793,9 +794,9 @@ class ToolchainCL(object):
 
     @property
     def _dist(self):
-        if (not hasattr(self, 'dist') or self.dist is None):
-            self.dist = dist_from_args(self.ctx, self.args)
-        return self.dist
+        if (self._cached_dist is None):
+            self._cached_dist = dist_from_args(self.ctx, self.args)
+        return self._cached_dist
 
     @require_prebuilt_dist
     def apk(self, args):


### PR DESCRIPTION
Cache self.dist so it isn't calculated multiple times (e.g. wrapper_func in toolchain).

Current problem scenario:
- I build for arm
- I build the same project for x86. p4a uses existing distribution and packages arm libraries into the apk instead of recompiling project for x86

I also modified _dist() as it was getting called multiple times, causing the dist search (and log output) twice.