### PR TITLE
fix groestlcoin_hash recipe

### DIFF
--- a/pythonforandroid/recipes/groestlcoin_hash/__init__.py
+++ b/pythonforandroid/recipes/groestlcoin_hash/__init__.py
@@ -5,7 +5,6 @@ class GroestlcoinHashRecipe(CythonRecipe):
     version = '1.0.1'
     url = 'https://github.com/Groestlcoin/groestlcoin-hash-python/archive/{version}.tar.gz'
     depends = []
-    call_hostpython_via_targetpython = False
     cythonize = False
 
 

--- a/pythonforandroid/recipes/groestlcoin_hash/__init__.py
+++ b/pythonforandroid/recipes/groestlcoin_hash/__init__.py
@@ -5,7 +5,7 @@ class GroestlcoinHashRecipe(CythonRecipe):
     version = '1.0.1'
     url = 'https://github.com/Groestlcoin/groestlcoin-hash-python/archive/{version}.tar.gz'
     depends = []
-    call_hostpython_via_targetpython = True
+    call_hostpython_via_targetpython = False
     cythonize = False
 
 


### PR DESCRIPTION
apparently since the move to python3, the recipes can/should disable call_hostpython_via_targetpython.