### PR TITLE
bugfix: unpack for nonzip archives also needs to compare basename(dir)

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -409,7 +409,7 @@ class Recipe(with_metaclass(RecipeMeta)):
                         sh.tar('xf', extraction_filename)
                         root_directory = sh.tar('tf', extraction_filename).stdout.decode(
                                 'utf-8').split('\n')[0].split('/')[0]
-                        if root_directory != directory_name:
+                        if root_directory != basename(directory_name):
                             shprint(sh.mv, root_directory, directory_name)
                     else:
                         raise Exception(


### PR DESCRIPTION
This fixes a case when a recipe for a tar.gz archive attempts to mv to a subdirectory of itself.