### PR TITLE
Fix SDL2 forcibly blocking apps in background with no way to disable [WARNING, major behavior change!]

### DIFF
--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -13,6 +13,8 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
     depends = ['sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
     conflicts = ['sdl', 'pygame', 'pygame_bootstrap_components']
 
+    patches = ["patches/disable-block-on-pause.patch"]
+
     def get_recipe_env(self, arch=None, with_flags_in_cc=True, with_python=True):
         env = super(LibSDL2Recipe, self).get_recipe_env(
             arch=arch, with_flags_in_cc=with_flags_in_cc, with_python=with_python)

--- a/pythonforandroid/recipes/sdl2/patches/disable-block-on-pause.patch
+++ b/pythonforandroid/recipes/sdl2/patches/disable-block-on-pause.patch
@@ -1,0 +1,8 @@
+diff --git a/src/video/android/SDL_androidevents.c b/src/video/android/SDL_androidevents.c
+index 6cf9af2..1c932a8 100644
+--- a/src/video/android/SDL_androidevents.c
++++ b/src/video/android/SDL_androidevents.c
+@@ -25,2 +25,2 @@
+ /* We're going to do this by default */
+-#define SDL_ANDROID_BLOCK_ON_PAUSE  1
++#define SDL_ANDROID_BLOCK_ON_PAUSE  0


### PR DESCRIPTION
Fix SDL2 forcibly blocking apps in background with no way to disable by setting `SDL_ANDROID_BLOCK_ON_PAUSE` to 0. **This is a major behavior change!** I tested this with a non-kivy SDL2 app, but not with kivy. (see below for details)

Advantages of `SDL_ANDROID_BLOCK_ON_PAUSE` set to `1`:

- **avoids bad data loss in some situations.** example: my app has a save button, but because I coded it properly I keep the UI mostly responsive while saving, but because I'm also avoiding unnecessary threading this is all still going on on the main thread.

   Result with the current `SDL_ANDROID_BLOCK_ON_PAUSE` set to `0`: if you press save then press the home button in like <500ms (which is a *common* user action) you are almost 99% guaranteed the save didn't actually go through for bigger documents, and now SDL2 will block the event loop making the UI update also block, and the entire save will block / *not finish*. Now if you wait long enough, you also have a really high risk the app will get unloaded without ever having saved, and you have *data loss.* -> very likely risk of save being completely lost if you tab out quick and then don't tab back in for a day or longer

   With this pull request: very unlikely there will ever be an issue. The only remaining risk is that your app runs on a rather low spec phone so it will get instant-unloaded after going to background, or android crashes entirely. Both aren't really common.

- **allows apps to do basic background stuff without services or threading.** this is self-explanatory. you can do things in the background without necessarily using complicated thread code, or even a service. of course the app may get terminated, but unless your app is a major resource hog you can assume to be able to do at least a few do low-risk background activities

Disadvantages / risks:

- **Naive/unaware frameworks will burn all batteries to death.** With this change, whatever is controlling the main loop (e.g. kivy, or the kivi app, or whatever other UI lib, ...) *must* do adaptive slowing down of the polling to something really slow like 500 milliseconds when in background. If not, this is almost guaranteed to be a major battery waster with a huge difference in battery impact of your app while in background

- **May cause higher battery usage even if you're moderately smart about it(??)** This would actually be interesting to know. I'm not sure how bad a 500 milliseconds wakeup interval still is. I assume it has *some* remaining impact, but is it much? However, an app can always serialize state & use `sys.exit(0)` if that turned out to be a problem. So far, my app running with this hasn't shown up in the battery chart although I'm not sure if/how background apps are tracked. If anyone has more info here that'd be interesting to know

Things to check:

- **Kivy should be tested for race conditions.** This pull request can in theory expose race conditions. (since now you can get all sorts of events while in background rather than none because the event loop just hangs until the app gets focus again.) I tested with a non-kivy SDL2 app (using my own UI facilities) which worked fine, but obviously kivy should also be tested

- **Kivy should slow down the event loop when in background.** if it doesn't do that already, of course. (or if kivy apps usually control the loop - I don't use kivy so I'm not sure about the API design here - then there will need to be a bigger announcement of this change, so that well-behaving apps implement this.)

- **The docs for kivy should possibly get a recommendation to use `sys.exit()` when in background on android.** In a battery save chapter, there could be a note that after longer background idle it might be wise for an app to quit if it has truly nothing to do and it serializes its state properly. After all, for longer running tasks it should spawn a service anyway