### PR TITLE
Fix crash when guessing Bootstrap (expand_dependencies)

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -394,8 +394,13 @@ def expand_dependencies(recipes, ctx):
         if not isinstance(entry, (tuple, list)) or len(entry) == 1:
             if isinstance(entry, (tuple, list)):
                 entry = entry[0]
-            recipe = Recipe.get_recipe(entry, ctx)
-            recipes_with_deps += recipe.depends
+            try:
+                recipe = Recipe.get_recipe(entry, ctx)
+                recipes_with_deps += recipe.depends
+            except ValueError:
+                # it's a pure python package without a recipe, so we
+                # don't know the dependencies...skipping for now
+                pass
 
     # Split up lists by available alternatives:
     recipe_lists = [[]]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -171,6 +171,18 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
         expanded_result_2 = expand_dependencies([("pysdl2", "kivy")], self.ctx)
         self.assertEqual([["pysdl2"], ["kivy"]], expanded_result_2)
 
+    def test_expand_dependencies_with_pure_python_package(self):
+        """Check that `expanded_dependencies`, with a pure python package as
+        one of the dependencies, returns a list of dependencies
+        """
+        expanded_result = expand_dependencies(
+            ["python3", "kivy", "peewee"], self.ctx
+        )
+        self.assertEqual(len(expanded_result), 3)
+        self.assertIsInstance(expanded_result, list)
+        for i in expanded_result:
+            self.assertIsInstance(i, list)
+
     def test_get_bootstraps_from_recipes(self):
         """A test which will initialize a bootstrap and will check if the
         method :meth:`~pythonforandroid.bootstrap.Bootstrap.


### PR DESCRIPTION
When a pure python package it's supplied inside the dependency list (for the method `expand_dependencies`), we will get a crash because we don't have a recipe for it, unless we contemplate that situation

**Note:** We missed that because we haven't a pure python package in our CI` builds for the [testapps](https://github.com/kivy/python-for-android/blob/develop/.travis.yml#L73-L81)

**As a side note:** The `expand_dependencies` method was recently introduced in PR #1887