### PR TITLE
Update recipes.rst

### DIFF
--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -438,7 +438,7 @@ overrides if you do not use them::
             # Manipulate the env here if you want
             return env
 
-        def should_build(self):
+        def should_build(self, arch):
             # Add a check for whether the recipe is already built if you
             # want, and return False if it is.
             return True


### PR DESCRIPTION
should_build method will crash without the arch parameter. It was omitted in the template.