### PR TITLE
Feature gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage.xml
 
 # testapp's build folder
 testapps/build/
+
+# Dolphin (the KDE file manager autogenerates the file `.directory`)
+.directory

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,14 @@ __pycache__/
 
 #idea/pycharm
 .idea/
-.tox
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ nosetests.xml
 coverage.xml
 *.cover
 .pytest_cache/
+
+# testapp's build folder
+testapps/build/


### PR DESCRIPTION
We can generate some files/folders, under some circumstances, which we don't want that git tracks them, so here we add some entries to `.gitignore`, to make sure that git ignores them:
  - files/folders generated by our unit tests
  - files/folders generated by our coverage
  - folders generated by our testapps (in case that we build some testapp directly from inside the source code folder)
  - file `.directory` auto generated by `Dolphin`, the KDE's file manager, when browsing a folder