### PR TITLE
Fix foreground notification being mandatory and more (attempt 2)

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
@@ -35,8 +35,11 @@ public class PythonService extends Service implements Runnable {
     private String pythonHome;
     private String pythonPath;
     private String serviceEntrypoint;
+    private boolean serviceStartAsForeground;
     // Argument to pass to Python code,
     private String pythonServiceArgument;
+
+
     public static PythonService mService = null;
     private Intent startIntent = null;
 
@@ -44,10 +47,6 @@ public class PythonService extends Service implements Runnable {
 
     public void setAutoRestartService(boolean restart) {
         autoRestartService = restart;
-    }
-
-    public boolean canDisplayNotification() {
-        return true;
     }
 
     public int startType() {
@@ -79,16 +78,22 @@ public class PythonService extends Service implements Runnable {
         pythonName = extras.getString("pythonName");
         pythonHome = extras.getString("pythonHome");
         pythonPath = extras.getString("pythonPath");
+        serviceStartAsForeground = (
+            extras.getString("serviceStartAsForeground") == "true"
+        );
         pythonServiceArgument = extras.getString("pythonServiceArgument");
-
         pythonThread = new Thread(this);
         pythonThread.start();
 
-        if (canDisplayNotification()) {
+        if (serviceStartAsForeground) {
             doStartForeground(extras);
         }
 
         return startType();
+    }
+
+    protected int getServiceId() {
+        return 1;
     }
 
     protected void doStartForeground(Bundle extras) {
@@ -116,7 +121,7 @@ public class PythonService extends Service implements Runnable {
             // for android 8+ we need to create our own channel
             // https://stackoverflow.com/questions/47531742/startforeground-fail-after-upgrade-to-android-8-1
             String NOTIFICATION_CHANNEL_ID = "org.kivy.p4a";    //TODO: make this configurable
-            String channelName = "PythonSerice";                //TODO: make this configurable
+            String channelName = "Background Service";                //TODO: make this configurable
             NotificationChannel chan = new NotificationChannel(NOTIFICATION_CHANNEL_ID, channelName, 
                 NotificationManager.IMPORTANCE_NONE);
             
@@ -132,7 +137,7 @@ public class PythonService extends Service implements Runnable {
             builder.setSmallIcon(context.getApplicationInfo().icon);
             notification = builder.build();
         }
-        startForeground(1, notification);
+        startForeground(getServiceId(), notification);
     }
 
     @Override

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -365,8 +365,32 @@ public class PythonActivity extends SDLActivity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service_not_as_foreground(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, false
+        );
+    }
+
+    public static void _do_start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -378,6 +402,9 @@ public class PythonActivity extends SDLActivity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -380,8 +380,32 @@ public class PythonActivity extends Activity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service_not_as_foreground(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, false
+        );
+    }
+
+    public static void _do_start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -393,6 +417,9 @@ public class PythonActivity extends Activity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -22,15 +22,10 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
     {% endif %}
 
-    {% if foreground %}
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean getStartForeground() {
-        return true;
+    protected int getServiceId() {
+        return {{ service_id }};
     }
-    {% endif %}
 
     public static void start(Context ctx, String pythonServiceArgument) {
         String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
@@ -41,6 +36,7 @@ public class Service{{ name|capitalize }} extends PythonService {
         intent.putExtra("serviceTitle", "{{ name|capitalize }}");
         intent.putExtra("serviceDescription", "");
         intent.putExtra("pythonName", "{{ name }}");
+        intent.putExtra("serviceStartAsForeground", "{{ foreground|lower }}");
         intent.putExtra("pythonHome", argument);
         intent.putExtra("androidUnpack", argument);
         intent.putExtra("pythonPath", argument + ":" + argument + "/lib");

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -437,8 +437,32 @@ public class PythonActivity extends Activity {
         }
     }
 
-    public static void start_service(String serviceTitle, String serviceDescription,
-                String pythonServiceArgument) {
+    public static void start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, true
+        );
+    }
+
+    public static void start_service_not_as_foreground(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument
+            ) {
+        _do_start_service(
+            serviceTitle, serviceDescription, pythonServiceArgument, false
+        );
+    }
+
+    public static void _do_start_service(
+            String serviceTitle,
+            String serviceDescription,
+            String pythonServiceArgument,
+            boolean showForegroundNotification
+            ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String filesDirectory = argument;
@@ -450,6 +474,9 @@ public class PythonActivity extends Activity {
         serviceIntent.putExtra("pythonName", "python");
         serviceIntent.putExtra("pythonHome", app_root_dir);
         serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
+        serviceIntent.putExtra("serviceStartAsForeground",
+            (showForegroundNotification ? "true" : "false")
+        );
         serviceIntent.putExtra("serviceTitle", serviceTitle);
         serviceIntent.putExtra("serviceDescription", serviceDescription);
         serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);

--- a/pythonforandroid/recipes/android/src/android/_android.pyx
+++ b/pythonforandroid/recipes/android/src/android/_android.pyx
@@ -280,17 +280,29 @@ class AndroidBrowser(object):
 import webbrowser
 webbrowser.register('android', AndroidBrowser)
 
-cdef extern void android_start_service(char *, char *, char *)
-def start_service(title=None, description=None, arg=None):
-    cdef char *j_title = NULL
-    cdef char *j_description = NULL
-    if title is not None:
-        j_title = <bytes>title
-    if description is not None:
-        j_description = <bytes>description
-    if arg is not None:
-        j_arg = <bytes>arg
-    android_start_service(j_title, j_description, j_arg)
+
+def start_service(title="Background Service",
+                  description="", arg="",
+                  as_foreground=True):
+    # Legacy None value support (for old function signature style):
+    if title is None:
+        title = "Background Service"
+    if description is None:
+        description = ""
+    if arg is None:
+        arg = ""
+
+    # Start service:
+    mActivity = autoclass('org.kivy.android.PythonActivity').mActivity
+    if as_foreground:
+        mActivity.start_service(
+            title, description, arg
+        )
+    else:
+        mActivity.start_service_not_as_foreground(
+            title, description, arg
+        )
+
 
 cdef extern void android_stop_service()
 def stop_service():

--- a/pythonforandroid/recipes/android/src/android/_android_jni.c
+++ b/pythonforandroid/recipes/android/src/android/_android_jni.c
@@ -201,34 +201,6 @@ void android_get_buildinfo() {
     }
 }
 
-void android_start_service(char *title, char *description, char *arg) {
-    static JNIEnv *env = NULL;
-    static jclass *cls = NULL;
-    static jmethodID mid = NULL;
-
-    if (env == NULL) {
-        env = SDL_ANDROID_GetJNIEnv();
-        aassert(env);
-        cls = (*env)->FindClass(env, JNI_NAMESPACE "/PythonActivity");
-        aassert(cls);
-        mid = (*env)->GetStaticMethodID(env, cls, "start_service",
-                                       "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
-        aassert(mid);
-    }
-
-    jstring j_title = NULL;
-    jstring j_description = NULL;
-    jstring j_arg = NULL;
-    if ( title != 0 )
-            j_title = (*env)->NewStringUTF(env, title);
-    if ( description != 0 )
-            j_description = (*env)->NewStringUTF(env, description);
-    if ( arg != 0 )
-            j_arg = (*env)->NewStringUTF(env, arg);
-
-    (*env)->CallStaticVoidMethod(env, cls, mid, j_title, j_description, j_arg);
-}
-
 void android_stop_service() {
     static JNIEnv *env = NULL;
     static jclass *cls = NULL;

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -84,11 +84,12 @@ class TestDistribution(unittest.TestCase):
         :meth:`~pythonforandroid.distribution.Distribution.folder_exist` is
         called once with the proper arguments."""
 
+        mock_exists.return_value = False
         self.setUp_distribution_with_bootstrap(
-            Bootstrap().get_bootstrap("sdl2", self.ctx)
+            Bootstrap.get_bootstrap("sdl2", self.ctx)
         )
         self.ctx.bootstrap.distribution.folder_exists()
-        mock_exists.assert_called_once_with(
+        mock_exists.assert_called_with(
             self.ctx.bootstrap.distribution.dist_dir
         )
 


### PR DESCRIPTION
- Adds start_service_not_as_foreground() to avoid always displaying
  an associated notification without this being configurable at runtime.
  It only is configurable right now if setting the foreground property
  via --service, which cannot be done when using the simpler
  service/main.py entrypoint

- Fixes service_only service code template not rendering .foreground
  correctly since it added an outdated, useless function name override

- Fixes notification channel name which is visible to end user
  hardcoding "python" in its name which is not ideal for end user
  naming (since the average user might not even know what python is)

- Fixes override of doStartForeground() leading to quite some
  error-prone code duplication