### PR TITLE
Fix outdated PySDL2 version and non-PyPI install source

### DIFF
--- a/pythonforandroid/recipes/pysdl2/__init__.py
+++ b/pythonforandroid/recipes/pysdl2/__init__.py
@@ -3,8 +3,8 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PySDL2Recipe(PythonRecipe):
-    version = '0.9.3'
-    url = 'https://bitbucket.org/marcusva/py-sdl2/downloads/PySDL2-{version}.tar.gz'
+    version = '0.9.6'
+    url = 'https://files.pythonhosted.org/packages/source/P/PySDL2/PySDL2-{version}.tar.gz'
 
     depends = ['sdl2']
 


### PR DESCRIPTION
Fix that the PySDL2 version is outdated and adjust from non-PyPI install source to a proper PyPI install source