### PR TITLE
Add `--without-bzip2` to freetype's configure args

### DIFF
--- a/pythonforandroid/recipes/freetype/__init__.py
+++ b/pythonforandroid/recipes/freetype/__init__.py
@@ -76,6 +76,7 @@ class FreetypeRecipe(Recipe):
             '--host={}'.format(arch.command_prefix),
             '--prefix={}'.format(prefix_path),
             '--without-zlib',
+            '--without-bzip2',
             '--with-png=no',
         }
         if not harfbuzz_in_recipes:


### PR DESCRIPTION
To fix freetype build for `openSUSE` and maybe other oses.

**Note:** It seems that there is a bug in `bzip2-devel` for debian and derivatives which are distributed without a `pkg-config` file, so when we compile freetype with a debian os (or derivative) we build it without bzip2 support, so we enforce to disable bzip2 support, because we know that freetype works fine without bzip2 support

Resolves: #1854