### PR TITLE
[kivy] updated recipe to c4d6894 revision

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -7,7 +7,7 @@ import glob
 
 class KivyRecipe(CythonRecipe):
     # post kivy==1.10.1, `fixes SDL2 image loading (jpg)`
-    version = 'a95d67f'
+    version = 'c4d6894'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 


### PR DESCRIPTION
a95d67f revision of Kivy doesn't handle properly the orientation on
Android (see https://github.com/kivy/python-for-android/issues/1763).

Revision c4d6894 works with `--orientation user`