### PR TITLE
fix ctypes-util-find-library issue for python2

### DIFF
--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -31,7 +31,8 @@ class Python2Recipe(GuestPythonRecipe):
                'patches/fix-filesystem-default-encoding.patch',
                'patches/fix-gethostbyaddr.patch',
                'patches/fix-posix-declarations.patch',
-               'patches/fix-pwd-gecos.patch']
+               'patches/fix-pwd-gecos.patch',
+               'patches/fix-ctypes-util-find-library.patch']
 
     configure_args = ('--host={android_host}',
                       '--build={android_build}',

--- a/pythonforandroid/recipes/python2/patches/fix-ctypes-util-find-library.patch
+++ b/pythonforandroid/recipes/python2/patches/fix-ctypes-util-find-library.patch
@@ -1,0 +1,19 @@
+diff -u a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+--- a/Lib/ctypes/util.py	2019-06-20 18:52:01.372205226 +0200
++++ b/Lib/ctypes/util.py	2019-06-20 18:51:39.612970779 +0200
+@@ -70,7 +70,14 @@
+     def find_library(name):
+         return name
+ 
+-if os.name == "posix" and sys.platform == "darwin":
++# This patch overrides the find_library to look in the right places on
++# Android
++if True:
++    from android._ctypes_library_finder import find_library as _find_lib
++    def find_library(name):
++        return _find_lib(name)
++
++elif os.name == "posix" and sys.platform == "darwin":
+     from ctypes.macholib.dyld import dyld_find as _dyld_find
+     def find_library(name):
+         possible = ['lib%s.dylib' % name,


### PR DESCRIPTION
Adding patch for fixing ctypes-util-find-library issue for python2 support