### PR TITLE
Add coverage with coveralls and make use of travis stages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+    *test*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ services:
 
 before_install:
   - travis_retry sudo apt update -qq
-  - travis_retry sudo apt install -qq --no-install-recommends python2.7 python3 python3-venv python3-virtualenv
+  # to successfully send the coveralls reports we need pyOpenSSL
+  - travis_retry sudo apt install -qq --no-install-recommends python2.7 python3 python3-venv python3-virtualenv python3-setuptools python3-pip python3-openssl
   # (venv/virtualenv are both used by tests/test_pythonpackage.py)
   - sudo pip install tox>=2.0
+  - sudo pip3 install coveralls
   # https://github.com/travis-ci/travis-ci/issues/6069#issuecomment-266546552
   - git remote set-branches --add origin master
   - git fetch
@@ -39,6 +41,8 @@ script:
   # case that the travis log doesn't produce any output for more than 10 minutes
   - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
   - docker build --tag=p4a --file Dockerfile.py3 .
-  - docker run -e CI p4a /bin/sh -c "$COMMAND"
+  - docker run -e CI -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" p4a /bin/sh -c "$COMMAND"
   # kill the background process started before run docker
   - kill %1
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,19 @@ dist: xenial  # needed for more recent python 3 and python3-venv
 
 language: generic
 
+stages:
+  - lint
+  - test
+
 services:
   - docker
 
 before_install:
   - travis_retry sudo apt update -qq
   # to successfully send the coveralls reports we need pyOpenSSL
-  - travis_retry sudo apt install -qq --no-install-recommends python2.7 python3 python3-venv python3-virtualenv python3-setuptools python3-pip python3-openssl
+  - travis_retry sudo apt install -qq --no-install-recommends
+    python2.7 python3 python3-venv python3-virtualenv python3-pip
+    python3-setuptools python3-openssl
   # (venv/virtualenv are both used by tests/test_pythonpackage.py)
   - sudo pip install tox>=2.0
   - sudo pip3 install coveralls
@@ -22,27 +28,42 @@ env:
   global:
     - ANDROID_SDK_HOME=/opt/android/android-sdk
     - ANDROID_NDK_HOME=/opt/android/android-ndk
-  matrix:
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools'
-    # overrides requirements to skip `peewee` pure python module, see:
-    # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
-    - COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements python2,numpy'
-    # builds only the recipes that moved
-    - COMMAND='. venv/bin/activate && ./ci/rebuild_updated_recipes.py'
 
-before_script:
-  # we want to fail fast on tox errors without having to `docker build` first
-  - tox -- tests/ --ignore tests/test_pythonpackage.py
-  # (we ignore test_pythonpackage.py since these run way too long!! test_pythonpackage_basic.py will still be run.)
+jobs:
+  include:
+    - stage: lint
+      name: "Tox tests and coverage"
+      script:
+        # we want to fail fast on tox errors without having to `docker build` first
+        - tox -- tests/ --ignore tests/test_pythonpackage.py
+        # (we ignore test_pythonpackage.py since these run way too long!!
+        #  test_pythonpackage_basic.py will still be run.)
+      after_success:
+        - coveralls
 
-script:
-  # Run a background process to make sure that travis will not kill our tests in
-  # case that the travis log doesn't produce any output for more than 10 minutes
-  - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
-  - docker build --tag=p4a --file Dockerfile.py3 .
-  - docker run -e CI -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" p4a /bin/sh -c "$COMMAND"
-  # kill the background process started before run docker
-  - kill %1
-after_success:
-  - coveralls
+    - &testing
+      stage: test
+      before_script:
+        # build docker image
+        - docker build --tag=p4a --file Dockerfile.py3 .
+        # Run a background process to make sure that travis will not kill our tests in
+        # case that the travis log doesn't produce any output for more than 10 minutes
+        - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
+      script:
+        - docker run -e CI -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" p4a /bin/sh -c "$COMMAND"
+      after_script:
+        # kill the background process started before run docker
+        - kill %1
+      name: Python 3 basic
+      # overrides requirements to skip `peewee` pure python module, see:
+      # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
+      env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools'
+    - <<: *testing
+      name: Python 2 basic
+      env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools'
+    - <<: *testing
+      name: Python 2 numpy
+      env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --bootstrap sdl2 --requirements python2,numpy'
+    - <<: *testing
+      name: Rebuild updated recipes
+      env: COMMAND='. venv/bin/activate && ./ci/rebuild_updated_recipes.py'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ python-for-android
 ==================
 
 [![Build Status](https://travis-ci.org/kivy/python-for-android.svg?branch=master)](https://travis-ci.org/kivy/python-for-android)
+[![Coverage Status](https://coveralls.io/repos/github/kivy/python-for-android/badge.svg?branch=master&kill_cache=1)](https://coveralls.io/github/kivy/python-for-android?branch=master)
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers) 
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors) 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,19 @@ deps =
     mock
     pytest
     virtualenv
+    py3: coveralls
 # makes it possible to override pytest args, e.g.
 # tox -- tests/test_graph.py
 commands = pytest {posargs:tests/}
+passenv = TRAVIS TRAVIS_*
 setenv =
     PYTHONPATH={toxinidir}
+
+[testenv:py3]
+# for py3 env we will get code coverage
+commands =
+    coverage run --branch --source=pythonforandroid -m pytest {posargs:tests/}
+    coverage report -m
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
To achieve the desired result we also modify the travis file, Implementing travis stages which are:
  - **Lint** (our tox tests runs in here and also we collect the coverage data)
  - **Test** (our build tests, which are exactly the same than the ones we have been using for a while, but now those are labelled)

Make use of the stages allow us to sequentially run some tests (without loosing the parallel builds, so the `Test` stage will be runned in parallel mode...the same behaviour than we have right now). Be aware that if the `Lint` stage fails, then the `Test` stage will never be run. This feature has been implemented in here in order to only send the coverage reports in case that we succeed with `Lint` stage.

This is friendly with the idea to implement some kind of automation to auto release/publish p4a versions (see issue/discussion #1833). We could implement it in a new stage (eg: deploy), to build docs, release a new version when master branch is tagged, upload it to pypi....

**As a side note:** notice that we currently perform our tox tests 4 times (one for each test we make)...with this pr we only make the tox tests one time (`Lint` stage), so this should improve the timings with our ci tests

**Notes:**
  - I took myself the liberty to enable `coveralls` for python-for-android (not only for my fork, also enabled for the main project `kivy/python-for-android`, if this pr is not merged, then we should disable it)
  - The added badge in README.md file should be automatically updated to the right value at the time of merging this in master branch
  - The coverage is configured to only track the `pythonforandroid` module 
  - The coverage report is not totally accurate because we skip some tests in travis

**Solves:**  #1788

**Coverage report at:** https://coveralls.io/jobs/49254277