### PR TITLE
Fixes psycopg2 lib install dir, closes #1711

### DIFF
--- a/pythonforandroid/recipes/psycopg2/__init__.py
+++ b/pythonforandroid/recipes/psycopg2/__init__.py
@@ -6,6 +6,9 @@ import sh
 class Psycopg2Recipe(PythonRecipe):
     """
     Requires `libpq-dev` system dependency e.g. for `pg_config` binary.
+    If you get `nl_langinfo` symbol runtime error, make sure you're running on
+    `ANDROID_API` (`ndk-api`) >= 26, see:
+    https://github.com/kivy/python-for-android/issues/1711#issuecomment-465747557
     """
     version = 'latest'
     url = 'http://initd.org/psycopg/tarballs/psycopg2-{version}.tar.gz'
@@ -41,7 +44,7 @@ class Psycopg2Recipe(PythonRecipe):
                     _env=env)
             shprint(hostpython, 'setup.py', 'install', '-O2',
                     '--root={}'.format(self.ctx.get_python_install_dir()),
-                    '--install-lib=lib/python2.7/site-packages', _env=env)
+                    '--install-lib=.', _env=env)
 
 
 recipe = Psycopg2Recipe()


### PR DESCRIPTION
Also note this recipe seems to depend on `nl_langinfo` which is only
available from ANDROID_API 26.