### PR TITLE
[WIP] Enhance distribution check when reusing distributions and...

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -126,7 +126,15 @@ class Bootstrap(object):
         return dir_name
 
     def get_build_dir(self):
-        return join(self.ctx.build_dir, 'bootstrap_builds', self.get_build_dir_name())
+        return join(
+            self.ctx.build_dir,
+            'bootstrap_builds',
+            self.get_build_dir_name(),
+            '{}__ndk_target_{}'.format(
+                '_'.join(arch.arch for arch in self.ctx.archs),
+                self.ctx.ndk_api,
+            ),
+        )
 
     def get_dist_dir(self, name):
         return join(self.ctx.dist_dir, name)

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -575,10 +575,10 @@ def build_recipes(build_order, python_modules, ctx, project_dir,
             info_main('Building {} for {}'.format(recipe.name, arch.arch))
             if recipe.should_build(arch):
                 recipe.build_arch(arch)
-                recipe.install_libraries(arch)
             else:
                 info('{} said it is already built, skipping'
                      .format(recipe.name))
+            recipe.install_libraries(arch)
 
         # 4) biglink everything
         info_main('# Biglinking object files')

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -99,7 +99,9 @@ class Distribution(object):
 
         # 0) Check if a dist with that name already exists
         if name is not None and name:
-            possible_dists = [d for d in possible_dists if d.name == name]
+            possible_dists = [
+                d for d in possible_dists if d.name.startswith(name)
+            ]
             if possible_dists:
                 name_match_dist = possible_dists[0]
 
@@ -224,7 +226,10 @@ class Distribution(object):
                 i += 1
             name = filen.format(i)
 
-        dist.name = name
+        # we add a suffix to our dist name, so we avoid to
+        # overwrite them when building for different arch
+        suffix_arch = f"_{{{'·'.join([arch.arch for arch in ctx.archs])}}}"
+        dist.name = name + suffix_arch
         dist.dist_dir = join(ctx.dist_dir, dist.name)
         dist.recipes = recipes_with_version
         dist.archs = req_archs

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -20,6 +20,7 @@ class Distribution(object):
 
     name = None  # A name identifying the dist. May not be None.
     needs_build = False  # Whether the dist needs compiling
+    needs_clean_build = False  # Whether the build needs a full clean
     url = None
     dist_dir = None  # Where the dist dir ultimately is. Should not be None.
     ndk_api = None
@@ -129,6 +130,11 @@ class Distribution(object):
                  not require_perfect_match)):
                 info_notify('{} has compatible recipes, using this one'
                             .format(dist.name))
+                if dist.p4a_version != __version__:
+                    # We build this dist with a different version of p4a, so
+                    # we mark it as a dist that requires a clean build environ
+                    # (to avoid old cached builds issues)
+                    dist.needs_clean_build = True
                 return dist
 
         assert len(possible_dists) < 2
@@ -209,7 +215,9 @@ class Distribution(object):
                 dist.dist_dir = folder
                 dist.needs_build = False
                 dist.recipes = dist_info['recipes']
-                for entry in {'archs', 'ndk_api', 'android_api'}:
+                for entry in {
+                    'archs', 'ndk_api', 'android_api', 'p4a_version'
+                }:
                     setattr(dist, entry, dist_info.get(entry, None))
                     if entry not in dist_info:
                         warning(

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -2,6 +2,7 @@ from os.path import exists, join
 import glob
 import json
 
+from pythonforandroid import __version__
 from pythonforandroid.logger import (info, info_notify, warning, Err_Style, Err_Fore)
 from pythonforandroid.util import current_directory, BuildInterruptingException
 from shutil import rmtree
@@ -23,6 +24,7 @@ class Distribution(object):
     dist_dir = None  # Where the dist dir ultimately is. Should not be None.
     ndk_api = None
     android_api = None
+    p4a_version = None
 
     archs = []
     '''The arch targets that the dist is built for.'''
@@ -237,7 +239,8 @@ class Distribution(object):
                            'use_setup_py': self.ctx.use_setup_py,
                            'recipes': self.ctx.recipe_build_order + self.ctx.python_modules,
                            'hostpython': self.ctx.hostpython,
-                           'python_version': self.ctx.python_recipe.major_minor_version_string},
+                           'python_version': self.ctx.python_recipe.major_minor_version_string,
+                           'p4a_version': __version__},
                           fileh)
 
 

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -44,7 +44,6 @@ class Distribution(object):
 
     @classmethod
     def get_distribution(cls, ctx, name=None, recipes=[],
-                         ndk_api=None,
                          force_build=False,
                          extra_dist_dirs=[],
                          require_perfect_match=False,
@@ -93,9 +92,7 @@ class Distribution(object):
         # 1) Check if any existing dists meet the requirements
         _possible_dists = []
         for dist in possible_dists:
-            if (
-                ndk_api is not None and dist.ndk_api != ndk_api
-            ) or dist.ndk_api is None:
+            if (dist.ndk_api != ctx.ndk_api) or dist.ndk_api is None:
                 continue
             for recipe in recipes:
                 if recipe not in dist.recipes:
@@ -115,7 +112,7 @@ class Distribution(object):
         for dist in possible_dists:
             if force_build:
                 continue
-            if ndk_api is not None and dist.ndk_api != ndk_api:
+            if ctx.ndk_api is not None and dist.ndk_api != ctx.ndk_api:
                 continue
             if (set(dist.recipes) == set(recipes) or
                 (set(recipes).issubset(set(dist.recipes)) and
@@ -136,7 +133,7 @@ class Distribution(object):
                 'with this name already exists and has either incompatible recipes '
                 '({dist_recipes}) or NDK API {dist_ndk_api}'.format(
                     name=name,
-                    req_ndk_api=ndk_api,
+                    req_ndk_api=ctx.ndk_api,
                     dist_ndk_api=name_match_dist.ndk_api,
                     req_recipes=', '.join(recipes),
                     dist_recipes=', '.join(name_match_dist.recipes)))

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -22,6 +22,7 @@ class Distribution(object):
     url = None
     dist_dir = None  # Where the dist dir ultimately is. Should not be None.
     ndk_api = None
+    android_api = None
 
     archs = []
     '''The arch targets that the dist is built for.'''
@@ -214,6 +215,7 @@ class Distribution(object):
                            'bootstrap': self.ctx.bootstrap.name,
                            'archs': [arch.arch for arch in self.ctx.archs],
                            'ndk_api': self.ctx.ndk_api,
+                           'android_api': self.ctx.android_api,
                            'use_setup_py': self.ctx.use_setup_py,
                            'recipes': self.ctx.recipe_build_order + self.ctx.python_modules,
                            'hostpython': self.ctx.hostpython,

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -712,6 +712,9 @@ class Recipe(with_metaclass(RecipeMeta)):
         if not hasattr(cls, "recipes"):
             cls.recipes = {}
         if name in cls.recipes:
+            # we already have recipe in cls.recipes,
+            # so we update the recipe's ctx and return it
+            cls.recipes[name].ctx = ctx
             return cls.recipes[name]
 
         recipe_file = None

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -622,8 +622,10 @@ class Recipe(with_metaclass(RecipeMeta)):
             base_dir = join(
                 self.ctx.build_dir, 'other_builds', self.get_dir_name()
             )
+            archs = [arch.arch for arch in self.ctx.archs]
         else:
             base_dir = self.get_build_container_dir(arch)
+            archs = [arch.arch]
         dirs = glob.glob(base_dir + '-*')
         if exists(base_dir):
             dirs.append(base_dir)
@@ -639,6 +641,15 @@ class Recipe(with_metaclass(RecipeMeta)):
         # Delete any Python distributions to ensure the recipe build
         # doesn't persist in site-packages
         shutil.rmtree(self.ctx.python_installs_dir)
+
+        if self.built_libraries:
+            for arch in archs:
+                for lib in self.get_recipe_libraries(arch, in_context=True):
+                    if isfile(lib):
+                        info('Deleting ctx {arch} library {lib}'.format(
+                            arch=arch, lib=split(lib)[-1])
+                        )
+                        shprint(sh.rm, '-f', lib)
 
     def install_libs(self, arch, *libs):
         libs_dir = self.ctx.get_libs_dir(arch.arch)

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -619,7 +619,9 @@ class Recipe(with_metaclass(RecipeMeta)):
 
         '''
         if arch is None:
-            base_dir = join(self.ctx.build_dir, 'other_builds', self.name)
+            base_dir = join(
+                self.ctx.build_dir, 'other_builds', self.get_dir_name()
+            )
         else:
             base_dir = self.get_build_container_dir(arch)
         dirs = glob.glob(base_dir + '-*')

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -758,6 +758,21 @@ class BootstrapNDKRecipe(Recipe):
 
     dir_name = None  # The name of the recipe build folder in the jni dir
 
+    def clean_build(self, arch=None):
+        # we must set python recipe first or `get_recipe_env` will fail
+        self.ctx.python_recipe = Recipe.get_recipe(
+            'python3'
+            if 'python3' in self.ctx.recipe_build_order
+            else 'python2',
+            self.ctx,
+        )
+        for arch in self.ctx.archs if not arch else [arch]:
+            env = self.get_recipe_env(arch)
+            # to clean sdl2 recipe, we also needs below to set nel variable
+            env['APP_ALLOW_MISSING_DEPS'] = 'true'
+            with current_directory(self.get_build_dir(arch.arch)):
+                shprint(sh.ndk_build, 'clean', _env=env)
+
     def get_build_container_dir(self, arch):
         return self.get_jni_dir()
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -163,7 +163,6 @@ def dist_from_args(ctx, args):
         ctx,
         name=args.dist_name,
         recipes=split_argument_list(args.requirements),
-        ndk_api=args.ndk_api,
         force_build=args.force_build,
         require_perfect_match=args.require_perfect_match,
         allow_replace_dist=args.allow_replace_dist)

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -145,6 +145,22 @@ def require_prebuilt_dist(func):
                                       user_android_api=self.android_api,
                                       user_ndk_api=self.ndk_api)
         dist = self._dist
+        export_dist = func.__name__ == 'export_dist'
+        if all([dist.needs_build, dist.needs_clean_build, not export_dist]):
+            warning(
+                '\n{separator}\n'
+                '* Detected new p4a version: {new_version}\n'
+                '* Selected dist was made using version: {dist_version}\n'
+                '* So We will remove all cached builds, to ensure a '
+                'successful build!!\n\n'
+                '* Note: the downloaded packages will not be removed.\n'
+                '{separator}'.format(
+                    separator='*' * 72,
+                    new_version=__version__,
+                    dist_version=dist.p4a_version
+                )
+            )
+            self.clean_builds(args)
         if dist.needs_build:
             if dist.folder_exists():  # possible if the dist is being replaced
                 dist.delete()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -163,10 +163,18 @@ def require_prebuilt_dist(func):
             self.clean_builds(args)
         if dist.needs_build:
             if dist.folder_exists():  # possible if the dist is being replaced
+                info_notify('A dist with requested name exists [{}], but we '
+                            'need to rebuild it because requirements '
+                            'changed'.format(dist.name))
                 dist.delete()
-            info_notify('No dist exists that meets your requirements, '
-                        'so one will be built.')
+            else:
+                info_notify('No dist exists that meets your requirements, '
+                            'so one will be built with this name: '
+                            '{}'.format(dist.name))
             build_dist_from_args(ctx, dist, args)
+        else:
+            info_notify('Reusing a dist that meets your requirements: '
+                        '{}'.format(dist.name))
         func(self, args)
     return wrapper_func
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1106,13 +1106,12 @@ class ToolchainCL(object):
             else:
                 raise BuildInterruptingException('Couldn\'t find the built APK')
 
-        info_main('# Found APK file: {}'.format(apk_file))
+        info_main(f'# Found APK file: {apk_file}')
         if apk_add_version:
             info('# Add version number to APK')
-            apk_name, apk_suffix = basename(apk_file).split("-", 1)
-            apk_file_dest = "{}-{}-{}".format(
-                apk_name, build_args.version, apk_suffix)
-            info('# APK renamed to {}'.format(apk_file_dest))
+            apk_name, apk_suffix = basename(apk_file).split("_{", 1)
+            apk_file_dest = f'{apk_name}-{build_args.version}-{{{apk_suffix}'
+            info(f'# APK renamed to {apk_file_dest}')
             shprint(sh.cp, apk_file, apk_file_dest)
         else:
             shprint(sh.cp, apk_file, './')

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -84,7 +84,9 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
 
         # test dist_dir success
         self.setUp_distribution_with_bootstrap(bs)
-        self.assertTrue(bs.dist_dir.endswith("dists/test_prj"))
+        self.assertTrue(bs.dist_dir.endswith(
+            "dists/test_prj_{armeabi·armeabi-v7a·x86·x86_64·arm64-v8a}")
+        )
 
     def test_build_dist_dirs(self):
         """A test which will initialize a bootstrap and will check if the

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -99,7 +99,10 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
         bs = Bootstrap.get_bootstrap("sdl2", self.ctx)
 
         self.assertTrue(
-            bs.get_build_dir().endswith("build/bootstrap_builds/sdl2-python3")
+            bs.get_build_dir().endswith(
+                "build/bootstrap_builds/sdl2-python3/"
+                "armeabi_armeabi-v7a_x86_x86_64_arm64-v8a__ndk_target_21"
+            )
         )
         self.assertTrue(bs.get_dist_dir("test_prj").endswith("dists/test_prj"))
         self.assertTrue(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -73,7 +73,9 @@ class TestDistribution(unittest.TestCase):
         distribution = self.ctx.bootstrap.distribution
         self.assertEqual(self.ctx, distribution.ctx)
         expected_repr = (
-            "<Distribution: name test_prj with recipes (python3, kivy)>"
+            "<Distribution: name "
+            "test_prj_{armeabi·armeabi-v7a·x86·x86_64·arm64-v8a} "
+            "with recipes (python3, kivy)>"
         )
         self.assertEqual(distribution.__str__(), expected_repr)
         self.assertEqual(distribution.__repr__(), expected_repr)
@@ -114,7 +116,10 @@ class TestDistribution(unittest.TestCase):
         mock_exists.return_value = False
         self.ctx.bootstrap = Bootstrap().get_bootstrap("sdl2", self.ctx)
         dist = Distribution.get_distribution(self.ctx)
-        self.assertEqual(dist.name, "unnamed_dist_1")
+        self.assertEqual(
+            dist.name,
+            "unnamed_dist_1_{armeabi·armeabi-v7a·x86·x86_64·arm64-v8a}"
+        )
 
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.distribution.open", create=True)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -211,8 +211,12 @@ class TestDistribution(unittest.TestCase):
         distribution with the same `name` but different `ndk_api`.
         """
         expected_dist = Distribution.get_distribution(
-            self.ctx, name="test_prj", recipes=["python3", "kivy"]
+            self.ctx,
+            name="test_prj",
+            recipes=["python3", "kivy"],
         )
+        expected_dist.ndk_api = 22
+        expected_dist.android_api = 27
         mock_get_dists.return_value = [expected_dist]
         mock_glob.return_value = ["sdl2-python3"]
 
@@ -220,13 +224,20 @@ class TestDistribution(unittest.TestCase):
             self.setUp_distribution_with_bootstrap(
                 Bootstrap().get_bootstrap("sdl2", self.ctx),
                 allow_replace_dist=False,
-                ndk_api=22,
             )
         self.assertEqual(
             e.exception.args[0],
-            "Asked for dist with name test_prj with recipes (python3, kivy)"
-            " and NDK API 22, but a dist with this name already exists and has"
-            " either incompatible recipes (python3, kivy) or NDK API 21",
+            "\n\tAsked for dist with name test_prj and:"
+            "\n\t-> recipes: (python3, kivy)"
+            "\n\t-> NDK api: (21)"
+            "\n\t-> android api (27)"
+            "\n\t-> archs (armeabi, armeabi-v7a, x86, x86_64, arm64-v8a)"
+            "\n...but a dist with this name already exists and has either "
+            "incompatible:"
+            "\n\t-> recipes: (python3, kivy)"
+            "\n\t-> NDK api: (22)"
+            "\n\t-> android api (27)"
+            "\n\t-> archs (armeabi, armeabi-v7a, x86, x86_64, arm64-v8a)",
         )
 
     def test_get_distributions_error_extra_dist_dirs(self):
@@ -261,6 +272,9 @@ class TestDistribution(unittest.TestCase):
         expected_dist = Distribution.get_distribution(
             self.ctx, name="test_prj", recipes=["python3", "kivy"]
         )
+        # since we simulate a dist we need to set the recipes in dict format,
+        # not not the case for the `Distribution.get_distribution` call
+        expected_dist.recipes = {"python3": "3.7.1", "kivy": "1.10.0"}
         mock_get_dists.return_value = [expected_dist]
         self.setUp_distribution_with_bootstrap(
             Bootstrap().get_bootstrap("sdl2", self.ctx), name="test_prj"


### PR DESCRIPTION
**...Skip some unneeded rebuilds**

The main reason to do this, it's because we usually have to deal with issues related with old cached builds as well as the reuse of a distributions it seems to not work as expected, so this PR is intended to deal with this.

**Things made in here:**
  - Save into dist_info.json file more information:
      + android api
      + archs
      + p4a version
      + recipes version
  - Perform more checks when we find a dist with the same name:  
      + check if android api is the same as the one we request
      + check if distribution's arch is the same that we are requesting
      + check if p4a version we are using is the same as the one we used for the built distribution (and if not, force a cleanup of the build directory)
       + check recipes version and remove old build in the case that we detect an outdated recipe version
  - Fix Recipes.clean_build, so we can remove old builds
  - Implement BootstrapNDKRecipe.should_build , so we can remove old bootstrap builds (Here I make use of `ndk-build clean` which it seems to remove all bootstrap builds and libraries regarding that which recipe we are targeting...:thinking:...I suppose it's fine for now (it simplifies a little the thing)
  - ~~Implement `GuestPythonRecipe.should_build` so we can skip python rebuild~~ (removed commit since it's already done at #1951)
  - change bootstrap build directory (to ensure that when we change arch and we already have build with another arch, we don't get conflicts)
  - detect when a PythonRecipe needs a rebuild, so we remove our `python-installs` directory (yeah, it's a little drastic this point but it would do the job and simplifies the code)
  - remove recipe's generated libraries from libs_collection when we detected a changed library recipe

**Things to consider...I may forgot something in here:**
  - The build/dist directories will grow up considerably
  - ~~we never remove recipe's generates libraries from `libs_collection` when we detected a changed recipe (we only remove the build directory...so this may cause some troubles in case that `Recipe.should_build` checks for the library into that folder)...mmm~~
  - buildozer need to be updated to work with this (since the dist name it will be modified with a suffix)

**Closes:** #1920 and #1917

**I leave this `WIP` because:**
  - we may want to discuss the whole idea...we could simply force a full clean in each build (sure that it would be simpler)
  - There are some parts of the code that may be improved  or even moved from one place to another...I have to review it...but if anyone sees something, I'll be glad to discuss/fix it
  - I tested different situations and this thing seems to work, but I may forgot something...so better other eyes take look on this
  -  we may want to split this thing into multiple PRs...sometimes things make sense in one PR, but when PRs go big it complicates things for all of us...should we have a workflow to deal with this? Maybe the [stacked pull requests](https://graysonkoonce.com/stacked-pull-requests-keeping-github-diffs-small/) method could be a solution?
     + **As a side note:** I think this method could only be used for those ones with write permissions to repo, since needs to create a new upstream branch plus it requires to merge things in `reverse` order)
