### PR TITLE
Adds new `backup_attributes` context manager for tests

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -741,12 +741,12 @@ class ToolchainCL(object):
     def recipes(self, args):
         """
         Prints recipes basic info, e.g.
-        ```
-        python3      3.7.1
-            depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
-            conflicts: ['python2']
-            optional depends: ['sqlite3', 'libffi', 'openssl']
-        ```
+        .. code-block:: bash
+
+            python3      3.7.1
+                depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
+                conflicts: ['python2']
+                optional depends: ['sqlite3', 'libffi', 'openssl']
         """
         ctx = self.ctx
         if args.compact:

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -2,6 +2,7 @@ import io
 import sys
 import pytest
 import mock
+from util import backup_attributes
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import ToolchainCL
 from pythonforandroid.util import BuildInterruptingException
@@ -121,7 +122,10 @@ class TestToolchainCL:
         Checks the `recipes` command prints out recipes information without crashing.
         """
         argv = ['toolchain.py', 'recipes']
-        with patch_sys_argv(argv), patch_sys_stdout() as m_stdout:
+        with (
+                patch_sys_argv(argv)), (
+                patch_sys_stdout()) as m_stdout, (
+                backup_attributes(Recipe, {'recipes'})):
             ToolchainCL()
         # check if we have common patterns in the output
         expected_strings = (
@@ -134,5 +138,3 @@ class TestToolchainCL:
         )
         for expected_string in expected_strings:
             assert expected_string in m_stdout.getvalue()
-        # deletes static attribute to not mess with other tests
-        del Recipe.recipes

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ except ImportError:
     # `Python 2` or lower than `Python 3.3` does not
     # have the `unittest.mock` module built-in
     import mock
+import util as test_util
 from pythonforandroid import util
 
 
@@ -16,6 +17,36 @@ class TestUtil(unittest.TestCase):
     An inherited class of `unittest.TestCase`to test the module
     :mod:`~pythonforandroid.util`.
     """
+
+    def test_backup_attributes(self):
+        """
+        Checks the helper backup_attributes context manager works as expected.
+        """
+        class MyClass:
+            def __init__(self, foo, bar):
+                self.foo = foo
+                self.bar = bar
+
+        # testing trivial flat backup
+        foo = 'foo'
+        bar = 'bar'
+        my_object = MyClass(foo=foo, bar=bar)
+        with test_util.backup_attributes(my_object, {'foo'}):
+            my_object.foo = 'not foo'
+            my_object.bar = 'not bar'
+        assert my_object.foo == 'foo'
+        assert my_object.bar == 'not bar'
+        # testing deep backup
+        foo = {'foo': {1, 2, 3}}
+        bar = {'bar': {3, 2, 1}}
+        my_object = MyClass(foo=foo, bar=bar)
+        with test_util.backup_attributes(my_object, {'foo', 'bar'}):
+            # changing the reference
+            my_object.foo = {}
+            # and mutating the object the attribute is referencing to
+            my_object.bar['bar'] = None
+        assert my_object.foo == {'foo': {1, 2, 3}}
+        assert my_object.bar == {'bar': {3, 2, 1}}
 
     @mock.patch("pythonforandroid.util.makedirs")
     def test_ensure_dir(self, mock_makedirs):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+from contextlib import contextmanager
+
+
+@contextmanager
+def backup_attributes(obj, attributes):
+    """
+    Makes a backup of the object attributes that gets restored later.
+    """
+    obj_dict = obj.__dict__
+    # creates a subset dictionary of the attributes we're interested in
+    attributes_backup = dict(
+        (k, obj_dict[k]) for k in attributes if k in obj_dict)
+    attributes_backup = deepcopy(attributes_backup)
+    try:
+        yield
+    finally:
+        for attribute in attributes:
+            setattr(obj, attribute, attributes_backup[attribute])


### PR DESCRIPTION
This context manager will makes it possible to rollback an object state
after leaving the context manager.
This is a follow up of
<https://github.com/kivy/python-for-android/pull/1867#discussion_r309345405>

Also address docstring format as suggested by @opacam in
<https://github.com/kivy/python-for-android/pull/1933#discussion_r308116515>