### PR TITLE
[libxml2] fixed crash on missing lzma.h

### DIFF
--- a/pythonforandroid/recipes/libxml2/__init__.py
+++ b/pythonforandroid/recipes/libxml2/__init__.py
@@ -37,6 +37,7 @@ class Libxml2Recipe(Recipe):
                     '--without-python',
                     '--without-threads',
                     '--without-iconv',
+                    '--without-lzma',
                     '--disable-shared',
                     '--enable-static',
                     _env=env)


### PR DESCRIPTION
libxml2 has been updated from 2.7.8 to 2.9.8 at commit
6ed40d551e4bbf87569bd30d929526173ff0e6aa, but version 2.8.0 added lzma
compression support, and with it a dependency to liblzma (available at
https://tukaani.org/xz/).

This patch fixes it by disabling lzma support.
A future improvment may add xz recipe and dependency.