### PR TITLE
Fix import in 'Using a PythonRecipe' doc

### DIFF
--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -251,7 +251,7 @@ install`` with an appropriate environment.
 For instance, the following is all that's necessary to create a recipe
 for the Vispy module::
 
-  from pythonforandroid.toolchain import PythonRecipe
+  from pythonforandroid.recipe import PythonRecipe
   class VispyRecipe(PythonRecipe):
       version = 'master'
       url = 'https://github.com/vispy/vispy/archive/{version}.zip'


### PR DESCRIPTION
Fix documentation on wrong `PythonRecipe` import, that stopped working after the #1284