### PR TITLE
[WIP] Fix foreground notification being mandatory and more

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
@@ -1,15 +1,8 @@
 package {{ args.package }};
 
-import android.os.Build;
-import java.lang.reflect.Method;
-import java.lang.reflect.InvocationTargetException;
 import android.content.Intent;
 import android.content.Context;
-import android.app.Notification;
-import android.app.PendingIntent;
-import android.os.Bundle;
 import org.kivy.android.PythonService;
-import org.kivy.android.PythonActivity;
 
 
 public class Service{{ name|capitalize }} extends PythonService {
@@ -20,41 +13,9 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
     {% endif %}
 
-    {% if not foreground %}
-    @Override
-    public boolean canDisplayNotification() {
-        return false;
-    }
-    {% endif %}
-
-    @Override
-    protected void doStartForeground(Bundle extras) {
-        Notification notification;
-        Context context = getApplicationContext();
-        Intent contextIntent = new Intent(context, PythonActivity.class);
-        PendingIntent pIntent = PendingIntent.getActivity(context, 0, contextIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-            notification = new Notification(
-                context.getApplicationInfo().icon, "{{ args.name }}", System.currentTimeMillis());
-            try {
-                // prevent using NotificationCompat, this saves 100kb on apk
-                Method func = notification.getClass().getMethod(
-                    "setLatestEventInfo", Context.class, CharSequence.class,
-                    CharSequence.class, PendingIntent.class);
-                func.invoke(notification, context, "{{ args.name }}", "{{ name| capitalize }}", pIntent);
-            } catch (NoSuchMethodException | IllegalAccessException |
-                     IllegalArgumentException | InvocationTargetException e) {
-            }
-        } else {
-            Notification.Builder builder = new Notification.Builder(context);
-            builder.setContentTitle("{{ args.name }}");
-            builder.setContentText("{{ name| capitalize }}");
-            builder.setContentIntent(pIntent);
-            builder.setSmallIcon(context.getApplicationInfo().icon);
-            notification = builder.build();
-        }
-        startForeground({{ service_id }}, notification);
+    @override
+    protected int getServiceId() {
+        return {{ service_id }};
     }
 
     static public void start(Context ctx, String pythonServiceArgument) {
@@ -62,8 +23,15 @@ public class Service{{ name|capitalize }} extends PythonService {
         String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
         intent.putExtra("androidPrivate", ctx.getFilesDir().getAbsolutePath());
         intent.putExtra("androidArgument", argument);
+        intent.putExtra("serviceTitle", "{{ args.name }}");
+        intent.putExtra("serviceDescription", "{{ name|capitalize }}");
         intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
         intent.putExtra("pythonName", "{{ name }}");
+        {% if foreground %}
+        intent.putExtra("serviceStartAsForeground", "true");
+        {% else %}
+        intent.putExtra("serviceStartAsForeground", "false");
+        {% endif %}
         intent.putExtra("pythonHome", argument);
         intent.putExtra("pythonPath", argument + ":" + argument + "/lib");
         intent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -365,8 +365,23 @@ public class PythonActivity extends SDLActivity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        // This is the legacy call with less parameters!
+        start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -378,6 +393,9 @@ public class PythonActivity extends SDLActivity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -380,8 +380,23 @@ public class PythonActivity extends Activity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        // This is the legacy call with less parameters!
+        start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -393,6 +408,9 @@ public class PythonActivity extends Activity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -22,15 +22,10 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
     {% endif %}
 
-    {% if foreground %}
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean getStartForeground() {
-        return true;
+    @override
+    protected int getServiceId() {
+        return {{ service_id }};
     }
-    {% endif %}
 
     public static void start(Context ctx, String pythonServiceArgument) {
         String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
@@ -41,6 +36,11 @@ public class Service{{ name|capitalize }} extends PythonService {
         intent.putExtra("serviceTitle", "{{ name|capitalize }}");
         intent.putExtra("serviceDescription", "");
         intent.putExtra("pythonName", "{{ name }}");
+        {% if foreground %}
+        intent.putExtra("serviceStartAsForeground", "true");
+        {% else %}
+        intent.putExtra("serviceStartAsForeground", "false");
+        {% endif %}
         intent.putExtra("pythonHome", argument);
         intent.putExtra("androidUnpack", argument);
         intent.putExtra("pythonPath", argument + ":" + argument + "/lib");

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -437,8 +437,23 @@ public class PythonActivity extends Activity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        // This is the legacy call with less parameters!
+        start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -450,6 +465,9 @@ public class PythonActivity extends Activity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);


### PR DESCRIPTION
Fix foreground notification being mandatory and more. Details:

- Fixes that right now the service always slaps up a notification
  without this being configurable at runtime. It only is configurable
  right now if setting the foreground property via --service, which
  cannot be done when using the simpler service/main.py entrypoint

- Fixes service_only service code template not rendering .foreground
  correctly since it added an outdated, useless function name override

- Fixes notification channel name which is visible to end user
  hardcoding "python" in its name which is not ideal for end user
  naming (since the average user might not even know what python is)

- Fixes override of doStartForeground() leading to quite some
  error-prone code duplication