### PR TITLE
Added missing recommendations command and cleaned up code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,20 @@ jobs:
     - &linting
       stage: lint
       language: python
-      python: 3.7
+      python: 3.8
       before_script:
         # We need to escape virtualenv for `test_pythonpackage_basic.test_virtualenv`
         #   See also: https://github.com/travis-ci/travis-ci/issues/8589
         - type -t deactivate && deactivate || true
-        - export PATH=/opt/python/3.7/bin:$PATH
+        - export PATH=/opt/python/3.8/bin:$PATH
         # Install tox & virtualenv
         #   Note: venv/virtualenv are both used by tests/test_pythonpackage.py
-        - pip3.7 install -U virtualenv
-        - pip3.7 install tox>=2.0
+        - pip3.8 install -U virtualenv
+        - pip3.8 install tox>=2.0
         # Install coveralls & dependencies
         #   Note: pyOpenSSL needed to send the coveralls reports
-        - pip3.7 install pyOpenSSL
-        - pip3.7 install coveralls
+        - pip3.8 install pyOpenSSL
+        - pip3.8 install coveralls
       script:
         # we want to fail fast on tox errors without having to `docker build` first
         - tox -- tests/ --ignore tests/test_pythonpackage.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,20 @@ jobs:
     - &linting
       stage: lint
       language: python
-      python: 3.8
+      python: 3.7
       before_script:
         # We need to escape virtualenv for `test_pythonpackage_basic.test_virtualenv`
         #   See also: https://github.com/travis-ci/travis-ci/issues/8589
         - type -t deactivate && deactivate || true
-        - export PATH=/opt/python/3.8/bin:$PATH
+        - export PATH=/opt/python/3.7/bin:$PATH
         # Install tox & virtualenv
         #   Note: venv/virtualenv are both used by tests/test_pythonpackage.py
-        - pip3.8 install -U virtualenv
-        - pip3.8 install tox>=2.0
+        - pip3.7 install -U virtualenv
+        - pip3.7 install tox>=2.0
         # Install coveralls & dependencies
         #   Note: pyOpenSSL needed to send the coveralls reports
-        - pip3.8 install pyOpenSSL
-        - pip3.8 install coveralls
+        - pip3.7 install pyOpenSSL
+        - pip3.7 install coveralls
       script:
         # we want to fail fast on tox errors without having to `docker build` first
         - tox -- tests/ --ignore tests/test_pythonpackage.py

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -226,9 +226,9 @@ def print_recommendations():
     """
     Print the main recommended dependency versions as simple key-value pairs.
     """
-    print(f'Min supported NDK version: {MIN_NDK_VERSION}')
-    print(f'Recommended NDK version: {RECOMMENDED_NDK_VERSION}')
-    print(f'Min target API: {MIN_TARGET_API}')
-    print(f'Recommended target API: {RECOMMENDED_TARGET_API}')
-    print(f'Min NDK API: {MIN_NDK_API}')
-    print(f'Recommended NDK API: {RECOMMENDED_NDK_API}')
+    print('Min supported NDK version: {}'.format(MIN_NDK_VERSION))
+    print('Recommended NDK version: {}'.format(RECOMMENDED_NDK_VERSION))
+    print('Min target API: {}'.format(MIN_TARGET_API))
+    print('Recommended target API: {}'.format(RECOMMENDED_TARGET_API))
+    print('Min NDK API: {}'.format(MIN_NDK_API))
+    print('Recommended NDK API: {}'.format(RECOMMENDED_NDK_API))

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -189,7 +189,7 @@ def check_ndk_api(ndk_api, android_api):
 
 
 MIN_PYTHON_MAJOR_VERSION = 3
-MIN_PYTHON_MINOR_VERSION = 4
+MIN_PYTHON_MINOR_VERSION = 6
 MIN_PYTHON_VERSION = LooseVersion('{major}.{minor}'.format(major=MIN_PYTHON_MAJOR_VERSION,
                                                            minor=MIN_PYTHON_MINOR_VERSION))
 PY2_ERROR_TEXT = (

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -221,6 +221,7 @@ def check_python_version():
 
         raise BuildInterruptingException(PY_VERSION_ERROR_TEXT)
 
+
 def print_recommendations():
     """
     Print the main recommended dependency versions as simple key-value pairs.

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -11,37 +11,39 @@ from pythonforandroid.util import BuildInterruptingException
 MIN_NDK_VERSION = 19
 MAX_NDK_VERSION = 20
 
+# DO NOT CHANGE LINE FORMAT: buildozer parses the existence of a RECOMMENDED_NDK_VERSION
 RECOMMENDED_NDK_VERSION = "19b"
+
 NDK_DOWNLOAD_URL = "https://developer.android.com/ndk/downloads/"
 
 # Important log messages
 NEW_NDK_MESSAGE = 'Newer NDKs may not be fully supported by p4a.'
 UNKNOWN_NDK_MESSAGE = (
-    'Could not determine NDK version, no source.properties in the NDK dir'
+    'Could not determine NDK version, no source.properties in the NDK dir.'
 )
 PARSE_ERROR_NDK_MESSAGE = (
-    'Could not parse $NDK_DIR/source.properties, not checking NDK version'
+    'Could not parse $NDK_DIR/source.properties, not checking NDK version.'
 )
 READ_ERROR_NDK_MESSAGE = (
-    'Unable to read the NDK version from the given directory {ndk_dir}'
+    'Unable to read the NDK version from the given directory {ndk_dir}.'
 )
 ENSURE_RIGHT_NDK_MESSAGE = (
     'Make sure your NDK version is greater than {min_supported}. If you get '
-    'build errors, download the recommended NDK {rec_version} from {ndk_url}'
+    'build errors, download the recommended NDK {rec_version} from {ndk_url}.'
 )
 NDK_LOWER_THAN_SUPPORTED_MESSAGE = (
     'The minimum supported NDK version is {min_supported}. '
-    'You can download it from {ndk_url}'
+    'You can download it from {ndk_url}.'
 )
 UNSUPPORTED_NDK_API_FOR_ARMEABI_MESSAGE = (
     'Asked to build for armeabi architecture with API '
-    '{req_ndk_api}, but API {max_ndk_api} or greater does not support armeabi'
+    '{req_ndk_api}, but API {max_ndk_api} or greater does not support armeabi.'
 )
 CURRENT_NDK_VERSION_MESSAGE = (
     'Found NDK version {ndk_version}'
 )
 RECOMMENDED_NDK_VERSION_MESSAGE = (
-    'Maximum recommended NDK version is {recommended_ndk_version}'
+    'Maximum recommended NDK version is {recommended_ndk_version}, but newer versions may work.'
 )
 
 
@@ -218,3 +220,14 @@ def check_python_version():
     ):
 
         raise BuildInterruptingException(PY_VERSION_ERROR_TEXT)
+
+def print_recommendations():
+    """
+    Print the main recommended dependency versions as simple key-value pairs.
+    """
+    print(f'Min supported NDK version: {MIN_NDK_VERSION}')
+    print(f'Recommended NDK version: {RECOMMENDED_NDK_VERSION}')
+    print(f'Min target API: {MIN_TARGET_API}')
+    print(f'Recommended target API: {RECOMMENDED_TARGET_API}')
+    print(f'Min NDK API: {MIN_NDK_API}')
+    print(f'Recommended NDK API: {RECOMMENDED_NDK_API}')

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -11,7 +11,7 @@ from os import environ
 from pythonforandroid import __version__
 from pythonforandroid.pythonpackage import get_dep_names_of_package
 from pythonforandroid.recommendations import (
-    RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API)
+    RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API, print_recommendations)
 from pythonforandroid.util import BuildInterruptingException
 from pythonforandroid.entrypoints import main
 
@@ -1158,6 +1158,9 @@ class ToolchainCL(object):
         for line in output:
             sys.stdout.write(line)
             sys.stdout.flush()
+
+    def recommendations(self, args):
+        print_recommendations()
 
     def build_status(self, _args):
         """Print the status of the specified build. """

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -9,6 +9,7 @@ from pythonforandroid.recommendations import (
     check_target_api,
     read_ndk_version,
     check_python_version,
+    print_recommendations,
     MAX_NDK_VERSION,
     RECOMMENDED_NDK_VERSION,
     RECOMMENDED_TARGET_API,
@@ -237,3 +238,12 @@ class TestRecommendations(unittest.TestCase):
             fake_version_info.major = MIN_PYTHON_MAJOR_VERSION
             fake_version_info.minor = MIN_PYTHON_MINOR_VERSION
             check_python_version()
+
+    def test_print_recommendations(self):
+        """
+        Simple test that the function actually runs.
+        """
+        # The main failure mode is if the function tries to print a variable
+        # that doesn't actually exist, so simply running to check all the
+        # prints work is the most important test.
+        print_recommendations()


### PR DESCRIPTION
Added this missing command, which existed in the argument parser but wasn't actually implemented.

Not sure what format we really want, but just having the command available is probably an improvement for now.

I thought about removing the argument entirely, but it does seem useful to be able to print the p4a recommendations easily.
