### PR TITLE
Fix corner case of pip hack workaround we should get rid of anyway

### DIFF
--- a/pythonforandroid/pythonpackage.py
+++ b/pythonforandroid/pythonpackage.py
@@ -55,16 +55,21 @@ import zipfile
 
 
 def transform_dep_for_pip(dependency):
-    if dependency.find("@") > 0:
+    if dependency.find("@") > 0 and (
+            dependency.find("@") < dependency.find("://") or
+            "://" not in dependency
+            ):
         # WORKAROUND FOR UPSTREAM BUG:
         # https://github.com/pypa/pip/issues/6097
         # (Please REMOVE workaround once that is fixed & released upstream!)
         #
         # Basically, setup_requires() can contain a format pip won't install
         # from a requirements.txt (PEP 508 URLs).
-        # To avoid this, translate to an #egg-name= reference:
-        url = (dependency.partition("@")[2].strip() +
-               "#egg-name=" +
+        # To avoid this, translate to an #egg= reference:
+        if dependency.endswith("#"):
+            dependency = dependency[:-1]
+        url = (dependency.partition("@")[2].strip().partition("#egg")[0] +
+               "#egg=" +
                dependency.partition("@")[0].strip()
               )
         return url

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -136,15 +136,31 @@ def test_get_dep_names_of_package():
 
 
 def test_transform_dep_for_pip():
-    transformed = transform_dep_for_pip(
-        "python-for-android @ https://github.com/kivy/"
-        "python-for-android/archive/master.zip"
+    # A reminder, this entire function we test here is just a workaround
+    # for https://github.com/pypa/pip/issues/6097 (and not a nice one.)
+    # As soon as upstream fixes it, we should throw it & this test out
+    transformed = (
+        transform_dep_for_pip(
+            "python-for-android @ https://github.com/kivy/" +
+            "python-for-android/archive/master.zip"
+        ),
+        transform_dep_for_pip(
+            "python-for-android @ https://github.com/kivy/" +
+            "python-for-android/archive/master.zip" +
+            "#egg=python-for-android-master"
+        ),
+        transform_dep_for_pip(
+            "python-for-android @ https://github.com/kivy/" +
+            "python-for-android/archive/master.zip" +
+            "#"  # common hack variant used by others to make pip parse it
+        ),
     )
     expected = (
-        "https://github.com/kivy/python-for-android/archive/master.zip"
-        "#egg-name=python-for-android"
+        "https://github.com/kivy/python-for-android/archive/master.zip" +
+        "#egg=python-for-android"
     )
-    assert transformed == expected
+    assert transformed == (expected, expected, expected)
+    assert transform_dep_for_pip("https://a@b/") == "https://a@b/"
 
 
 def test_is_filesystem_path():


### PR DESCRIPTION
This is just an adjustment for the workaround for
https://github.com/pypa/pip/issues/6097 to fix a corner case.
(The affected corner case was added to the unit test!)

So this code should really be thrown out once pip fixes that issue (so if we're wondering "should we even be dealing with this corner case?" - no, we shouldn't, pip should but sadly right now it doesn't)

---
Also I had this small fix lying around before #1625 was merged but forgot to include it :woman_facepalming:  :woman_facepalming:  :woman_facepalming: lol