### PR TITLE
Fix travis log doesn't produce any output for more than 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,10 @@ before_script:
   # (we ignore test_pythonpackage.py since these run way too long!! test_pythonpackage_basic.py will still be run.)
 
 script:
+  # Run a background process to make sure that travis will not kill our tests in
+  # case that the travis log doesn't produce any output for more than 10 minutes
+  - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
   - docker build --tag=p4a --file Dockerfile.py3 .
   - docker run -e CI p4a /bin/sh -c "$COMMAND"
+  # kill the background process started before run docker
+  - kill %1

--- a/ci/constants.py
+++ b/ci/constants.py
@@ -39,10 +39,6 @@ BROKEN_RECIPES_PYTHON2 = set([
     'x3dh',
     'pynacl',
     'doubleratchet',
-    # The opencv recipe fails to pass travis tests due to the long processing
-    # when building it and the lack of console output, so, it's only broken
-    # for travis, see: https://github.com/kivy/python-for-android/pull/1661
-    'opencv',
     'omemo',
     # requires `libpq-dev` system dependency e.g. for `pg_config` binary
     'psycopg2',
@@ -72,11 +68,6 @@ BROKEN_RECIPES_PYTHON3 = set([
     'secp256k1',
     'ffpyplayer',
     'icu',
-    # https://github.com/kivy/python-for-android/issues/1354
-    # The opencv recipe fails to pass travis tests due to the long processing
-    # when building it and the lack of console output, so, it's only broken
-    # for travis, see: https://github.com/kivy/python-for-android/pull/1661
-    'opencv',
     # requires `libpq-dev` system dependency e.g. for `pg_config` binary
     'psycopg2',
     'protobuf_cpp',

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -1,10 +1,8 @@
 from os.path import join
 import sh
 from pythonforandroid.recipe import NDKRecipe
-from pythonforandroid.toolchain import (
-    current_directory,
-    shprint,
-)
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
 from multiprocessing import cpu_count
 
 


### PR DESCRIPTION
I saw this in the following situations:
  - **Random error with `CI` tests that shouldn't fail** (I suspect that this is caused at times of high overload of the travis system)...like this one: https://travis-ci.org/kivy/python-for-android/builds/527925625
  - **Recipe that takes a long time to being processed** like the opencv recipe (also see #1661): https://travis-ci.org/kivy/python-for-android/jobs/487920951[ci]

So, in order to fix the above mentioned situations, this pr will run a background process which will print a message in travis log each 9 minutes. This background process will be killed after we make our tests.

Also we enable the `opencv` recipe for `rebuild_updated_recipes` in order to demonstrate that the background process introduced in here works as expected.

**As a side note:** we also could use the travis command `travis_wait` to do a similar thing as we do in this pr, but the problem of this command is that we will not get any log until we finish all the tests...

**Also see:** https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received