### PR TITLE
Removed unnecessary genericndkbuild dependency from the flask recipe

### DIFF
--- a/pythonforandroid/recipes/flask/__init__.py
+++ b/pythonforandroid/recipes/flask/__init__.py
@@ -9,7 +9,7 @@ class FlaskRecipe(PythonRecipe):
     version = '0.10.1'
     url = 'https://github.com/pallets/flask/archive/{version}.zip'
 
-    depends = [('python2', 'python3', 'python3crystax'), 'setuptools', 'genericndkbuild']
+    depends = [('python2', 'python3', 'python3crystax'), 'setuptools']
 
     python_depends = ['jinja2', 'werkzeug', 'markupsafe', 'itsdangerous', 'click']
 


### PR DESCRIPTION
Fixes https://github.com/kivy/python-for-android/issues/1728