### PR TITLE
Requests runtime permissions list, fixes #1704

### DIFF
--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -15,8 +15,8 @@ to access the SD card, the camera, and other things.
 This can be done through the `android` module which is *available per default*
 unless you blacklist it. Use it in your app like this::
 
-      from android.permissions import request_permission, Permission
-      request_permission(Permission.WRITE_EXTERNAL_STORAGE)
+      from android.permissions import request_permissions, Permission
+      request_permissions([Permission.WRITE_EXTERNAL_STORAGE])
 
 The available permissions are listed here:
 

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -604,17 +604,16 @@ public class PythonActivity extends SDLActivity {
     }
 
     /**
-     * Used by android.permissions p4a module to request a permission
+     * Used by android.permissions p4a module to request runtime permissions
      **/
-    public void requestNewPermission(String permission) {
+    public void requestPermissions(String[] permissions) {
         if (android.os.Build.VERSION.SDK_INT < 23)
             return;
-
         try {
             java.lang.reflect.Method methodRequestPermission =
                 Activity.class.getMethod("requestPermissions",
                 java.lang.String[].class, int.class);  
-            methodRequestPermission.invoke(this, new String[] {permission}, 1);
+            methodRequestPermission.invoke(this, permissions, 1);
         } catch (IllegalAccessException | NoSuchMethodException |
                  InvocationTargetException e) {
         }

--- a/pythonforandroid/recipes/android/src/android/permissions.py
+++ b/pythonforandroid/recipes/android/src/android/permissions.py
@@ -421,9 +421,13 @@ class Permission:
         )
 
 
-def request_permission(permission):
+def request_permissions(permissions):
     python_activity = autoclass('org.kivy.android.PythonActivity')
-    python_activity.requestNewPermission(permission + "")
+    python_activity.requestPermissions(permissions)
+
+
+def request_permission(permission):
+    request_permissions([permission])
 
 
 def check_permission(permission):

--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -6,7 +6,9 @@ from os.path import join
 
 
 class PyjniusRecipe(CythonRecipe):
-    version = '1.1.3'
+    # "6553ad4" is one commit after last release (1.2.0)
+    # it fixes method resolution, required for resolving requestPermissions()
+    version = '6553ad4'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
     depends = [('genericndkbuild', 'sdl2', 'sdl'), 'six']


### PR DESCRIPTION
Matches the official Android API via, making it possible to request
multiple runtime permissions at once.

Keeps the previous `android.permissions.request_permission()` interface
for compatibility.

Bumps pyjnius to post 1.2.0 release that solves required method
resolution issues. On 1.2.0, the error was:
```
jnius.jnius.JavaException: No methods matching your arguments, available: []
```