### PR TITLE
Fix libffi recipe, and build + runtime linker errors when compiling on WSL

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -106,7 +106,7 @@ RUN dpkg --add-architecture i386 \
         build-essential ccache git python3 python3-dev \
         libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
         libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 \
-        zip zlib1g-dev zlib1g:i386 lld \
+        zip zlib1g-dev zlib1g:i386 \
     && apt -y autoremove
 
 # specific recipes dependencies (e.g. libffi requires autoreconf binary)

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -106,7 +106,7 @@ RUN dpkg --add-architecture i386 \
         build-essential ccache git python3 python3-dev \
         libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
         libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 \
-        zip zlib1g-dev zlib1g:i386 \
+        zip zlib1g-dev zlib1g:i386 lld \
     && apt -y autoremove
 
 # specific recipes dependencies (e.g. libffi requires autoreconf binary)

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -86,7 +86,7 @@ class Arch(object):
                                          self.ctx.python_recipe.version[0:3])
                                     )
 
-        env['LDFLAGS'] += '--sysroot {} '.format(self.ctx.ndk_platform)
+        env['LDFLAGS'] += '--sysroot={} '.format(self.ctx.ndk_platform)
 
         env["CXXFLAGS"] = env["CFLAGS"]
 

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -170,8 +170,7 @@ class GuestPythonRecipe(TargetPythonRecipe):
 
         env['SYSROOT'] = sysroot
 
-        exitcode, _ = subprocess.getstatusoutput('which lld')
-        if exitcode == 0:
+        if sh.which('lld') is not None:
             # Note: The -L. is to fix a bug in python 3.7. 
             # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234409
             env["LDFLAGS"] += ' -L. -fuse-ld=lld'

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -170,6 +170,15 @@ class GuestPythonRecipe(TargetPythonRecipe):
 
         env['SYSROOT'] = sysroot
 
+        exitcode, _ = subprocess.getstatusoutput('which lld')
+        if exitcode == 0:
+            # Note: The -L. is to fix a bug in python 3.7. 
+            # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234409
+            env["LDFLAGS"] += ' -L. -fuse-ld=lld'
+        else:
+            logger.warning('lld not found, linking without it. ' +
+                           'Consider installing lld if linker errors occur.')
+
         return env
 
     def set_libs_flags(self, env, arch):
@@ -197,7 +206,6 @@ class GuestPythonRecipe(TargetPythonRecipe):
             add_flags(' -I' + ' -I'.join(recipe.get_include_dirs(arch)),
                       ' -L' + join(recipe.get_build_dir(arch.arch), '.libs'),
                       ' -lffi')
-            env["LDFLAGS"] += ' -L. -fuse-ld=lld'
 
         if 'openssl' in self.ctx.recipe_build_order:
             info('Activating flags for openssl')

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -171,7 +171,7 @@ class GuestPythonRecipe(TargetPythonRecipe):
         env['SYSROOT'] = sysroot
 
         if sh.which('lld') is not None:
-            # Note: The -L. is to fix a bug in python 3.7. 
+            # Note: The -L. is to fix a bug in python 3.7.
             # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234409
             env["LDFLAGS"] += ' -L. -fuse-ld=lld'
         else:

--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -197,6 +197,7 @@ class GuestPythonRecipe(TargetPythonRecipe):
             add_flags(' -I' + ' -I'.join(recipe.get_include_dirs(arch)),
                       ' -L' + join(recipe.get_build_dir(arch.arch), '.libs'),
                       ' -lffi')
+            env["LDFLAGS"] += ' -L. -fuse-ld=lld'
 
         if 'openssl' in self.ctx.recipe_build_order:
             info('Activating flags for openssl')

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -1,8 +1,7 @@
 from os.path import exists, join
 from pythonforandroid.recipe import Recipe
-from pythonforandroid.logger import info, shprint
+from pythonforandroid.logger import shprint
 from pythonforandroid.util import current_directory, ensure_dir
-from glob import glob
 import sh
 
 

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -1,4 +1,5 @@
 from os.path import exists, join
+from multiprocessing import cpu_count
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import shprint
 from pythonforandroid.util import current_directory, ensure_dir
@@ -37,7 +38,7 @@ class LibffiRecipe(Recipe):
                     '--disable-builddir',
                     '--enable-shared', _env=env)
 
-            shprint(sh.make, '-j5', 'libffi.la', _env=env)
+            shprint(sh.make, '-j', str(cpu_count()), 'libffi.la', _env=env)
 
             host_build = self.get_build_dir(arch.arch)
             ensure_dir(self.ctx.get_libs_dir(arch.arch))

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -37,46 +37,10 @@ class LibffiRecipe(Recipe):
                     '--prefix=' + self.get_build_dir(arch.arch),
                     '--disable-builddir',
                     '--enable-shared', _env=env)
-            # '--with-sysroot={}'.format(self.ctx.ndk_platform),
-            # '--target={}'.format(arch.toolchain_prefix),
 
-            # ndk 15 introduces unified headers required --sysroot and
-            # -isysroot for libraries and headers. libtool's head explodes
-            # trying to weave them into it's own magic. The result is a link
-            # failure trying to link libc. We call make to compile the bits
-            # and manually link...
+            shprint(sh.make, '-j5', 'libffi.la', _env=env)
 
-            try:
-                shprint(sh.make, '-j5', 'libffi.la', _env=env)
-            except sh.ErrorReturnCode_2:
-                info("make libffi.la failed as expected")
-            cc = sh.Command(env['CC'].split()[0])
-            cflags = env['CC'].split()[1:]
             host_build = self.get_build_dir(arch.arch)
-
-            arch_flags = ''
-            if '-march=' in env['CFLAGS']:
-                arch_flags = '-march={}'.format(env['CFLAGS'].split('-march=')[1])
-
-            src_arch = arch.command_prefix.split('-')[0]
-            if src_arch == 'x86_64':
-                # libffi has not specific arch files for x86_64...so...using
-                # the ones from x86 which seems to build fine...
-                src_arch = 'x86'
-
-            cflags.extend(arch_flags.split())
-            cflags.extend(['-shared', '-fPIC', '-DPIC'])
-            cflags.extend(glob(join(host_build, 'src/.libs/*.o')))
-            cflags.extend(glob(join(host_build, 'src', src_arch, '.libs/*.o')))
-
-            ldflags = env['LDFLAGS'].split()
-            cflags.extend(ldflags)
-            cflags.extend(['-Wl,-soname', '-Wl,libffi.so', '-o',
-                           '.libs/libffi.so'])
-
-            with current_directory(host_build):
-                shprint(cc, *cflags, _env=env)
-
             ensure_dir(self.ctx.get_libs_dir(arch.arch))
             shprint(sh.cp,
                     join(host_build, '.libs', 'libffi.so'),

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,4 +1,4 @@
-import subprocess
+import sh
 from pythonforandroid.python import GuestPythonRecipe
 from pythonforandroid.recipe import Recipe
 
@@ -24,8 +24,7 @@ class Python3Recipe(GuestPythonRecipe):
 
     patches = ["patches/fix-ctypes-util-find-library.patch"]
 
-    exitcode, _ = subprocess.getstatusoutput('which lld')
-    if exitcode == 0:
+    if sh.which('lld') is not None:
         patches = patches + ["patches/remove-fix-cortex-a8.patch"]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -1,3 +1,4 @@
+import subprocess
 from pythonforandroid.python import GuestPythonRecipe
 from pythonforandroid.recipe import Recipe
 
@@ -21,7 +22,11 @@ class Python3Recipe(GuestPythonRecipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
-    patches = ["patches/fix-ctypes-util-find-library.patch", "patches/remove-fix-cortex-a8.patch"]
+    patches = ["patches/fix-ctypes-util-find-library.patch"]
+
+    exitcode, _ = subprocess.getstatusoutput('which lld')
+    if exitcode == 0:
+        patches = patches + ["patches/remove-fix-cortex-a8.patch"]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
     conflicts = ['python3crystax', 'python2', 'python2legacy']

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -21,7 +21,7 @@ class Python3Recipe(GuestPythonRecipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
-    patches = ["patches/fix-ctypes-util-find-library.patch"]
+    patches = ["patches/fix-ctypes-util-find-library.patch", "patches/remove-fix-cortex-a8.patch"]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
     conflicts = ['python3crystax', 'python2', 'python2legacy']

--- a/pythonforandroid/recipes/python3/patches/remove-fix-cortex-a8.patch
+++ b/pythonforandroid/recipes/python3/patches/remove-fix-cortex-a8.patch
@@ -1,3 +1,5 @@
+This patch removes --fix-cortex-a8 from the linker flags in order to support linking
+with lld, as lld does not support this flag (https://github.com/android-ndk/ndk/issues/766).
 diff --git a/configure b/configure
 --- a/configure
 +++ b/configure

--- a/pythonforandroid/recipes/python3/patches/remove-fix-cortex-a8.patch
+++ b/pythonforandroid/recipes/python3/patches/remove-fix-cortex-a8.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -5671,7 +5671,7 @@ $as_echo_n "checking for the Android arm ABI... " >&6; }
+ $as_echo "$_arm_arch" >&6; }
+   if test "$_arm_arch" = 7; then
+     BASECFLAGS="${BASECFLAGS} -mfloat-abi=softfp -mfpu=vfpv3-d16"
+-    LDFLAGS="${LDFLAGS} -march=armv7-a -Wl,--fix-cortex-a8"
++    LDFLAGS="${LDFLAGS} -march=armv7-a"
+   fi
+ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: not Android" >&5


### PR DESCRIPTION
Force the use of lld (LLVM's linker), and include a python37 bugfix.
https://clang.llvm.org/docs/Toolchain.html
https://lld.llvm.org/
https://bz-attachments.freebsd.org/attachment.cgi?id=200526

I use p4a in windows bash (windows subsystem for linux). Upgrading from the stable version 0.7.0 to the develop version 0.7.1 causes linker errors when building libffi:

```
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_cif_machdep'
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_closure_loc'
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_raw_closure_loc'
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_cif_machdep'
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_closure_loc'
/other_builds/libffi/x86__ndk_target_21/libffi/.libs/libffi.so: error: undefined reference to 'ffi_prep_raw_closure_loc'
```

This is partially due the fact that we now use clang to compile libffi instead of gcc. I fixed the problem by ~~forcing the clang invocation to use `lld`, which is llvm's linker~~ fixing the libffi recipe, by adding an equals sign = between the `--sysroot` flag and value in LDFLAGS (see commit messages). If this PR is merged, `lld` will now be a requirement to use p4a. I think this is fine since we are using clang anyway (and it is awesome).

*EDIT*: `lld` is now not required, libffi builds successfully with regular `ld` now, but I have left in my deltas which change the linker to `lld`, as I feel like it should be the way forward. Let me know what you think.

The `-L.` flag is just me incorporating the fix of a bug in python37, as linked above.

I've updated the dockerfile for python 3 to include an `lld` install, but please let me know if I should update any documentation etc to indicate that `lld` is required. Thanks!