### PR TITLE
Added setuptools to Kivy recipe requirements

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -10,7 +10,7 @@ class KivyRecipe(CythonRecipe):
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 
-    depends = ['sdl2', 'pyjnius']
+    depends = ['sdl2', 'pyjnius', 'setuptools']
 
     def cythonize_build(self, env, build_dir='.'):
         super(KivyRecipe, self).cythonize_build(env, build_dir=build_dir)


### PR DESCRIPTION
Kivy master (and future Kivy releases) depends on setuptools now, whereas it didn't before. I think we should just add it to the requirements now, to avoid issues when people try to install from master. It doesn't seem worth messing around with making setuptools a requirement only if Kivy > 1.11 is being targeted.