### PR TITLE
 Fix build for case-insensitive FS and add CI test for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ before_install:
   - git remote set-branches --add origin develop
   - git fetch
 
-env:
-  global:
-    - ANDROID_SDK_HOME=/opt/android/android-sdk
-    - ANDROID_NDK_HOME=/opt/android/android-ndk
-
 jobs:
   include:
     - &linting
@@ -65,19 +60,41 @@ jobs:
         # case that the travis log doesn't produce any output for more than 10 minutes
         - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
       script:
-        - docker run -e CI -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" p4a /bin/sh -c "$COMMAND"
+        - >
+          docker run
+          -e CI
+          -e TRAVIS_JOB_ID
+          -e TRAVIS_BRANCH
+          -e ANDROID_SDK_HOME="/home/user/.android/android-sdk"
+          -e ANDROID_NDK_HOME="/home/user/.android/android-ndk"
+          p4a /bin/sh -c "$COMMAND"
       after_script:
         # kill the background process started before run docker
         - kill %1
-      name: Python 3 armeabi-v7a
+      name: Python 3 arm64-v8a
       # overrides requirements to skip `peewee` pure python module, see:
       # https://github.com/kivy/python-for-android/issues/1263#issuecomment-390421054
-      env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools' --arch=armeabi-v7a
+      env:
+        COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools' --arch=arm64-v8a
     - <<: *testing
-      name: Python 3 arm64-v8a
-      env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools' --arch=arm64-v8a
+      name: Python 3 armeabi-v7a
+      os: osx
+      osx_image: xcode11  # since xcode1.3, python3 is the default interpreter
+      before_script:
+        # installs java 1.8, android's SDK/NDK and p4a
+        - make -f ci/makefiles/osx.mk
+        - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+        # Run a background process (like we do with linux tests)
+        - while sleep 540; do echo "==== Still running (travis, don't kill me) ===="; done &
+      script:
+        - >
+          cd testapps && python3 setup_testapp_python3_sqlite_openssl.py apk
+          --sdk-dir $HOME/.android/android-sdk
+          --ndk-dir $HOME/.android/android-ndk
+          --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools
+          --arch=armeabi-v7a
     - <<: *testing
-      name: Python 2 basic
+      name: Python 2 armeabi-v7a (with numpy)
       env: COMMAND='. venv/bin/activate && cd testapps/ && python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $ANDROID_SDK_HOME --ndk-dir $ANDROID_NDK_HOME --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools,numpy'
     - <<: *testing
       name: Rebuild updated recipes

--- a/Dockerfile.py2
+++ b/Dockerfile.py2
@@ -37,64 +37,17 @@ ENV RETRY="retry -t 3 --"
 RUN curl https://raw.githubusercontent.com/kadwanev/retry/1.0.1/retry \
     --output /usr/local/bin/retry && chmod +x /usr/local/bin/retry
 
-ENV ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk"
-ENV ANDROID_NDK_VERSION="17c"
-ENV ANDROID_NDK_HOME_V="${ANDROID_NDK_HOME}-r${ANDROID_NDK_VERSION}"
-
-# get the latest version from https://developer.android.com/ndk/downloads/index.html
-ENV ANDROID_NDK_ARCHIVE="android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip"
-ENV ANDROID_NDK_DL_URL="https://dl.google.com/android/repository/${ANDROID_NDK_ARCHIVE}"
-
-# download and install Android NDK
-RUN ${RETRY} curl --location --progress-bar --insecure \
-        "${ANDROID_NDK_DL_URL}" \
-        --output "${ANDROID_NDK_ARCHIVE}" \
-    && mkdir --parents "${ANDROID_NDK_HOME_V}" \
-    && unzip -q "${ANDROID_NDK_ARCHIVE}" -d "${ANDROID_HOME}" \
-    && ln -sfn "${ANDROID_NDK_HOME_V}" "${ANDROID_NDK_HOME}" \
-    && rm -rf "${ANDROID_NDK_ARCHIVE}"
-
-
-ENV ANDROID_SDK_HOME="${ANDROID_HOME}/android-sdk"
-
-# get the latest version from https://developer.android.com/studio/index.html
-ENV ANDROID_SDK_TOOLS_VERSION="4333796"
-ENV ANDROID_SDK_BUILD_TOOLS_VERSION="28.0.2"
-ENV ANDROID_SDK_TOOLS_ARCHIVE="sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip"
-ENV ANDROID_SDK_TOOLS_DL_URL="https://dl.google.com/android/repository/${ANDROID_SDK_TOOLS_ARCHIVE}"
-
-# download and install Android SDK
-RUN ${RETRY} curl --location --progress-bar --insecure \
-        "${ANDROID_SDK_TOOLS_DL_URL}" \
-        --output "${ANDROID_SDK_TOOLS_ARCHIVE}" \
-    && mkdir --parents "${ANDROID_SDK_HOME}" \
-    && unzip -q "${ANDROID_SDK_TOOLS_ARCHIVE}" -d "${ANDROID_SDK_HOME}" \
-    && rm -rf "${ANDROID_SDK_TOOLS_ARCHIVE}"
-
-# update Android SDK, install Android API, Build Tools...
-RUN mkdir --parents "${ANDROID_SDK_HOME}/.android/" \
-    && echo '### User Sources for Android SDK Manager' \
-        > "${ANDROID_SDK_HOME}/.android/repositories.cfg"
-
-# Download and accept Android licenses (JDK necessary!)
-RUN ${RETRY} apt -y install -qq --no-install-recommends openjdk-8-jdk \
-    && apt -y autoremove
-RUN yes | "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "build-tools;${ANDROID_SDK_BUILD_TOOLS_VERSION}" > /dev/null
-RUN yes | "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" "platforms;android-27" > /dev/null
-
-# Set avdmanager permissions (executable)
-RUN chmod +x "${ANDROID_SDK_HOME}/tools/bin/avdmanager"
-
-
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
+ENV ANDROID_HOME="${HOME_DIR}/.android"
 ENV WORK_DIR="${HOME_DIR}" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
 
 # install system dependencies
 RUN ${RETRY} apt -y install -qq --no-install-recommends \
         python virtualenv python-pip wget lbzip2 patch sudo \
-    && apt -y autoremove
+    && apt -y autoremove \
+    && apt -y clean
 
 # build dependencies
 # https://buildozer.readthedocs.io/en/latest/installation.html#android-on-ubuntu-16-04-64bit
@@ -113,6 +66,10 @@ RUN ${RETRY} apt -y install -qq --no-install-recommends \
     && apt -y autoremove \
     && apt -y clean
 
+# Install Java, set JAVA_HOME (to accept android's SDK licenses) and clean
+RUN ${RETRY} apt -y install -qq --no-install-recommends openjdk-8-jdk \
+    && apt -y autoremove && apt -y clean
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # prepare non root env
 RUN useradd --create-home --shell /bin/bash ${USER}
@@ -124,8 +81,11 @@ RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 WORKDIR ${WORK_DIR}
 COPY --chown=user:user . ${WORK_DIR}
-RUN chown --recursive ${USER} ${ANDROID_SDK_HOME}
+RUN mkdir ${ANDROID_HOME} && chown --recursive ${USER} ${ANDROID_HOME}
 USER ${USER}
+
+# Download and install android's NDK/SDK
+RUN make -f ci/makefiles/android.mk target_os=linux
 
 # install python-for-android from current branch
 RUN virtualenv --python=python venv \

--- a/ci/makefiles/android.mk
+++ b/ci/makefiles/android.mk
@@ -1,0 +1,68 @@
+# Downloads and installs the Android SDK depending on supplied platform: darwin or linux
+
+# We must provide a platform (darwin or linux) and we need JAVA_HOME defined
+ifndef target_os
+    $(error target_os is not set...aborted!)
+endif
+
+# Those android NDK/SDK variables can be override when running the file
+ANDROID_NDK_VERSION ?= 17c
+ANDROID_SDK_TOOLS_VERSION ?= 4333796
+ANDROID_SDK_BUILD_TOOLS_VERSION ?= 28.0.2
+ANDROID_HOME ?= $(HOME)/.android
+ANDROID_API_LEVEL ?= 27
+
+ANDROID_SDK_HOME=$(ANDROID_HOME)/android-sdk
+ANDROID_SDK_TOOLS_ARCHIVE=sdk-tools-$(target_os)-$(ANDROID_SDK_TOOLS_VERSION).zip
+ANDROID_SDK_TOOLS_DL_URL=https://dl.google.com/android/repository/$(ANDROID_SDK_TOOLS_ARCHIVE)
+
+ANDROID_NDK_HOME=$(ANDROID_HOME)/android-ndk
+ANDROID_NDK_FOLDER=$(ANDROID_HOME)/android-ndk-r$(ANDROID_NDK_VERSION)
+ANDROID_NDK_ARCHIVE=android-ndk-r$(ANDROID_NDK_VERSION)-$(target_os)-x86_64.zip
+ANDROID_NDK_DL_URL=https://dl.google.com/android/repository/$(ANDROID_NDK_ARCHIVE)
+
+$(info Target install OS is          : $(target_os))
+$(info Android SDK home is           : $(ANDROID_SDK_HOME))
+$(info Android NDK home is           : $(ANDROID_NDK_HOME))
+$(info Android SDK download url is   : $(ANDROID_SDK_TOOLS_DL_URL))
+$(info Android NDK download url is   : $(ANDROID_NDK_DL_URL))
+$(info Android API level is          : $(ANDROID_API_LEVEL))
+$(info Android NDK version is        : $(ANDROID_NDK_VERSION))
+$(info JAVA_HOME is                  : $(JAVA_HOME))
+
+all: install_sdk install_ndk
+
+install_sdk: download_android_sdk extract_android_sdk update_android_sdk
+
+install_ndk: download_android_ndk extract_android_ndk
+
+download_android_sdk:
+	curl --location --progress-bar --continue-at - \
+	$(ANDROID_SDK_TOOLS_DL_URL) --output $(ANDROID_SDK_TOOLS_ARCHIVE)
+
+download_android_ndk:
+	curl --location --progress-bar --continue-at - \
+	$(ANDROID_NDK_DL_URL) --output $(ANDROID_NDK_ARCHIVE)
+
+# Extract android SDK and remove the compressed file
+extract_android_sdk:
+	mkdir -p $(ANDROID_SDK_HOME) \
+	&& unzip -q $(ANDROID_SDK_TOOLS_ARCHIVE) -d $(ANDROID_SDK_HOME) \
+	&& rm -f $(ANDROID_SDK_TOOLS_ARCHIVE)
+
+
+# Extract android NDK and remove the compressed file
+extract_android_ndk:
+	mkdir -p $(ANDROID_NDK_FOLDER) \
+	&& unzip -q $(ANDROID_NDK_ARCHIVE) -d $(ANDROID_HOME) \
+	&& ln -sfn $(ANDROID_NDK_FOLDER) $(ANDROID_NDK_HOME) \
+	&& rm -f $(ANDROID_NDK_ARCHIVE)
+
+# updates Android SDK, install Android API, Build Tools and accept licenses
+update_android_sdk:
+	touch $(ANDROID_HOME)/repositories.cfg
+	yes | $(ANDROID_SDK_HOME)/tools/bin/sdkmanager --licenses > /dev/null
+	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager "build-tools;$(ANDROID_SDK_BUILD_TOOLS_VERSION)" > /dev/null
+	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager "platforms;android-$(ANDROID_API_LEVEL)" > /dev/null
+	# Set avdmanager permissions (executable)
+	chmod +x $(ANDROID_SDK_HOME)/tools/bin/avdmanager

--- a/ci/makefiles/osx.mk
+++ b/ci/makefiles/osx.mk
@@ -1,0 +1,23 @@
+# installs java 1.8, android's SDK/NDK, cython and p4a
+
+# The following variable/s can be override when running the file
+ANDROID_HOME ?= $(HOME)/.android
+
+all: install_java upgrade_cython install_android_ndk_sdk install_p4a
+
+install_java:
+	brew tap adoptopenjdk/openjdk
+	brew cask install adoptopenjdk8
+	/usr/libexec/java_home -V
+
+upgrade_cython:
+	pip3 install --upgrade Cython==0.28.6
+
+install_android_ndk_sdk:
+	mkdir -p $(ANDROID_HOME)
+	make -f ci/makefiles/android.mk target_os=darwin JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+
+install_p4a:
+	# check python version and install p4a
+	python3 --version
+	pip3 install -e .

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -773,9 +773,9 @@ class PythonRecipe(Recipe):
     @property
     def real_hostpython_location(self):
         host_name = 'host{}'.format(self.ctx.python_recipe.name)
-        host_build = Recipe.get_recipe(host_name, self.ctx).get_build_dir()
         if host_name in ['hostpython2', 'hostpython3']:
-            return join(host_build, 'native-build', 'python')
+            python_recipe = Recipe.get_recipe(host_name, self.ctx)
+            return python_recipe.python_exe
         else:
             python_recipe = self.ctx.python_recipe
             return 'python{}'.format(python_recipe.version)

--- a/pythonforandroid/recipes/python2/__init__.py
+++ b/pythonforandroid/recipes/python2/__init__.py
@@ -32,7 +32,9 @@ class Python2Recipe(GuestPythonRecipe):
                'patches/fix-gethostbyaddr.patch',
                'patches/fix-posix-declarations.patch',
                'patches/fix-pwd-gecos.patch',
-               'patches/fix-ctypes-util-find-library.patch']
+               'patches/fix-ctypes-util-find-library.patch',
+               'patches/fix-interpreter-version.patch',
+    ]
 
     configure_args = ('--host={android_host}',
                       '--build={android_build}',

--- a/pythonforandroid/recipes/python2/patches/fix-interpreter-version.patch
+++ b/pythonforandroid/recipes/python2/patches/fix-interpreter-version.patch
@@ -1,0 +1,11 @@
+--- Python-2.7.15/configure.orig	2018-04-30 00:47:33.000000000 +0200
++++ Python-2.7.15/configure	2019-08-16 14:09:48.696030207 +0200
+@@ -2903,7 +2903,7 @@ case $host_os in *\ *) host_os=`echo "$h
+ # pybuilddir.txt will be created by --generate-posix-vars in the Makefile
+ rm -f pybuilddir.txt
+ 
+-for ac_prog in python$PACKAGE_VERSION python3 python
++for ac_prog in python$PACKAGE_VERSION python2 python
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2


### PR DESCRIPTION
It turns out that the generated binary for `MacOS` and `Cygwin` is not `python`...it's `python.exe`...this leads to not set correctly the `ctx.hostpython` variable for `Mac OS`. This rename of the python binary for  `MacOS` is to, probably,  avoid issues with the  `Mac OS` filesystem which could be Case Insensitive and it would conflict with the build folder named `Python`).

I hope that this solve the `Mac OS` build issue :crossed_fingers:

**Note:** this should be tested by some mac user, unfortunately I could not test it because I don't have a mac...so I recommend to merge after someone test this, but all seems indicate that this is the problem of p4a with Mac OS...thanks to [this comment](https://github.com/kivy/python-for-android/issues/1817#issuecomment-517338012) we got the solution :smile:,**Thanks** @TheSin-

**See also:** https://github.com/python/cpython/blob/3.7/README.rst#build-instructions

Closes: #1817
Closes: #1800
Closes: #1682
Closes: #1647