### PR TITLE
Rework of freetype/harfbuzz recipes

### DIFF
--- a/pythonforandroid/recipes/freetype/__init__.py
+++ b/pythonforandroid/recipes/freetype/__init__.py
@@ -1,44 +1,120 @@
 from pythonforandroid.toolchain import Recipe
+from pythonforandroid.logger import shprint, info
 from pythonforandroid.util import current_directory
-from pythonforandroid.logger import shprint
-from os.path import exists, join, realpath
+from os.path import exists, join
+from multiprocessing import cpu_count
 import sh
 
 
 class FreetypeRecipe(Recipe):
+    """The freetype library it's special, because has cyclic dependencies with
+    harfbuzz library, so freetype can be build with harfbuzz support, and
+    harfbuzz can be build with freetype support. This complicates the build of
+    both recipes because in order to get the full set we need to compile those
+    recipes several times:
+        - build freetype without harfbuzz
+        - build harfbuzz with freetype
+        - build freetype with harfbuzz support
+
+    .. note::
+        To build freetype with harfbuzz support you must add `harfbuzz` to your
+        requirements, otherwise freetype will be build without harfbuzz
+
+    .. seealso::
+        https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/
+    """
 
     version = '2.5.5'
     url = 'http://download.savannah.gnu.org/releases/freetype/freetype-{version}.tar.gz'  # noqa
 
-    depends = ['harfbuzz']
-
     def should_build(self, arch):
-        if exists(join(self.get_build_dir(arch.arch),
-                       'objs', '.libs', 'libfreetype.a')):
-            return False
-        return True
+        return not exists(
+            join(
+                self.get_build_dir(arch.arch),
+                'objs',
+                '.libs',
+                'libfreetype.so',
+            )
+        )
 
-    def build_arch(self, arch):
-        env = self.get_recipe_env(arch)
+    def get_recipe_env(self, arch=None, with_harfbuzz=False):
+        env = super(FreetypeRecipe, self).get_recipe_env(arch)
+        if with_harfbuzz:
+            harfbuzz_build = self.get_recipe(
+                'harfbuzz', self.ctx
+            ).get_build_dir(arch.arch)
+            freetype_install = join(self.get_build_dir(arch.arch), 'install')
+            env['CFLAGS'] = ' '.join(
+                [env['CFLAGS'], '-DFT_CONFIG_OPTION_USE_HARFBUZZ']
+            )
 
-        harfbuzz_recipe = Recipe.get_recipe('harfbuzz', self.ctx)
-        env['LDFLAGS'] = ' '.join(
-            [env['LDFLAGS'],
-             '-L{}'.format(join(harfbuzz_recipe.get_build_dir(arch.arch),
-                                'src', '.libs'))])
+            env['HARFBUZZ_CFLAGS'] = '-I{harfbuzz} -I{harfbuzz}/src'.format(
+                harfbuzz=harfbuzz_build
+            )
+            env['HARFBUZZ_LIBS'] = (
+                '-L{freetype}/lib -lfreetype '
+                '-L{harfbuzz}/src/.libs -lharfbuzz'.format(
+                    freetype=freetype_install, harfbuzz=harfbuzz_build
+                )
+            )
+        return env
 
+    def build_arch(self, arch, with_harfbuzz=False):
+        env = self.get_recipe_env(arch, with_harfbuzz=with_harfbuzz)
+
+        harfbuzz_in_recipes = 'harfbuzz' in self.ctx.recipe_build_order
+        prefix_path = self.get_build_dir(arch.arch)
+        if harfbuzz_in_recipes and not with_harfbuzz:
+            # This is the first time we build freetype and we modify `prefix`,
+            # because we will install the compiled library so later we can
+            # build harfbuzz (with freetype support) using this freetype
+            # installation
+            prefix_path = join(prefix_path, 'install')
+
+        # Configure freetype library
+        config_args = {
+            '--host={}'.format(arch.command_prefix),
+            '--prefix={}'.format(prefix_path),
+            '--without-zlib',
+            '--with-png=no',
+        }
+        if not harfbuzz_in_recipes:
+            info('Build freetype (without harfbuzz)')
+            config_args = config_args.union(
+                {'--disable-static', '--enable-shared', '--with-harfbuzz=no'}
+            )
+        elif not with_harfbuzz:
+            info('Build freetype for First time (without harfbuzz)')
+            # This time we will build our freetype library as static because we
+            # want that the harfbuzz library to have the necessary freetype
+            # symbols/functions, so we avoid to have two freetype shared
+            # libraries which will be confusing and harder to link with them
+            config_args = config_args.union(
+                {'--disable-shared', '--with-harfbuzz=no'}
+            )
+        else:
+            info('Build freetype for Second time (with harfbuzz)')
+            config_args = config_args.union(
+                {'--disable-static', '--enable-shared', '--with-harfbuzz=yes'}
+            )
+        info('Configure args are:\n\t-{}'.format('\n\t-'.join(config_args)))
+
+        # Build freetype library
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
-            shprint(configure,
-                    '--host=arm-linux-androideabi',
-                    '--prefix={}'.format(realpath('.')),
-                    '--without-zlib',
-                    '--with-png=no',
-                    '--disable-shared',
-                    _env=env)
-            shprint(sh.make, '-j5', _env=env)
+            shprint(configure, *config_args, _env=env)
+            shprint(sh.make, '-j', str(cpu_count()), _env=env)
 
-            shprint(sh.cp, 'objs/.libs/libfreetype.a', self.ctx.libs_dir)
+            if not with_harfbuzz and harfbuzz_in_recipes:
+                info('Installing freetype (first time build without harfbuzz)')
+                # First build, install the compiled lib, and clean build env
+                shprint(sh.make, 'install', _env=env)
+                shprint(sh.make, 'distclean', _env=env)
+            else:
+                # Second build (or the first if harfbuzz not enabled), now we
+                # copy definitive libs to libs collection. Be sure to link your
+                # recipes to the definitive library, located at: objs/.libs
+                self.install_libs(arch, 'objs/.libs/libfreetype.so')
 
 
 recipe = FreetypeRecipe()


### PR DESCRIPTION
To fix cyclic dependency between `freetype` and `harfbuzz` and to produce shared libraries

And because we use those libraries in multiple recipes and building those libraries as shared libraries can reduce a little the apk size in some circumstances (when we build multiple recipes that depends on those libraries)

This changes are friendly with #1822 which needs shared libraries for `freetype` and `harfbuzz`

**Important note:** if `freetype` and `harfbuzz` are in `requirements`, then the cyclic dependency of those libraries will be solved otherwise the library will be build without linking with the other library (as expected)

**As a side note:** tested with a Pillow test app and arch armv7a (#1826)