### PR TITLE
Remove `--sysroot` from LDFLAGS for cffi and pymunk

### DIFF
--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -38,7 +38,6 @@ class CffiRecipe(CompiledComponentsPythonRecipe):
         ndk_dir = self.ctx.ndk_platform
         ndk_lib_dir = os.path.join(ndk_dir, 'usr', 'lib')
         env['LDFLAGS'] += ' -L{}'.format(ndk_lib_dir)
-        env['LDFLAGS'] += " --sysroot={}".format(self.ctx.ndk_platform)
         env['PYTHONPATH'] = ':'.join([
             self.ctx.get_site_packages_dir(),
             env['BUILDLIB_PATH'],

--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -14,7 +14,6 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
         env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
         env['LDFLAGS'] += " -shared -llog"
         env['LDFLAGS'] += ' -L{}'.format(join(self.ctx.ndk_platform, 'usr', 'lib'))
-        env['LDFLAGS'] += " --sysroot={}".format(self.ctx.ndk_platform)
         env['LIBS'] = env.get('LIBS', '') + ' -landroid'
         return env
 


### PR DESCRIPTION
Because `--sysroot` flag is not needed anymore and make it fails the build since we migrated to new android's build system (implemented in NDK r19)

BTW, I succesfully build for `armeabi-v7a` and `arm64-v8a` (python3 both tests) and our `CI` test for `rebuild_updated_recipes` seems happy.

See also:
  - @AndreMiras's [comment at android'd NDK r19+ migration PR](https://github.com/kivy/python-for-android/pull/1722#issuecomment-524564468) which discovered the `cffi`'s error, **thanks** :smile:!!
  - https://developer.android.com/ndk/guides/other_build_systems