### PR TITLE
Bumps to setuptools==40.9.0

### DIFF
--- a/pythonforandroid/recipes/setuptools/__init__.py
+++ b/pythonforandroid/recipes/setuptools/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class SetuptoolsRecipe(PythonRecipe):
-    version = '40.0.0'
+    version = '40.9.0'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
     call_hostpython_via_targetpython = False
     install_in_hostpython = True


### PR DESCRIPTION
Version 40.0.0 seems to give gateway timeout while downloading:
```
wget
https://pypi.python.org/packages/source/s/setuptools/setuptools-40.0.0.zip
--2019-04-18 12:26:42--
https://pypi.python.org/packages/source/s/setuptools/setuptools-40.0.0.zip
Resolving pypi.python.org (pypi.python.org)... 151.101.132.223,
2a04:4e42:1f::223
Connecting to pypi.python.org (pypi.python.org)|151.101.132.223|:443...
connected.
HTTP request sent, awaiting response... 301 Redirect to Primary Domain
Location:
https://pypi.org/packages/source/s/setuptools/setuptools-40.0.0.zip
[following]
--2019-04-18 12:26:43--
https://pypi.org/packages/source/s/setuptools/setuptools-40.0.0.zip
Resolving pypi.org (pypi.org)... 151.101.64.223, 151.101.128.223,
151.101.192.223, ...
Connecting to pypi.org (pypi.org)|151.101.64.223|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location:
https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-40.0.0.zip
[following]
--2019-04-18 12:26:43--
https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-40.0.0.zip
Resolving files.pythonhosted.org (files.pythonhosted.org)...
151.101.133.63, 2a04:4e42:1f::319
Connecting to files.pythonhosted.org
(files.pythonhosted.org)|151.101.133.63|:443... connected.
HTTP request sent, awaiting response... 504 Gateway Time-out
Retrying.
````