### PR TITLE
[LIBS - PART I] Initial refactor of library recipes

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -575,6 +575,7 @@ def build_recipes(build_order, python_modules, ctx, project_dir,
             info_main('Building {} for {}'.format(recipe.name, arch.arch))
             if recipe.should_build(arch):
                 recipe.build_arch(arch)
+                recipe.install_libraries(arch)
             else:
                 info('{} said it is already built, skipping'
                      .format(recipe.name))

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -516,6 +516,19 @@ class Recipe(with_metaclass(RecipeMeta)):
         if hasattr(self, build):
             getattr(self, build)()
 
+    def install_libraries(self, arch):
+        '''This method is always called after `build_arch`. In case that we
+        detect a library recipe, defined by the class attribute
+        `built_libraries`, we will copy all defined libraries into the
+         right location.
+        '''
+        if not self.built_libraries:
+            return
+        shared_libs = [
+            lib for lib in self.get_libraries(arch) if lib.endswith(".so")
+        ]
+        self.install_libs(arch, *shared_libs)
+
     def postbuild_arch(self, arch):
         '''Run any post-build tasks for the Recipe. By default, this checks if
         any postbuild_archname methods exist for the archname of the

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -498,9 +498,14 @@ class Recipe(with_metaclass(RecipeMeta)):
 
     def should_build(self, arch):
         '''Should perform any necessary test and return True only if it needs
-        building again.
+        building again. Per default we implement a library test, in case that
+        we detect so.
 
         '''
+        if self.built_libraries:
+            return not all(
+                exists(lib) for lib in self.get_libraries(arch.arch)
+            )
         return True
 
     def build_arch(self, arch):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -573,6 +573,27 @@ class Recipe(with_metaclass(RecipeMeta)):
     def has_libs(self, arch, *libs):
         return all(map(lambda l: self.ctx.has_lib(arch.arch, l), libs))
 
+    def get_libraries(self, arch_name, in_context=False):
+        """Return the full path of the library depending on the architecture.
+        Per default, the build library path it will be returned, unless
+        `get_libraries` has been called with kwarg `in_context` set to
+        True.
+
+        .. note:: this method should be used for library recipes only
+        """
+        recipe_libs = set()
+        if not self.built_libraries:
+            return recipe_libs
+        for lib, rel_path in self.built_libraries.items():
+            if not in_context:
+                abs_path = join(self.get_build_dir(arch_name), rel_path, lib)
+                if rel_path in {".", "", None}:
+                    abs_path = join(self.get_build_dir(arch_name), lib)
+            else:
+                abs_path = join(self.ctx.get_libs_dir(arch_name), lib)
+            recipe_libs.add(abs_path)
+        return recipe_libs
+
     @classmethod
     def recipe_dirs(cls, ctx):
         recipe_dirs = []

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -106,6 +106,25 @@ class Recipe(with_metaclass(RecipeMeta)):
 
     archs = ['armeabi']  # Not currently implemented properly
 
+    built_libraries = {}
+    """Each recipe that builds a system library (e.g.:libffi, openssl, etc...)
+    should contain a dict holding the relevant information of the library. The
+    keys should be the generated libraries and the values the relative path of
+    the library inside his build folder. This dict will be used to perform
+    different operations:
+        - copy the library into the right location, depending on if it's shared
+          or static)
+        - check if we have to rebuild the library
+
+    Here an example of how it would look like for `libffi` recipe:
+
+        - `built_libraries = {'libffi.so': '.libs'}`
+
+    .. note:: in case that the built library resides in recipe's build
+              directory, you can set the following values for the relative
+              path: `'.', None or ''`
+    """
+
     @property
     def version(self):
         key = 'VERSION_' + self.name

--- a/pythonforandroid/recipes/harfbuzz/__init__.py
+++ b/pythonforandroid/recipes/harfbuzz/__init__.py
@@ -1,8 +1,8 @@
-from pythonforandroid.toolchain import Recipe
+from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import current_directory
 from pythonforandroid.logger import shprint
 from multiprocessing import cpu_count
-from os.path import exists, join
+from os.path import join
 import sh
 
 
@@ -23,13 +23,7 @@ class HarfbuzzRecipe(Recipe):
     version = '0.9.40'
     url = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-{version}.tar.bz2'  # noqa
     opt_depends = ['freetype']
-
-    def should_build(self, arch):
-        return not exists(
-            join(
-                self.get_build_dir(arch.arch), 'src', '.libs', 'libharfbuzz.so'
-            )
-        )
+    built_libraries = {'libharfbuzz.so': 'src/.libs'}
 
     def get_recipe_env(self, arch=None):
         env = super(HarfbuzzRecipe, self).get_recipe_env(arch)
@@ -68,12 +62,12 @@ class HarfbuzzRecipe(Recipe):
                 _env=env,
             )
             shprint(sh.make, '-j', str(cpu_count()), _env=env)
-            self.install_libs(arch, join('src', '.libs', 'libharfbuzz.so'))
 
         if 'freetype' in self.ctx.recipe_build_order:
-            # Rebuild freetype with harfbuzz support
+            # Rebuild/install freetype with harfbuzz support
             freetype = self.get_recipe('freetype', self.ctx)
             freetype.build_arch(arch, with_harfbuzz=True)
+            freetype.install_libraries(arch)
 
 
 recipe = HarfbuzzRecipe()

--- a/pythonforandroid/recipes/jpeg/__init__.py
+++ b/pythonforandroid/recipes/jpeg/__init__.py
@@ -1,9 +1,8 @@
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import shprint
 from pythonforandroid.util import current_directory
-from os.path import join, exists
+from os.path import join
 from os import environ, uname
-from glob import glob
 import sh
 
 
@@ -16,15 +15,11 @@ class JpegRecipe(Recipe):
     name = 'jpeg'
     version = '2.0.1'
     url = 'https://github.com/libjpeg-turbo/libjpeg-turbo/archive/{version}.tar.gz'  # noqa
+    built_libraries = {'libjpeg.a': '.', 'libturbojpeg.a': '.'}
     # we will require this below patch to build the shared library
     # patches = ['remove-version.patch']
 
-    def should_build(self, arch):
-        return not exists(join(self.get_build_dir(arch.arch),
-                               'libturbojpeg.a'))
-
     def build_arch(self, arch):
-        super(JpegRecipe, self).build_arch(arch)
         build_dir = self.get_build_dir(arch.arch)
 
         # TODO: Fix simd/neon
@@ -58,10 +53,6 @@ class JpegRecipe(Recipe):
                     '-DENABLE_STATIC=1',
                     _env=env)
             shprint(sh.make, _env=env)
-
-            # copy static libs to libs collection
-            for lib in glob(join(build_dir, '*.a')):
-                shprint(sh.cp, '-L', lib, self.ctx.libs_dir)
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=False):
         env = environ.copy()

--- a/pythonforandroid/recipes/libcurl/__init__.py
+++ b/pythonforandroid/recipes/libcurl/__init__.py
@@ -1,20 +1,18 @@
 import sh
-from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
-from os.path import exists, join
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
+from os.path import join
 from multiprocessing import cpu_count
 
 
 class LibcurlRecipe(Recipe):
     version = '7.55.1'
     url = 'https://curl.haxx.se/download/curl-7.55.1.tar.gz'
+    built_libraries = {'libcurl.so': 'dist/lib'}
     depends = ['openssl']
 
-    def should_build(self, arch):
-        super(LibcurlRecipe, self).should_build(arch)
-        return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libcurl.so'))
-
     def build_arch(self, arch):
-        super(LibcurlRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
 
         r = self.get_recipe('openssl', self.ctx)
@@ -31,10 +29,6 @@ class LibcurlRecipe(Recipe):
                 _env=env)
             shprint(sh.make, '-j', str(cpu_count()), _env=env)
             shprint(sh.make, 'install', _env=env)
-            shutil.copyfile('{}/lib/libcurl.so'.format(dst_dir),
-                            join(
-                                self.ctx.get_libs_dir(arch.arch),
-                                'libcurl.so'))
 
 
 recipe = LibcurlRecipe()

--- a/pythonforandroid/recipes/libexpat/__init__.py
+++ b/pythonforandroid/recipes/libexpat/__init__.py
@@ -1,38 +1,32 @@
 
 import sh
-from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
-from os.path import exists, join
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
+from os.path import join
 from multiprocessing import cpu_count
 
 
 class LibexpatRecipe(Recipe):
     version = 'master'
     url = 'https://github.com/libexpat/libexpat/archive/{version}.zip'
+    built_libraries = {'libexpat.so': 'dist/lib'}
     depends = []
 
-    def should_build(self, arch):
-        super(LibexpatRecipe, self).should_build(arch)
-        return not exists(
-            join(self.ctx.get_libs_dir(arch.arch), 'libexpat.so'))
-
     def build_arch(self, arch):
-        super(LibexpatRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(join(self.get_build_dir(arch.arch), 'expat')):
             dst_dir = join(self.get_build_dir(arch.arch), 'dist')
             shprint(sh.Command('./buildconf.sh'), _env=env)
             shprint(
                 sh.Command('./configure'),
-                '--host=arm-linux-androideabi',
+                '--host={}'.format(arch.command_prefix),
                 '--enable-shared',
                 '--without-xmlwf',
                 '--prefix={}'.format(dst_dir),
                 _env=env)
             shprint(sh.make, '-j', str(cpu_count()), _env=env)
             shprint(sh.make, 'install', _env=env)
-            shutil.copyfile(
-                '{}/lib/libexpat.so'.format(dst_dir),
-                join(self.ctx.get_libs_dir(arch.arch), 'libexpat.so'))
 
 
 recipe = LibexpatRecipe()

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -2,7 +2,7 @@ from os.path import exists, join
 from multiprocessing import cpu_count
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import shprint
-from pythonforandroid.util import current_directory, ensure_dir
+from pythonforandroid.util import current_directory
 import sh
 
 
@@ -31,8 +31,7 @@ class LibffiRecipe(Recipe):
 
     patches = ['remove-version-info.patch']
 
-    def should_build(self, arch):
-        return not exists(join(self.ctx.get_libs_dir(arch.arch), 'libffi.so'))
+    built_libraries = {'libffi.so': '.libs'}
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
@@ -46,10 +45,6 @@ class LibffiRecipe(Recipe):
                     '--disable-builddir',
                     '--enable-shared', _env=env)
             shprint(sh.make, '-j', str(cpu_count()), 'libffi.la', _env=env)
-            ensure_dir(self.ctx.get_libs_dir(arch.arch))
-            self.install_libs(
-                arch, join(self.get_build_dir(arch.arch), '.libs', 'libffi.so')
-            )
 
     def get_include_dirs(self, arch):
         return [join(self.get_build_dir(arch.arch), 'include')]

--- a/pythonforandroid/recipes/libglob/__init__.py
+++ b/pythonforandroid/recipes/libglob/__init__.py
@@ -3,13 +3,13 @@
     available via '-lglob' LDFLAG
 """
 from os.path import exists, join
-from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import current_directory
 from pythonforandroid.logger import info, shprint
 import sh
 
 
-class LibGlobRecipe(CompiledComponentsPythonRecipe):
+class LibGlobRecipe(Recipe):
     """Make a glob.h and glob.so for the python_install_dir()"""
     version = '0.0.1'
     url = None
@@ -20,6 +20,7 @@ class LibGlobRecipe(CompiledComponentsPythonRecipe):
     #   https://raw.githubusercontent.com/white-gecko/TokyoCabinet/master/glob.c
     # and pushed in via patch
     name = 'libglob'
+    built_libraries = {'libglob.so': '.'}
 
     depends = [('hostpython2', 'hostpython3')]
     patches = ['glob.patch']
@@ -60,7 +61,6 @@ class LibGlobRecipe(CompiledComponentsPythonRecipe):
             cflags.extend(['-shared', '-I.', 'glob.o', '-o', 'libglob.so'])
             cflags.extend(env['LDFLAGS'].split())
             shprint(cc, *cflags, _env=env)
-            shprint(sh.cp, 'libglob.so', join(self.ctx.libs_dir, arch.arch))
 
 
 recipe = LibGlobRecipe()

--- a/pythonforandroid/recipes/libglob/glob.patch
+++ b/pythonforandroid/recipes/libglob/glob.patch
@@ -911,7 +911,7 @@ diff -Nur /tmp/x/glob.c libglob/glob.c
 diff -Nur /tmp/x/glob.h libglob/glob.h
 --- /tmp/x/glob.h	1969-12-31 19:00:00.000000000 -0500
 +++ libglob/glob.h	2017-08-19 15:22:18.367109399 -0400
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,104 @@
 +/*
 + * Copyright (c) 1989, 1993
 + *	The Regents of the University of California.  All rights reserved.
@@ -952,10 +952,12 @@ diff -Nur /tmp/x/glob.h libglob/glob.h
 +
 +#include <sys/cdefs.h>
 +#include <sys/types.h>
++#ifndef ARG_MAX
 +#define     ARG_MAX     6553
++#endif
 +
 +#ifndef	_SIZE_T_DECLARED
-+typedef	__size_t	size_t;
++#include <stddef.h>
 +#define	_SIZE_T_DECLARED
 +#endif
 +

--- a/pythonforandroid/recipes/libiconv/__init__.py
+++ b/pythonforandroid/recipes/libiconv/__init__.py
@@ -1,5 +1,5 @@
-import os
-from pythonforandroid.toolchain import shprint, current_directory
+from pythonforandroid.logger import shprint
+from pythonforandroid.util import current_directory
 from pythonforandroid.recipe import Recipe
 from multiprocessing import cpu_count
 import sh
@@ -11,14 +11,11 @@ class LibIconvRecipe(Recipe):
 
     url = 'https://ftp.gnu.org/pub/gnu/libiconv/libiconv-{version}.tar.gz'
 
+    built_libraries = {'libiconv.so': 'lib/.libs'}
+
     patches = ['libiconv-1.15-no-gets.patch']
 
-    def should_build(self, arch):
-        return not os.path.exists(
-                os.path.join(self.ctx.get_libs_dir(arch.arch), 'libiconv.so'))
-
     def build_arch(self, arch):
-        super(LibIconvRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
             shprint(
@@ -27,8 +24,6 @@ class LibIconvRecipe(Recipe):
                 '--prefix=' + self.ctx.get_python_install_dir(),
                 _env=env)
             shprint(sh.make, '-j' + str(cpu_count()), _env=env)
-            libs = ['lib/.libs/libiconv.so']
-            self.install_libs(arch, *libs)
 
 
 recipe = LibIconvRecipe()

--- a/pythonforandroid/recipes/libogg/__init__.py
+++ b/pythonforandroid/recipes/libogg/__init__.py
@@ -1,14 +1,12 @@
-from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import current_directory, shprint
-from os.path import join
 import sh
 
 
-class OggRecipe(NDKRecipe):
+class OggRecipe(Recipe):
     version = '1.3.3'
     url = 'http://downloads.xiph.org/releases/ogg/libogg-{version}.tar.gz'
-
-    generated_libraries = ['libogg.so']
+    built_libraries = {'libogg.so': 'src/.libs'}
 
     def build_arch(self, arch):
         with current_directory(self.get_build_dir(arch.arch)):
@@ -20,7 +18,6 @@ class OggRecipe(NDKRecipe):
             configure = sh.Command('./configure')
             shprint(configure, *flags, _env=env)
             shprint(sh.make, _env=env)
-            self.install_libs(arch, join('src', '.libs', 'libogg.so'))
 
 
 recipe = OggRecipe()

--- a/pythonforandroid/recipes/libsecp256k1/__init__.py
+++ b/pythonforandroid/recipes/libsecp256k1/__init__.py
@@ -1,4 +1,5 @@
-from pythonforandroid.toolchain import shprint, current_directory
+from pythonforandroid.logger import shprint
+from pythonforandroid.util import current_directory
 from pythonforandroid.recipe import Recipe
 from multiprocessing import cpu_count
 from os.path import exists
@@ -7,10 +8,11 @@ import sh
 
 class LibSecp256k1Recipe(Recipe):
 
+    built_libraries = {'libsecp256k1.so': '.libs'}
+
     url = 'https://github.com/bitcoin-core/secp256k1/archive/master.zip'
 
     def build_arch(self, arch):
-        super(LibSecp256k1Recipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
             if not exists('configure'):
@@ -25,8 +27,6 @@ class LibSecp256k1Recipe(Recipe):
                 '--enable-module-ecdh',
                 _env=env)
             shprint(sh.make, '-j' + str(cpu_count()), _env=env)
-            libs = ['.libs/libsecp256k1.so']
-            self.install_libs(arch, *libs)
 
 
 recipe = LibSecp256k1Recipe()

--- a/pythonforandroid/recipes/libshine/__init__.py
+++ b/pythonforandroid/recipes/libshine/__init__.py
@@ -1,5 +1,8 @@
-from pythonforandroid.toolchain import Recipe, current_directory, shprint
-from os.path import exists, join, realpath
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
+from multiprocessing import cpu_count
+from os.path import realpath
 import sh
 
 
@@ -7,9 +10,7 @@ class LibShineRecipe(Recipe):
     version = 'c72aba9031bde18a0995e7c01c9b53f2e08a0e46'
     url = 'https://github.com/toots/shine/archive/{version}.zip'
 
-    def should_build(self, arch):
-        build_dir = self.get_build_dir(arch.arch)
-        return not exists(join(build_dir, 'lib', 'libshine.a'))
+    built_libraries = {'libshine.a': 'lib'}
 
     def build_arch(self, arch):
         with current_directory(self.get_build_dir(arch.arch)):
@@ -23,7 +24,7 @@ class LibShineRecipe(Recipe):
                     '--enable-static',
                     '--prefix={}'.format(realpath('.')),
                     _env=env)
-            shprint(sh.make, '-j4', _env=env)
+            shprint(sh.make, '-j', str(cpu_count()), _env=env)
             shprint(sh.make, 'install', _env=env)
 
 

--- a/pythonforandroid/recipes/libx264/__init__.py
+++ b/pythonforandroid/recipes/libx264/__init__.py
@@ -1,15 +1,15 @@
-from pythonforandroid.toolchain import Recipe, current_directory, shprint
-from os.path import exists, join, realpath
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
+from multiprocessing import cpu_count
+from os.path import realpath
 import sh
 
 
 class LibX264Recipe(Recipe):
     version = 'x264-snapshot-20171218-2245-stable'  # using mirror url since can't use ftp
     url = 'http://mirror.yandex.ru/mirrors/ftp.videolan.org/x264/snapshots/{version}.tar.bz2'
-
-    def should_build(self, arch):
-        build_dir = self.get_build_dir(arch.arch)
-        return not exists(join(build_dir, 'lib', 'libx264.a'))
+    built_libraries = {'libx264.a': 'lib'}
 
     def build_arch(self, arch):
         with current_directory(self.get_build_dir(arch.arch)):
@@ -29,7 +29,7 @@ class LibX264Recipe(Recipe):
                     '--enable-static',
                     '--prefix={}'.format(realpath('.')),
                     _env=env)
-            shprint(sh.make, '-j4', _env=env)
+            shprint(sh.make, '-j', str(cpu_count()), _env=env)
             shprint(sh.make, 'install', _env=env)
 
 

--- a/pythonforandroid/recipes/libxml2/__init__.py
+++ b/pythonforandroid/recipes/libxml2/__init__.py
@@ -1,6 +1,7 @@
 from pythonforandroid.recipe import Recipe
-from pythonforandroid.toolchain import shprint, shutil, current_directory
-from os.path import exists, join
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
+from os.path import exists
 import sh
 
 
@@ -9,14 +10,9 @@ class Libxml2Recipe(Recipe):
     url = 'http://xmlsoft.org/sources/libxml2-{version}.tar.gz'
     depends = []
     patches = ['add-glob.c.patch']
-
-    def should_build(self, arch):
-        super(Libxml2Recipe, self).should_build(arch)
-        return not exists(
-            join(self.get_build_dir(arch.arch), '.libs', 'libxml2.a'))
+    built_libraries = {'libxml2.a': '.libs'}
 
     def build_arch(self, arch):
-        super(Libxml2Recipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
 
@@ -45,9 +41,6 @@ class Libxml2Recipe(Recipe):
             # Ensure we only build libxml2.la as if we do everything
             # we'll need the glob dependency which is a big headache
             shprint(sh.make, "libxml2.la", _env=env)
-
-            shutil.copyfile('.libs/libxml2.a',
-                            join(self.ctx.libs_dir, 'libxml2.a'))
 
     def get_recipe_env(self, arch):
         env = super(Libxml2Recipe, self).get_recipe_env(arch)

--- a/pythonforandroid/recipes/libxslt/__init__.py
+++ b/pythonforandroid/recipes/libxslt/__init__.py
@@ -1,5 +1,6 @@
 from pythonforandroid.recipe import Recipe
-from pythonforandroid.toolchain import shprint, shutil, current_directory
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
 from os.path import exists, join
 import sh
 
@@ -9,16 +10,14 @@ class LibxsltRecipe(Recipe):
     url = 'http://xmlsoft.org/sources/libxslt-{version}.tar.gz'
     depends = ['libxml2']
     patches = ['fix-dlopen.patch']
+    built_libraries = {
+        'libxslt.a': 'libxslt/.libs',
+        'libexslt.a': 'libexslt/.libs'
+    }
 
     call_hostpython_via_targetpython = False
 
-    def should_build(self, arch):
-        return not exists(
-            join(self.get_build_dir(arch.arch),
-                 'libxslt', '.libs', 'libxslt.a'))
-
     def build_arch(self, arch):
-        super(LibxsltRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         build_dir = self.get_build_dir(arch.arch)
         with current_directory(build_dir):
@@ -44,11 +43,6 @@ class LibxsltRecipe(Recipe):
                     '--disable-shared',
                     _env=env)
             shprint(sh.make, "V=1", _env=env)
-
-            shutil.copyfile('libxslt/.libs/libxslt.a',
-                            join(self.ctx.libs_dir, 'libxslt.a'))
-            shutil.copyfile('libexslt/.libs/libexslt.a',
-                            join(self.ctx.libs_dir, 'libexslt.a'))
 
     def get_recipe_env(self, arch):
         env = super(LibxsltRecipe, self).get_recipe_env(arch)

--- a/pythonforandroid/recipes/libzbar/__init__.py
+++ b/pythonforandroid/recipes/libzbar/__init__.py
@@ -1,6 +1,7 @@
 import os
-from pythonforandroid.toolchain import shprint, current_directory
 from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
 from multiprocessing import cpu_count
 import sh
 
@@ -15,9 +16,7 @@ class LibZBarRecipe(Recipe):
 
     patches = ["werror.patch"]
 
-    def should_build(self, arch):
-        return not os.path.exists(
-            os.path.join(self.ctx.get_libs_dir(arch.arch), 'libzbar.so'))
+    built_libraries = {'libzbar.so': 'zbar/.libs'}
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super(LibZBarRecipe, self).get_recipe_env(arch, with_flags_in_cc)
@@ -28,7 +27,6 @@ class LibZBarRecipe(Recipe):
         return env
 
     def build_arch(self, arch):
-        super(LibZBarRecipe, self).build_arch(arch)
         env = self.get_recipe_env(arch)
         with current_directory(self.get_build_dir(arch.arch)):
             shprint(sh.Command('autoreconf'), '-vif', _env=env)
@@ -50,8 +48,6 @@ class LibZBarRecipe(Recipe):
                 '--enable-static=no',
                 _env=env)
             shprint(sh.make, '-j' + str(cpu_count()), _env=env)
-            libs = ['zbar/.libs/libzbar.so']
-            self.install_libs(arch, *libs)
 
 
 recipe = LibZBarRecipe()

--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -1,6 +1,8 @@
 from os.path import join
 
-from pythonforandroid.toolchain import Recipe, shprint, current_directory
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+from pythonforandroid.logger import shprint
 import sh
 
 
@@ -50,6 +52,11 @@ class OpenSSLRecipe(Recipe):
 
     url = 'https://www.openssl.org/source/openssl-{url_version}.tar.gz'
 
+    built_libraries = {
+        'libcrypto{version}.so'.format(version=version): '.',
+        'libssl{version}.so'.format(version=version): '.',
+    }
+
     @property
     def versioned_url(self):
         if self.url is None:
@@ -84,10 +91,6 @@ class OpenSSLRecipe(Recipe):
         '''Returns a string with the flags to link with the openssl libraries
         in the format: `-L<lib directory> -l<lib>`'''
         return self.link_dirs_flags(arch) + self.link_libs_flags()
-
-    def should_build(self, arch):
-        return not self.has_libs(arch, 'libssl' + self.version + '.so',
-                                 'libcrypto' + self.version + '.so')
 
     def get_recipe_env(self, arch=None):
         env = super(OpenSSLRecipe, self).get_recipe_env(arch)
@@ -128,9 +131,6 @@ class OpenSSLRecipe(Recipe):
             self.apply_patch('disable-sover.patch', arch.arch)
 
             shprint(sh.make, 'build_libs', _env=env)
-
-            self.install_libs(arch, 'libssl' + self.version + '.so',
-                              'libcrypto' + self.version + '.so')
 
 
 recipe = OpenSSLRecipe()

--- a/pythonforandroid/recipes/png/__init__.py
+++ b/pythonforandroid/recipes/png/__init__.py
@@ -2,7 +2,6 @@ from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import shprint
 from pythonforandroid.util import current_directory
 from multiprocessing import cpu_count
-from os.path import join, exists
 import sh
 
 
@@ -10,14 +9,9 @@ class PngRecipe(Recipe):
     name = 'png'
     version = 'v1.6.37'
     url = 'https://github.com/glennrp/libpng/archive/{version}.zip'
-
-    def should_build(self, arch):
-        return not exists(
-            join(self.get_build_dir(arch.arch), '.libs', 'libpng16.so')
-        )
+    built_libraries = {'libpng16.so': '.libs'}
 
     def build_arch(self, arch):
-        super(PngRecipe, self).build_arch(arch)
         build_dir = self.get_build_dir(arch.arch)
         with current_directory(build_dir):
             env = self.get_recipe_env(arch)
@@ -37,7 +31,6 @@ class PngRecipe(Recipe):
                 _env=env,
             )
             shprint(sh.make, '-j', str(cpu_count()), _env=env)
-            self.install_libs(arch, join(build_dir, '.libs', 'libpng16.so'))
 
 
 recipe = PngRecipe()


### PR DESCRIPTION
This PR will introduce a new cls attribute: `built_libraries`.
This `built_libraries` attribute must be a dictionary. The keys are the full library name, e.g.: `libffi.so`. And the values must be the relative path of the library, e.g: `.libs`. So the this cls attribute for libffi recipe it would look like:
    ```built_libraries = {'libffi.so': '.libs'}```

This new cls attribute will allow us to detect library recipes and to refactor common operations that we do for those kind of recipes:
  - copy library into right location
  - implement `should_build` for library recipes

Those two things will make that our rebuilds to be more consistent and I hope that it will be easier to maintain. Also I was thinking that it would be great to refactor the build methods that we use in those recipes, but this is another chapter of p4a story...and maybe better to wait for the NDK r19 migration thing

This could be safely merged without affecting the library recipes untouched here, which will behave as usual. This is because the `build_arch` method, for library recipes only, it will be split into two jobs:
 - do_build_libs
 - do_install_libs

**So, once explained a little this PR, in here we do:**
  - [x] Add attribute `built_libraries`
  - [x] Add methods to refactor common library operations:
    - [x] do_build_libs
    - [x] do_install_libs
  - [x] implement `should_build` for library recipes
  - [x] implement basic tests for the newly introduced `Recipe` methods
  - [x] Make use of those Library attributes/methods for some basic set of recipes:
    - [x] libffi
    - [x] openssl
    - [x] png
     - [x] jpeg
     - [x] freetype
     - [x] harfbuzz
     - [x] libcurl
     - [x] libzbar
     - [x] libiconv
     - [x] libexpat
     - [x] libogg
     - [x] libxml2
     - [x] libxslt
     - [x] libshine
     - [x] libx264
     - [x] libglob
     - [x] libsodium
     - [x] libsecp256k1

**Things to do in seperate PRs**, to be easy to review and because those points will start to conflict with the `NDK r19 migration` thing:
  - Make use of Library attributes/methods introduced in this PR for un covered library recipes in here. Here we have two situations:
     - library recipes that depends on android's STL library (almost all the work done in here will depend of the `NDK r19 migration` thing)
     - all remaining library recipes, wich are not STL lib dependant and that are not implemented in here (because I was unable to perform a successful build with them using arch `arm64-v8a`...so I think it would  be better to deal with those recipes in seperate PRs and later...with the `NDK r19 migration` thing merged)

**Notes about changed recipes:** all the recipes touched in here almost have the same changes:
  - remove `should_build` method (to make use of the one implemented in base class for library recipes)
  - rename `build_arch` to `do_build_libs`
  - remove the copy of the library (because that will be done automatically by the method `do_install_libs` implemented in base class)
  - fixed the imports due to refactoring