### PR TITLE
[WIP] Fix crashes when using other commands than 'apk'

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -593,7 +593,8 @@ def project_has_setup_py(project_dir):
     return False
 
 
-def run_pymodules_install(ctx, modules, project_dir, ignore_setup_py=False):
+def run_pymodules_install(ctx, modules, project_dir=None,
+                          ignore_setup_py=False):
     """ This function will take care of all non-recipe things, by:
 
         1. Processing them from --requirements (the modules argument)
@@ -610,6 +611,7 @@ def run_pymodules_install(ctx, modules, project_dir, ignore_setup_py=False):
     # Bail out if no python deps and no setup.py to process:
     if not modules and (
             ignore_setup_py or
+            project_dir is None or
             not project_has_setup_py(project_dir)
             ):
         info('No Python modules and no setup.py to process, skipping')
@@ -621,7 +623,8 @@ def run_pymodules_install(ctx, modules, project_dir, ignore_setup_py=False):
              'install them with pip'.format(', '.join(modules)))
         info('If this fails, it may mean that the module has compiled '
              'components and needs a recipe.')
-    if project_has_setup_py(project_dir) and not ignore_setup_py:
+    if project_dir is not None and \
+            project_has_setup_py(project_dir) and not ignore_setup_py:
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
 
@@ -694,7 +697,9 @@ def run_pymodules_install(ctx, modules, project_dir, ignore_setup_py=False):
                     _env=copy.copy(env))
 
         # Afterwards, run setup.py if present:
-        if project_has_setup_py(project_dir) and not ignore_setup_py:
+        if project_dir is not None and (
+                project_has_setup_py(project_dir) and not ignore_setup_py
+                ):
             with current_directory(project_dir):
                 info('got setup.py or similar, running project install. ' +
                      '(disable this behavior with --ignore-setup-py)')

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -199,8 +199,11 @@ def build_dist_from_args(ctx, dist, args):
     if dist.needs_build:
         ctx.prepare_dist(ctx.dist_name)
 
-    build_recipes(build_order, python_modules, ctx, args.private,
-                  ignore_project_setup_py=args.ignore_setup_py,
+    build_recipes(build_order, python_modules, ctx,
+                  getattr(args, "private", None),
+                  ignore_project_setup_py=getattr(
+                      args, "ignore_setup_py", False
+                  ),
                  )
 
     ctx.bootstrap.run_distribute()
@@ -568,7 +571,7 @@ class ToolchainCL(object):
         if hasattr(args, "private") and args.private is not None:
             # Pass this value on to the internal bootstrap build.py:
             args.unknown_args += ["--private", args.private]
-        if args.ignore_setup_py:
+        if hasattr(args, "ignore_setup_py") and args.ignore_setup_py:
             args.use_setup_py = False
 
         self.args = args
@@ -583,7 +586,7 @@ class ToolchainCL(object):
             logger.setLevel(logging.DEBUG)
 
         self.ctx = Context()
-        self.ctx.use_setup_py = args.use_setup_py
+        self.ctx.use_setup_py = getattr(args, "use_setup_py", True)
 
         have_setup_py_or_similar = False
         if getattr(args, "private", None) is not None:


### PR DESCRIPTION
I broke things with the `setup.py` pull request :joy: commands other than `p4a apk` appear to be broken, from my test this fix makes it work again, sorry :grimacing: