### PR TITLE
Remove `nosetests.xml` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .pytest_cache/


### PR DESCRIPTION
Because we don't use it (we are using pytest), so better keep it simple

**Note:** this was introduced by mistake in b5d9b611 (#1911), and noticed by @AndreMiras (**thanks** :smile:), unfortunately I saw it once already merged in develop branch, so this PR is to address [this comment](https://github.com/kivy/python-for-android/pull/1911#discussion_r302161021)