### PR TITLE
Make it raise an error if an old ndk is used

### DIFF
--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -22,7 +22,7 @@ def check_ndk_version(ndk_dir):
     specified via attribute `MIN_NDK_VERSION`.
 
     .. versionchanged:: 2019.06.06.1.dev0
-        Added the ability to get android's ndk `letter version` and also
+        Added the ability to get android's NDK `letter version` and also
         rewrote to raise an exception in case that an NDK version lower than
         the minimum supported is detected.
     """
@@ -30,11 +30,11 @@ def check_ndk_version(ndk_dir):
 
     if version is None:
         warning(
-            'Unable to read the ndk version, assuming that you are using an'
-            ' NDK greater than {min_supported} (the minimum ndk required to'
+            'Unable to read the NDK version, assuming that you are using an'
+            ' NDK greater than {min_supported} (the minimum NDK required to'
             ' use p4a successfully).\n'
             'Note: If you got build errors, consider to download the'
-            ' recommended ndk version which is {rec_version} and try'
+            ' recommended NDK version which is {rec_version} and try'
             ' it again (after removing all the files generated with this'
             ' build). To download the android NDK visit the following page: '
             '{ndk_url}'.format(
@@ -46,7 +46,7 @@ def check_ndk_version(ndk_dir):
         return
 
     # create a dictionary which will describe the relationship of the android's
-    # ndk minor version with the `human readable` letter version, egs:
+    # NDK minor version with the `human readable` letter version, egs:
     # Pkg.Revision = 17.1.4828580 => ndk-17b
     # Pkg.Revision = 17.2.4988734 => ndk-17c
     # Pkg.Revision = 19.0.5232133 => ndk-19 (No letter)
@@ -70,7 +70,7 @@ def check_ndk_version(ndk_dir):
                 user_version=string_version, min_supported=MIN_NDK_VERSION
             ),
             instructions=(
-                'Please, go to the android ndk page ({ndk_url}) and download a'
+                'Please, go to the android NDK page ({ndk_url}) and download a'
                 ' supported version.\n*** The currently recommended NDK'
                 ' version is {rec_version} ***'.format(
                     ndk_url=NDK_DOWNLOAD_URL,

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -9,9 +9,38 @@ from pythonforandroid.util import BuildInterruptingException
 MIN_NDK_VERSION = 17
 MAX_NDK_VERSION = 17
 
-RECOMMENDED_NDK_VERSION = '17c'
+RECOMMENDED_NDK_VERSION = "17c"
+NDK_DOWNLOAD_URL = "https://developer.android.com/ndk/downloads/"
+
+# Important log messages
 NEW_NDK_MESSAGE = 'Newer NDKs may not be fully supported by p4a.'
-NDK_DOWNLOAD_URL = 'https://developer.android.com/ndk/downloads/'
+UNKNOWN_NDK_MESSAGE = (
+    'Could not determine NDK version, no source.properties in the NDK dir'
+)
+PARSE_ERROR_NDK_MESSAGE = (
+    'Could not parse $NDK_DIR/source.properties, not checking NDK version'
+)
+READ_ERROR_NDK_MESSAGE = (
+    'Unable to read the NDK version from the given directory {ndk_dir}'
+)
+ENSURE_RIGHT_NDK_MESSAGE = (
+    'Make sure your NDK version is greater than {min_supported}. If you get '
+    'build errors, download the recommended NDK {rec_version} from {ndk_url}'
+)
+NDK_LOWER_THAN_SUPPORTED_MESSAGE = (
+    'The minimum supported NDK version is {min_supported}. '
+    'You can download it from {ndk_url}'
+)
+UNSUPPORTED_NDK_API_FOR_ARMEABI_MESSAGE = (
+    'Asked to build for armeabi architecture with API '
+    '{req_ndk_api}, but API {max_ndk_api} or greater does not support armeabi'
+)
+CURRENT_NDK_VERSION_MESSAGE = (
+    'Found NDK version {ndk_version}'
+)
+RECOMMENDED_NDK_VERSION_MESSAGE = (
+    'Maximum recommended NDK version is {recommended_ndk_version}'
+)
 
 
 def check_ndk_version(ndk_dir):
@@ -29,14 +58,9 @@ def check_ndk_version(ndk_dir):
     version = read_ndk_version(ndk_dir)
 
     if version is None:
+        warning(READ_ERROR_NDK_MESSAGE.format(ndk_dir=ndk_dir))
         warning(
-            'Unable to read the NDK version from the given directory '
-            '{}'.format(ndk_dir)
-        )
-        warning(
-            "Make sure your NDK version is greater than {min_supported}. "
-            "If you get build errors, download the recommended NDK "
-            "{rec_version} from {ndk_url}".format(
+            ENSURE_RIGHT_NDK_MESSAGE.format(
                 min_supported=MIN_NDK_VERSION,
                 rec_version=RECOMMENDED_NDK_VERSION,
                 ndk_url=NDK_DOWNLOAD_URL,
@@ -60,13 +84,12 @@ def check_ndk_version(ndk_dir):
         major_version=major_version, letter_version=letter_version
     )
 
-    info('Found NDK version {}'.format(string_version))
+    info(CURRENT_NDK_VERSION_MESSAGE.format(ndk_version=string_version))
 
     if major_version < MIN_NDK_VERSION:
         raise BuildInterruptingException(
-            'The minimum supported NDK version is {min_supported}. You can '
-            'download it from {ndk_url}'.format(
-                min_supported=MIN_NDK_VERSION, ndk_url=NDK_DOWNLOAD_URL,
+            NDK_LOWER_THAN_SUPPORTED_MESSAGE.format(
+                min_supported=MIN_NDK_VERSION, ndk_url=NDK_DOWNLOAD_URL
             ),
             instructions=(
                 'Please, go to the android NDK page ({ndk_url}) and download a'
@@ -79,8 +102,8 @@ def check_ndk_version(ndk_dir):
         )
     elif major_version > MAX_NDK_VERSION:
         warning(
-            'Maximum recommended NDK version is {}'.format(
-                RECOMMENDED_NDK_VERSION
+            RECOMMENDED_NDK_VERSION_MESSAGE.format(
+                recommended_ndk_version=RECOMMENDED_NDK_VERSION
             )
         )
         warning(NEW_NDK_MESSAGE)
@@ -92,16 +115,14 @@ def read_ndk_version(ndk_dir):
         with open(join(ndk_dir, 'source.properties')) as fileh:
             ndk_data = fileh.read()
     except IOError:
-        info('Could not determine NDK version, no source.properties '
-             'in the NDK dir')
+        info(UNKNOWN_NDK_MESSAGE)
         return
 
     for line in ndk_data.split('\n'):
         if line.startswith('Pkg.Revision'):
             break
     else:
-        info('Could not parse $NDK_DIR/source.properties, not checking '
-             'NDK version')
+        info(PARSE_ERROR_NDK_MESSAGE)
         return
 
     # Line should have the form "Pkg.Revision = ..."
@@ -130,9 +151,9 @@ def check_target_api(api, arch):
 
     if api >= ARMEABI_MAX_TARGET_API and arch == 'armeabi':
         raise BuildInterruptingException(
-            'Asked to build for armeabi architecture with API '
-            '{}, but API {} or greater does not support armeabi'.format(
-                api, ARMEABI_MAX_TARGET_API),
+            UNSUPPORTED_NDK_API_FOR_ARMEABI_MESSAGE.format(
+                req_ndk_api=api, max_ndk_api=ARMEABI_MAX_TARGET_API
+            ),
             instructions='You probably want to build with --arch=armeabi-v7a instead')
 
     if api < MIN_TARGET_API:
@@ -143,14 +164,19 @@ def check_target_api(api, arch):
 MIN_NDK_API = 21
 RECOMMENDED_NDK_API = 21
 OLD_NDK_API_MESSAGE = ('NDK API less than {} is not supported'.format(MIN_NDK_API))
+TARGET_NDK_API_GREATER_THAN_TARGET_API_MESSAGE = (
+    'Target NDK API is {ndk_api}, '
+    'higher than the target Android API {android_api}.'
+)
 
 
 def check_ndk_api(ndk_api, android_api):
     """Warn if the user's NDK is too high or low."""
     if ndk_api > android_api:
         raise BuildInterruptingException(
-            'Target NDK API is {}, higher than the target Android API {}.'.format(
-                ndk_api, android_api),
+            TARGET_NDK_API_GREATER_THAN_TARGET_API_MESSAGE.format(
+                ndk_api=ndk_api, android_api=android_api
+            ),
             instructions=('The NDK API is a minimum supported API number and must be lower '
                           'than the target Android API'))
 

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -30,14 +30,13 @@ def check_ndk_version(ndk_dir):
 
     if version is None:
         warning(
-            'Unable to read the NDK version, assuming that you are using an'
-            ' NDK greater than {min_supported} (the minimum NDK required to'
-            ' use p4a successfully).\n'
-            'Note: If you got build errors, consider to download the'
-            ' recommended NDK version which is {rec_version} and try'
-            ' it again (after removing all the files generated with this'
-            ' build). To download the android NDK visit the following page: '
-            '{ndk_url}'.format(
+            'Unable to read the NDK version from the given directory '
+            '{}'.format(ndk_dir)
+        )
+        warning(
+            "Make sure your NDK version is greater than {min_supported}. "
+            "If you get build errors, download the recommended NDK "
+            "{rec_version} from {ndk_url}".format(
                 min_supported=MIN_NDK_VERSION,
                 rec_version=RECOMMENDED_NDK_VERSION,
                 ndk_url=NDK_DOWNLOAD_URL,
@@ -65,9 +64,9 @@ def check_ndk_version(ndk_dir):
 
     if major_version < MIN_NDK_VERSION:
         raise BuildInterruptingException(
-            'Unsupported NDK version detected {user_version}\n'
-            '* Note: Minimum supported NDK version is {min_supported}'.format(
-                user_version=string_version, min_supported=MIN_NDK_VERSION
+            'The minimum supported NDK version is {min_supported}. You can '
+            'download it from {ndk_url}'.format(
+                min_supported=MIN_NDK_VERSION, ndk_url=NDK_DOWNLOAD_URL,
             ),
             instructions=(
                 'Please, go to the android NDK page ({ndk_url}) and download a'

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,191 @@
+import unittest
+from os.path import join
+from sys import version as py_version
+
+try:
+    from unittest import mock
+except ImportError:
+    # `Python 2` or lower than `Python 3.3` does not
+    # have the `unittest.mock` module built-in
+    import mock
+from pythonforandroid.recommendations import (
+    check_ndk_api,
+    check_ndk_version,
+    check_target_api,
+    read_ndk_version,
+    MAX_NDK_VERSION,
+    RECOMMENDED_NDK_VERSION,
+    RECOMMENDED_TARGET_API,
+    MIN_NDK_API,
+    MIN_NDK_VERSION,
+    NDK_DOWNLOAD_URL,
+    ARMEABI_MAX_TARGET_API,
+    MIN_TARGET_API,
+)
+from pythonforandroid.util import BuildInterruptingException
+running_in_py2 = int(py_version[0]) < 3
+
+
+class TestRecommendations(unittest.TestCase):
+    """
+    An inherited class of `unittest.TestCase`to test the module
+    :mod:`~pythonforandroid.recommendations`.
+    """
+
+    def setUp(self):
+        self.ndk_dir = "/opt/android/android-ndk"
+
+    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
+    @mock.patch("pythonforandroid.recommendations.read_ndk_version")
+    def test_check_ndk_version_greater_than_recommended(self, mock_read_ndk):
+        mock_read_ndk.return_value.version = [MAX_NDK_VERSION + 1, 0, 5232133]
+        with self.assertLogs(level="INFO") as cm:
+            check_ndk_version(self.ndk_dir)
+        mock_read_ndk.assert_called_once_with(self.ndk_dir)
+        self.assertEqual(
+            cm.output,
+            [
+                "INFO:p4a:[INFO]:    Found NDK version {ndk_current}".format(
+                    ndk_current=MAX_NDK_VERSION + 1
+                ),
+                "WARNING:p4a:[WARNING]:"
+                " Maximum recommended NDK version is {ndk_recommended}".format(
+                    ndk_recommended=RECOMMENDED_NDK_VERSION
+                ),
+                "WARNING:p4a:[WARNING]:"
+                " Newer NDKs may not be fully supported by p4a.",
+            ],
+        )
+
+    @mock.patch("pythonforandroid.recommendations.read_ndk_version")
+    def test_check_ndk_version_lower_than_recommended(self, mock_read_ndk):
+        mock_read_ndk.return_value.version = [MIN_NDK_VERSION - 1, 0, 5232133]
+        with self.assertRaises(BuildInterruptingException) as e:
+            check_ndk_version(self.ndk_dir)
+        self.assertEqual(
+            e.exception.args[0],
+            "Unsupported NDK version detected {ndk_current}"
+            "\n* Note: Minimum supported NDK version is {ndk_min}".format(
+                ndk_current=MIN_NDK_VERSION - 1, ndk_min=MIN_NDK_VERSION
+            ),
+        )
+        mock_read_ndk.assert_called_once_with(self.ndk_dir)
+
+    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
+    def test_check_ndk_version_error(self):
+        """
+        Test that a fake ndk dir give us two messages:
+            - first should be an `INFO` log
+            - second should be an `WARNING` log
+        """
+        with self.assertLogs(level="INFO") as cm:
+            check_ndk_version(self.ndk_dir)
+        self.assertEqual(
+            cm.output,
+            [
+                "INFO:p4a:[INFO]:    Could not determine NDK version, "
+                "no source.properties in the NDK dir",
+                "WARNING:p4a:[WARNING]: Unable to read the ndk version, "
+                "assuming that you are using an NDK greater than 17 (the "
+                "minimum ndk required to use p4a successfully).\n"
+                "Note: If you got build errors, consider to download the "
+                "recommended ndk version which is 17c and try it again (after "
+                "removing all the files generated with this build). To "
+                "download the android NDK visit the following "
+                "page: {download_url}".format(download_url=NDK_DOWNLOAD_URL),
+            ],
+        )
+
+    @mock.patch("pythonforandroid.recommendations.open")
+    def test_read_ndk_version(self, mock_open_src_prop):
+        mock_open_src_prop.side_effect = [
+            mock.mock_open(
+                read_data="Pkg.Revision = 17.2.4988734"
+            ).return_value
+        ]
+        version = read_ndk_version(self.ndk_dir)
+        mock_open_src_prop.assert_called_once_with(
+            join(self.ndk_dir, "source.properties")
+        )
+        assert version == "17.2.4988734"
+
+    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
+    @mock.patch("pythonforandroid.recommendations.open")
+    def test_read_ndk_version_error(self, mock_open_src_prop):
+        mock_open_src_prop.side_effect = [
+            mock.mock_open(read_data="").return_value
+        ]
+        with self.assertLogs(level="INFO") as cm:
+            version = read_ndk_version(self.ndk_dir)
+        self.assertEqual(
+            cm.output,
+            [
+                "INFO:p4a:[INFO]:    Could not parse "
+                "$NDK_DIR/source.properties, not checking NDK version"
+            ],
+        )
+        mock_open_src_prop.assert_called_once_with(
+            join(self.ndk_dir, "source.properties")
+        )
+        assert version is None
+
+    def test_check_target_api_error_arch_armeabi(self):
+
+        with self.assertRaises(BuildInterruptingException) as e:
+            check_target_api(RECOMMENDED_TARGET_API, "armeabi")
+        self.assertEqual(
+            e.exception.args[0],
+            "Asked to build for armeabi architecture with API {ndk_api}, but "
+            "API {max_target_api} or greater does not support armeabi".format(
+                ndk_api=RECOMMENDED_TARGET_API,
+                max_target_api=ARMEABI_MAX_TARGET_API,
+            ),
+        )
+
+    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
+    def test_check_target_api_warning_target_api(self):
+
+        with self.assertLogs(level="INFO") as cm:
+            check_target_api(MIN_TARGET_API - 1, MIN_TARGET_API)
+        self.assertEqual(
+            cm.output,
+            [
+                "WARNING:p4a:[WARNING]: Target API 25 < 26",
+                "WARNING:p4a:[WARNING]: Target APIs lower than 26 are no "
+                "longer supported on Google Play, and are not recommended. "
+                "Note that the Target API can be higher than your device "
+                "Android version, and should usually be as high as possible.",
+            ],
+        )
+
+    def test_check_ndk_api_error_android_api(self):
+        """
+        Given an `android api` greater than an `ndk_api`, we should get an
+        `BuildInterruptingException`.
+        """
+        ndk_api = MIN_NDK_API + 1
+        android_api = MIN_NDK_API
+        with self.assertRaises(BuildInterruptingException) as e:
+            check_ndk_api(ndk_api, android_api)
+        self.assertEqual(
+            e.exception.args[0],
+            "Target NDK API is {ndk_api}, higher than the target Android "
+            "API {android_api}.".format(
+                ndk_api=ndk_api, android_api=android_api
+            ),
+        )
+
+    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
+    def test_check_ndk_api_warning_old_ndk(self):
+        """
+        Given an `android api` lower than the supported by p4a, we should
+        get an `BuildInterruptingException`.
+        """
+        ndk_api = MIN_NDK_API - 1
+        android_api = RECOMMENDED_TARGET_API
+        with self.assertLogs(level="INFO") as cm:
+            check_ndk_api(ndk_api, android_api)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:p4a:[WARNING]: NDK API less than 21 is not supported"],
+        )


### PR DESCRIPTION
In order to avoid issues with old android's NDKs, we force to raise an error in case that an NDK version lower than the specified is detected. We also add the ability to extract the android's NDK letter version, which for now, will only be used to inform the user of the version which is using.

~~**Important note:** **Don't merge this before the ndk-r19 core part I** (we can easily adapt this for ndk-r17 but I leave it to `ndk-19` so we make sure that travis fails as expected), once the Part I gets merged, we can rebase this into develop, push it and the tests should pass **or we could adapt it to ndk-r17 and merge it before**~~

**Note:** The idea to create this pr comes from [this comment](https://github.com/kivy/python-for-android/pull/1722#issuecomment-502844382) from the pull request `ndk-r19 initial migration`

**See also:** The reported error in [travis test](https://travis-ci.org/kivy/python-for-android/jobs/549176086#L2332)