### PR TITLE
Make the tox jobs run in parallel &...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
 
 jobs:
   include:
-    - stage: lint
-      name: "Tox tests and coverage"
+    - &linting
+      stage: lint
       language: python
       python: 3.7
       before_script:
@@ -45,6 +45,14 @@ jobs:
         - tox -- tests/ --ignore tests/test_pythonpackage.py
         # (we ignore test_pythonpackage.py since these run way too long!!
         #  test_pythonpackage_basic.py will still be run.)
+      name: "Tox Pep8"
+      env: TOXENV=pep8
+    - <<: *linting
+      name: "Tox Python 2"
+      env: TOXENV=py27
+    - <<: *linting
+      name: "Tox Python 3 & Coverage"
+      env: TOXENV=py3
       after_success:
         - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/6069#issuecomment-266546552
-  - git remote set-branches --add origin master
+  - git remote set-branches --add origin develop
   - git fetch
 
 env:


### PR DESCRIPTION
Also move from branch `master` to `develop` our travis file git commands

Make the tox jobs run in parallel will decrease the timings of the lint stage considerably (from ~5' to ~3'). Also, Making the jobs run in parallel will allow us to split the log output for each test, so it will be easier to find the problem, if any