### PR TITLE
customizability

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -663,6 +663,24 @@ tools directory of the Android SDK.
                               'https://developer.android.com/guide/'
                               'topics/manifest/'
                               'activity-element.html'))
+
+    ap.add_argument('--android-entrypoint', dest='android_entrypoint',
+                    default='org.kivy.android.PythonActivity',
+                    help='Defines which java class will be used for startup, usually a subclass of PythonActivity')
+    ap.add_argument('--android-apptheme', dest='android_apptheme',
+                    default='@android:style/Theme.NoTitleBar',
+                    help='Defines which app theme should be selected for the main activity')
+    ap.add_argument('--add-compile-option', dest='compile_options', default=[],
+                    action='append', help='add compile options to gradle.build')
+    ap.add_argument('--add-gradle-repository', dest='gradle_repositories',
+                    default=[],
+                    action='append',
+                    help='Ddd a repository for gradle')
+    ap.add_argument('--add-packaging-option', dest='packaging_options',
+                    default=[],
+                    action='append',
+                    help='Dndroid packaging options')
+
     ap.add_argument('--wakelock', dest='wakelock', action='store_true',
                     help=('Indicate if the application needs the device '
                           'to stay on'))

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -13,68 +13,82 @@ allprojects {
     repositories {
         google()
         jcenter()
-	    flatDir {
-	    	dirs 'libs'
-	    }
+        {%- for repo in args.gradle_repositories %}
+        {{repo}}
+        {%- endfor %}
+        flatDir {
+            dirs 'libs'
+        }
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion {{ android_api }}
-	buildToolsVersion '{{ build_tools_version }}'
-	defaultConfig {
-		minSdkVersion {{ args.min_sdk_version }}
-		targetSdkVersion {{ android_api }}
-		versionCode {{ args.numeric_version }}
-		versionName '{{ args.version }}'
-	}
+    compileSdkVersion {{ android_api }}
+    buildToolsVersion '{{ build_tools_version }}'
+    defaultConfig {
+        minSdkVersion {{ args.min_sdk_version }}
+        targetSdkVersion {{ android_api }}
+        versionCode {{ args.numeric_version }}
+        versionName '{{ args.version }}'
+    }
 
-	{% if args.sign -%}
-	signingConfigs {
-		release {
-			storeFile file(System.getenv("P4A_RELEASE_KEYSTORE"))
-			keyAlias System.getenv("P4A_RELEASE_KEYALIAS")
-			storePassword System.getenv("P4A_RELEASE_KEYSTORE_PASSWD")
-			keyPassword System.getenv("P4A_RELEASE_KEYALIAS_PASSWD")
-		}
-	}
+    {% if args.sign -%}
+    signingConfigs {
+        release {
+            storeFile file(System.getenv("P4A_RELEASE_KEYSTORE"))
+            keyAlias System.getenv("P4A_RELEASE_KEYALIAS")
+            storePassword System.getenv("P4A_RELEASE_KEYSTORE_PASSWD")
+            keyPassword System.getenv("P4A_RELEASE_KEYALIAS_PASSWD")
+        }
+    }
     {%- endif %}
 
-	buildTypes {
-		debug {
-		}
-		release {
-			{% if args.sign -%}
-			signingConfig signingConfigs.release
-			{%- endif %}
-		}
-	}
+    {% if args.packaging_options -%}
+    packagingOptions {
+        {%- for option in args.packaging_options %}
+        {{option}}
+        {%- endfor %}
+    }
+    {%- endif %}
+
+    buildTypes {
+        debug {
+        }
+        release {
+            {% if args.sign -%}
+            signingConfig signingConfigs.release
+            {%- endif %}
+        }
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+        {%- for option in args.compile_options %}
+        {{option}}
+        {%- endfor %}
     }
 
     sourceSets {
         main {
             jniLibs.srcDir 'libs'
-            }
+        }
     }
 
 }
 
 dependencies {
-	{%- for aar in aars %}
-	compile(name: '{{ aar }}', ext: 'aar')
-	{%- endfor -%}
-        {%- for jar in jars %}
-        compile files('src/main/libs/{{ jar }}')
-        {%- endfor -%}
-	{%- if args.depends -%}
-	{%- for depend in args.depends %}
-	compile '{{ depend }}'
-	{%- endfor %}
-	{%- endif %}
+    {%- for aar in aars %}
+    compile(name: '{{ aar }}', ext: 'aar')
+    {%- endfor -%}
+    {%- for jar in jars %}
+    compile files('src/main/libs/{{ jar }}')
+    {%- endfor -%}
+    {%- if args.depends -%}
+    {%- for depend in args.depends %}
+    compile '{{ depend }}'
+    {%- endfor %}
+    {%- endif %}
 }

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -54,7 +54,7 @@
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon"
                  android:allowBackup="{{ args.allow_backup }}"
-                 android:theme="@android:style/Theme.NoTitleBar{% if not args.window %}.Fullscreen{% endif %}"
+                 android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true" >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />
@@ -64,7 +64,7 @@
         <meta-data android:name="{{ m.split('=', 1)[0] }}" android:value="{{ m.split('=', 1)[-1] }}"/>{% endfor %}
         <meta-data android:name="wakelock" android:value="{% if args.wakelock %}1{% else %}0{% endif %}"/>
 
-        <activity android:name="org.kivy.android.PythonActivity"
+        <activity android:name="{{args.android_entrypoint}}"
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -47,7 +47,7 @@
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon"
                  android:allowBackup="true"
-                 android:theme="@android:style/Theme.NoTitleBar{% if not args.window %}.Fullscreen{% endif %}"
+                 android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true" >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -48,7 +48,7 @@
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon"
                  android:allowBackup="true"
-                 android:theme="@android:style/Theme.NoTitleBar{% if not args.window %}.Fullscreen{% endif %}"
+                 android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true" >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />


### PR DESCRIPTION
# customizability options for p4a

This PR introduces a set of options which deal with integration of java/kotlin libraries

- android entrypoint: this option already existed in buildozer but was not implemented in p4a.
    this allows to specify a custom class inherited class from org.kivy.android.PythonActivity as entrypoint
- android apptheme: specifies a custom app-theme for the main activity, will be generated into the manifest
- compile-options
- gradle-repository: with this option it is possible to specify additional repositories for the gradle build
- packaging-options: results in packagingOptions in the gradle script, can be necessary to resolve conflicts in java/kotlin packages
