### PR TITLE
decode JAVA_NAMESPACE in _android.pyx

### DIFF
--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -175,7 +175,7 @@ api_version = autoclass('android.os.Build$VERSION').SDK_INT
 version_codes = autoclass('android.os.Build$VERSION_CODES')
 
 
-python_act = autoclass(JAVA_NAMESPACE + u'.PythonActivity')
+python_act = autoclass(JAVA_NAMESPACE.decode('utf8') + u'.PythonActivity')
 Rect = autoclass(u'android.graphics.Rect')
 mActivity = python_act.mActivity
 if mActivity:


### PR DESCRIPTION
not sure why i need that if others don't, but i can't build anything depending on the android recipe without it.