### PR TITLE
Unit tests Recipe.download_file() partly

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -741,12 +741,11 @@ class ToolchainCL(object):
     def recipes(self, args):
         """
         Prints recipes basic info, e.g.
-        ```
-        python3      3.7.1
-            depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
-            conflicts: ['python2']
-            optional depends: ['sqlite3', 'libffi', 'openssl']
-        ```
+        .. code-block:: bash
+            python3      3.7.1
+                depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
+                conflicts: ['python2']
+                optional depends: ['sqlite3', 'libffi', 'openssl']
         """
         ctx = self.ctx
         if args.compact:


### PR DESCRIPTION
Follow up of #1946.
Increases coverage by testing part of `Recipe.download_file()` handling
https schema. Next up would be to handle more schemas in the tests.
Also addressed @opacam comments from previous pull requests.