### PR TITLE
Try to be more clear in README about api levels & quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,29 +33,27 @@ Follow the [quickstart
 instructions](<https://python-for-android.readthedocs.org/en/latest/quickstart/>)
 to install and begin creating APKs.
 
-Quick instructions to start would be:
+**Quick instructions**: install python-for-android with:
 
     pip install python-for-android
 
-or to test the develop branch:
+(for the develop branch: `pip install git+https://github.com/kivy/python-for-android.git`)
 
-    pip install git+https://github.com/kivy/python-for-android.git
+Test that the install works with:
 
-The executable is called ``python-for-android`` or ``p4a`` (both are
-equivalent). To test that the installation worked, try::
+    p4a --version
 
-    python-for-android recipes
+To build any actual apps, **set up the Android SDK and NDK**
+as described in the [quickstart](
+<https://python-for-android.readthedocs.org/en/latest/quickstart/#installing-android-sdk>).
+**Use the SDK/NDK API level & NDK version as in the quickstart,**
+other API levels may not work.
 
-This should return a list of available build recipes.
-
-To build any distributions, you need to set up the Android SDK and NDK
-as described in the documentation linked above.
-
-If you did this, to build an APK with SDL2 you can try e.g.:
+With everything installed, build an APK with SDL2 with e.g.:
 
     p4a apk --requirements=kivy --private /home/username/devel/planewave_frozen/ --package=net.inclem.planewavessdl2 --name="planewavessdl2" --version=0.5 --bootstrap=sdl2
 
-For full instructions and parameter options, see [the
+**For full instructions and parameter options,** see [the
 documentation](https://python-for-android.readthedocs.io/en/latest/quickstart/#usage).
 
 ## Support

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -101,17 +101,15 @@ This will reveal all the Python-related files::
   $ ls
   android_runnable.pyo  include          interpreter_subprocess  main.kv   pipinterface.kv   settings.pyo
   assets                __init__.pyo     interpreterwrapper.pyo  main.pyo  pipinterface.pyo  utils.pyo
-  editor.kv             interpreter.kv   lib                     menu.kv   private.mp3       widgets.pyo
+  editor.kv             interpreter.kv   _python_bundle          menu.kv   private.mp3       widgets.pyo
   editor.pyo            interpreter.pyo  libpymodules.so         menu.pyo  settings.kv
 
 Most of these files have been included by the user (in this case, they
 come from one of my own apps), the rest relate to the python
 distribution.
 
-With Python 2, the Python installation can mostly be found in the
-``lib`` folder. With Python 3 (using the ``python3crystax`` recipe),
-the Python installation can be found in a folder named
-``crystax_python``.
+The python installation, along with all side-packages, is mostly contained
+inside the `_python_bundle` folder.
 
 
 Common errors


### PR DESCRIPTION
I revamped the starting out section in the README, to address the following issues:

- I tried making it super clear that the target api, minimum api & ndk version of the quickstart should be used to avoid trouble. we have so many beginners who come into the chat who use another version and don't realize this is the reason why nothing works

- the old readme mentioned recipes, and from my own years ago beginner experience this is quite confusing. recipes are an advanced tool and to a beginner it may not be clear what it is, if e.g. a recipe may be something to build their own app and they need to create one, etc

- the readme also used the word "distribution": similarly nobody knows what that is starting out, so I avoided using it and instead called it building an app, since that is what anyone coming to the project likely wants to do

- I also tried to trim the readme quick instructions down and put optional parts (e.g. the dev version) such that they stand out less, so that the non-optional steps are more obvious

Non-README fixes:

- Revamped many parts of the quickstart, including the section at the start where concepts are explained to make it more clear that usually there is no need to touch & deal with recipes, and I moved the 32-bit section of the NDK way below since it's such a special case

- The quickstart chapter in the docs recommended minimum/ndk API 19, I'm pretty sure that doesn't work. I changed it to 21 which works. It also had a mention of target API 26 although another part mentions 27. I changed it all to 27 for consistency

- The troubleshooting guide still mentions Crystax as the usual Python 3 approach, and claims the python install is inside a `lib` folder. Pretty sure it's always `_python_bundle` now, so I changed it to reflect that