### PR TITLE
Fix `CI` errors with latest tox

### DIFF
--- a/pythonforandroid/pythonpackage.py
+++ b/pythonforandroid/pythonpackage.py
@@ -436,10 +436,11 @@ def _extract_metainfo_files_from_package_unsafe(
                 os.path.join(output_path, 'pyproject.toml')
             )
 
-            # Get build backend from pyproject.toml:
+            # Get build backend and requirements from pyproject.toml:
             with open(os.path.join(path, 'pyproject.toml')) as f:
                 build_sys = pytoml.load(f)['build-system']
                 backend = build_sys["build-backend"]
+                build_requires.extend(build_sys["requires"])
 
             # Get a virtualenv with build requirements and get all metadata:
             env = BuildEnvironment()

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ deps =
 # makes it possible to override pytest args, e.g.
 # tox -- tests/test_graph.py
 commands = pytest {posargs:tests/}
+setenv =
+    PYTHONPATH={toxinidir}
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Due to a recent update of tox our ci tests are failing.

This pr makes two things:
  - Fixes the import errors with the latest tox by setting the `PYTHONPATH` environment variable
  - Fixes `python_package_basic` tests error: `pep517.wrappers.BackendUnavailable`

**Note:** resolves ci's tox errors appeared in #1819