### PR TITLE
Increases toolchain.py test coverage

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -739,6 +739,15 @@ class ToolchainCL(object):
                 sys.argv.append(arg)
 
     def recipes(self, args):
+        """
+        Prints recipes basic info, e.g.
+        ```
+        python3      3.7.1
+            depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
+            conflicts: ['python2']
+            optional depends: ['sqlite3', 'libffi', 'openssl']
+        ```
+        """
         ctx = self.ctx
         if args.compact:
             print(" ".join(set(Recipe.list_recipes(ctx))))


### PR DESCRIPTION
Increases `test_create()` coverage demonstrating crash referenced in:
<https://github.com/kivy/python-for-android/pull/1867#issuecomment-514352035>
Adds `test_recipes()` checking if it prints out without crashing.