### PR TITLE
Proof of concept - A bunch of tests for library recipes

### DIFF
--- a/pythonforandroid/recipes/jpeg/__init__.py
+++ b/pythonforandroid/recipes/jpeg/__init__.py
@@ -2,7 +2,6 @@ from pythonforandroid.recipe import Recipe
 from pythonforandroid.logger import shprint
 from pythonforandroid.util import current_directory
 from os.path import join
-from os import environ, uname
 import sh
 
 
@@ -35,10 +34,9 @@ class JpegRecipe(Recipe):
                     '-DCMAKE_POSITION_INDEPENDENT_CODE=1',
                     '-DCMAKE_ANDROID_ARCH_ABI={arch}'.format(arch=arch.arch),
                     '-DCMAKE_ANDROID_NDK=' + self.ctx.ndk_dir,
-                    '-DCMAKE_C_COMPILER={toolchain}/bin/clang'.format(
-                        toolchain=env['TOOLCHAIN']),
-                    '-DCMAKE_CXX_COMPILER={toolchain}/bin/clang++'.format(
-                        toolchain=env['TOOLCHAIN']),
+                    '-DCMAKE_C_COMPILER={cc}'.format(cc=arch.get_clang_exe()),
+                    '-DCMAKE_CXX_COMPILER={cc_plus}'.format(
+                        cc_plus=arch.get_clang_exe(plus_plus=True)),
                     '-DCMAKE_BUILD_TYPE=Release',
                     '-DCMAKE_INSTALL_PREFIX=./install',
                     '-DCMAKE_TOOLCHAIN_FILE=' + toolchain_file,
@@ -53,17 +51,6 @@ class JpegRecipe(Recipe):
                     '-DENABLE_STATIC=1',
                     _env=env)
             shprint(sh.make, _env=env)
-
-    def get_recipe_env(self, arch=None, with_flags_in_cc=False):
-        env = environ.copy()
-
-        build_platform = '{system}-{machine}'.format(
-            system=uname()[0], machine=uname()[-1]).lower()
-        env['TOOLCHAIN'] = join(self.ctx.ndk_dir, 'toolchains/llvm/'
-                                'prebuilt/{build_platform}'.format(
-                                    build_platform=build_platform))
-
-        return env
 
 
 recipe = JpegRecipe()

--- a/tests/recipes/recipe_ctx.py
+++ b/tests/recipes/recipe_ctx.py
@@ -1,0 +1,52 @@
+import os
+
+from pythonforandroid.bootstrap import Bootstrap
+from pythonforandroid.distribution import Distribution
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.build import Context
+from pythonforandroid.archs import ArchAarch_64
+
+
+class RecipeCtx:
+    """
+    An base class for unit testing a recipe. This will create a context so we
+    can test any recipe using this context. Implement `setUp` and `tearDown`
+    methods used by unit testing.
+    """
+
+    ctx = None
+    arch = None
+    recipe = None
+
+    recipe_name = ""
+    "The name of the recipe to test."
+
+    recipes = []
+    """A List of recipes to pass to `Distribution.get_distribution`. Should
+    contain the target recipe to test as well as a python recipe."""
+    recipe_build_order = []
+    """A recipe_build_order which should take into account the recipe we want
+    to test as well as the possible dependant recipes"""
+
+    def setUp(self):
+        self.ctx = Context()
+        self.ctx.ndk_api = 21
+        self.ctx.android_api = 27
+        self.ctx._sdk_dir = "/opt/android/android-sdk"
+        self.ctx._ndk_dir = "/opt/android/android-ndk"
+        self.ctx.setup_dirs(os.getcwd())
+        self.ctx.bootstrap = Bootstrap().get_bootstrap("sdl2", self.ctx)
+        self.ctx.bootstrap.distribution = Distribution.get_distribution(
+            self.ctx, name="sdl2", recipes=self.recipes
+        )
+        self.ctx.recipe_build_order = self.recipe_build_order
+        self.ctx.python_recipe = Recipe.get_recipe("python3", self.ctx)
+        self.arch = ArchAarch_64(self.ctx)
+        self.ctx.ndk_platform = (
+            f"{self.ctx._ndk_dir}/platforms/"
+            f"android-{self.ctx.ndk_api}/{self.arch.platform_dir}"
+        )
+        self.recipe = Recipe.get_recipe(self.recipe_name, self.ctx)
+
+    def tearDown(self):
+        self.ctx = None

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -1,0 +1,110 @@
+from unittest import mock
+from tests.recipes.recipe_ctx import RecipeCtx
+
+
+class BaseTestForMakeRecipe(RecipeCtx):
+    """
+    An unittest for testing any recipe using the standard build commands
+    (`configure/make`).
+
+    .. note:: Note that Some cmake recipe may need some more specific testing
+        ...but this should cover the basics.
+    """
+
+    recipe_name = None
+    recipes = ["python3", "kivy"]
+    recipe_build_order = ["hostpython3", "python3", "sdl2", "kivy"]
+    expected_compiler = (
+        "{android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+    )
+
+    sh_command_calls = ["./configure"]
+    """The expected commands that the recipe runs via `sh.command`."""
+
+    extra_env_flags = {}
+    """
+    This must be a dictionary containing pairs of key (env var) and value.
+    """
+
+    def __new__(cls, *args):
+        obj = super(BaseTestForMakeRecipe, cls).__new__(cls)
+        if obj.recipe_name is not None:
+            print(f"We are testing recipe: {obj.recipe_name}")
+            obj.recipes.append(obj.recipe_name)
+            obj.recipe_build_order.insert(1, obj.recipe_name)
+            return obj
+
+    @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_get_recipe_env(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_check_recipe_choices,
+    ):
+        """
+        Test that get_recipe_env contains some expected arch flags and that
+        some internal methods has been called.
+        """
+        mock_find_executable.return_value = self.expected_compiler.format(
+                android_ndk=self.ctx._ndk_dir
+        )
+        mock_glob.return_value = ["llvm"]
+        mock_check_recipe_choices.return_value = sorted(
+            self.ctx.recipe_build_order
+        )
+
+        # make sure the arch flags are in env
+        env = self.recipe.get_recipe_env(self.arch)
+        for flag in self.arch.arch_cflags:
+            self.assertIn(flag, env["CFLAGS"])
+        self.assertIn(
+            f"-target {self.arch.target}",
+            env["CFLAGS"],
+        )
+
+        for flag, value in self.extra_env_flags.items():
+            self.assertIn(value, env[flag])
+
+        # make sure that the mocked methods are actually called
+        mock_glob.assert_called()
+        mock_ensure_dir.assert_called()
+        mock_find_executable.assert_called()
+        mock_check_recipe_choices.assert_called()
+
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+    ):
+        mock_find_executable.return_value = self.expected_compiler.format(
+                android_ndk=self.ctx._ndk_dir
+        )
+        mock_glob.return_value = ["llvm"]
+        with mock.patch(
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.Command"
+        ) as mock_sh_command, mock.patch(
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.make"
+        ) as mock_make:
+            self.recipe.build_arch(self.arch)
+
+            # make sure that the mocked methods are actually called
+            mock_glob.assert_called()
+            mock_ensure_dir.assert_called()
+            mock_current_directory.assert_called()
+            mock_find_executable.assert_called()
+            for command in self.sh_command_calls:
+                self.assertIn(
+                    mock.call(command),
+                    mock_sh_command.mock_calls,
+                )
+            mock_make.assert_called()

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -108,3 +108,44 @@ class BaseTestForMakeRecipe(RecipeCtx):
                     mock_sh_command.mock_calls,
                 )
             mock_make.assert_called()
+
+
+class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
+    """
+    An unittest for testing any recipe using `cmake`. It inherits from
+    `BaseTestForMakeRecipe` but we override the build method to match the cmake
+    build method.
+
+    .. note:: Note that Some cmake recipe may need some more specific testing
+        ...but this should cover the basics.
+    """
+
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+    ):
+        mock_find_executable.return_value = self.expected_compiler.format(
+                android_ndk=self.ctx._ndk_dir
+        )
+        mock_glob.return_value = ["llvm"]
+        with mock.patch(
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.make"
+        ) as mock_make, mock.patch(
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.cmake"
+        ) as mock_cmake:
+            self.recipe.build_arch(self.arch)
+
+            # make sure that the mocked methods are actually called
+            mock_glob.assert_called()
+            mock_ensure_dir.assert_called()
+            mock_current_directory.assert_called()
+            mock_find_executable.assert_called()
+            mock_cmake.assert_called()
+            mock_make.assert_called()

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -27,7 +27,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
     """
 
     def __new__(cls, *args):
-        obj = super(BaseTestForMakeRecipe, cls).__new__(cls)
+        obj = super().__new__(cls)
         if obj.recipe_name is not None:
             print(f"We are testing recipe: {obj.recipe_name}")
             obj.recipes.append(obj.recipe_name)

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -90,6 +90,9 @@ class BaseTestForMakeRecipe(RecipeCtx):
                 android_ndk=self.ctx._ndk_dir
         )
         mock_glob.return_value = ["llvm"]
+
+        # Since the following mocks are dynamic,
+        # we mock it inside a Context Manager
         with mock.patch(
             f"pythonforandroid.recipes.{self.recipe_name}.sh.Command"
         ) as mock_sh_command, mock.patch(
@@ -97,17 +100,17 @@ class BaseTestForMakeRecipe(RecipeCtx):
         ) as mock_make:
             self.recipe.build_arch(self.arch)
 
-            # make sure that the mocked methods are actually called
-            mock_glob.assert_called()
-            mock_ensure_dir.assert_called()
-            mock_current_directory.assert_called()
-            mock_find_executable.assert_called()
-            for command in self.sh_command_calls:
-                self.assertIn(
-                    mock.call(command),
-                    mock_sh_command.mock_calls,
-                )
-            mock_make.assert_called()
+        # make sure that the mocked methods are actually called
+        for command in self.sh_command_calls:
+            self.assertIn(
+                mock.call(command),
+                mock_sh_command.mock_calls,
+            )
+        mock_make.assert_called()
+        mock_glob.assert_called()
+        mock_ensure_dir.assert_called()
+        mock_current_directory.assert_called()
+        mock_find_executable.assert_called()
 
 
 class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
@@ -135,6 +138,9 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
                 android_ndk=self.ctx._ndk_dir
         )
         mock_glob.return_value = ["llvm"]
+
+        # Since the following mocks are dynamic,
+        # we mock it inside a Context Manager
         with mock.patch(
             f"pythonforandroid.recipes.{self.recipe_name}.sh.make"
         ) as mock_make, mock.patch(
@@ -142,10 +148,10 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
         ) as mock_cmake:
             self.recipe.build_arch(self.arch)
 
-            # make sure that the mocked methods are actually called
-            mock_glob.assert_called()
-            mock_ensure_dir.assert_called()
-            mock_current_directory.assert_called()
-            mock_find_executable.assert_called()
-            mock_cmake.assert_called()
-            mock_make.assert_called()
+        # make sure that the mocked methods are actually called
+        mock_cmake.assert_called()
+        mock_make.assert_called()
+        mock_glob.assert_called()
+        mock_ensure_dir.assert_called()
+        mock_current_directory.assert_called()
+        mock_find_executable.assert_called()

--- a/tests/recipes/test_freetype.py
+++ b/tests/recipes/test_freetype.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestFreetypeRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.freetype`
+    """
+    recipe_name = "freetype"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_gevent.py
+++ b/tests/recipes/test_gevent.py
@@ -1,21 +1,11 @@
 import unittest
 from mock import patch
-from pythonforandroid.archs import ArchARMv7_a
-from pythonforandroid.build import Context
-from pythonforandroid.recipe import Recipe
+from tests.recipes.recipe_ctx import RecipeCtx
 
 
-class TestGeventRecipe(unittest.TestCase):
+class TestGeventRecipe(RecipeCtx, unittest.TestCase):
 
-    def setUp(self):
-        """
-        Setups recipe and context.
-        """
-        self.context = Context()
-        self.context.ndk_api = 21
-        self.context.android_api = 27
-        self.arch = ArchARMv7_a(self.context)
-        self.recipe = Recipe.get_recipe('gevent', self.context)
+    recipe_name = "gevent"
 
     def test_get_recipe_env(self):
         """

--- a/tests/recipes/test_harfbuzz.py
+++ b/tests/recipes/test_harfbuzz.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestHarfbuzzRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.harfbuzz`
+    """
+    recipe_name = "harfbuzz"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_jpeg.py
+++ b/tests/recipes/test_jpeg.py
@@ -1,0 +1,9 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestJpegRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.jpeg`
+    """
+    recipe_name = "jpeg"

--- a/tests/recipes/test_leveldb.py
+++ b/tests/recipes/test_leveldb.py
@@ -1,0 +1,9 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestLeveldbRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.leveldb`
+    """
+    recipe_name = "leveldb"

--- a/tests/recipes/test_libcurl.py
+++ b/tests/recipes/test_libcurl.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibcurlRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libcurl`
+    """
+    recipe_name = "libcurl"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_libexpat.py
+++ b/tests/recipes/test_libexpat.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibexpatRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libexpat`
+    """
+    recipe_name = "libexpat"
+    sh_command_calls = ["./buildconf.sh", "./configure"]

--- a/tests/recipes/test_libffi.py
+++ b/tests/recipes/test_libffi.py
@@ -1,0 +1,15 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibffiRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libffi`
+    """
+    recipe_name = "libffi"
+    sh_command_calls = ["./autogen.sh", "autoreconf", "./configure"]
+
+    def test_get_include_dirs(self):
+        list_of_includes = self.recipe.get_include_dirs(self.arch)
+        self.assertIsInstance(list_of_includes, list)
+        self.assertTrue(list_of_includes[0].endswith("include"))

--- a/tests/recipes/test_libgeos.py
+++ b/tests/recipes/test_libgeos.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestLibgeosRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libgeos`
+    """
+    recipe_name = "libgeos"
+
+    @mock.patch("pythonforandroid.util.makedirs")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_makedirs,
+    ):
+        # We overwrite the base test method because we
+        # want to avoid any file/directory creation
+        super(TestLibgeosRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_makedirs.assert_called()

--- a/tests/recipes/test_libgeos.py
+++ b/tests/recipes/test_libgeos.py
@@ -24,6 +24,6 @@ class TestLibgeosRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we
         # want to avoid any file/directory creation
-        super(TestLibgeosRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_makedirs.assert_called()

--- a/tests/recipes/test_libiconv.py
+++ b/tests/recipes/test_libiconv.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibiconvRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libiconv`
+    """
+    recipe_name = "libiconv"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_libmysqlclient.py
+++ b/tests/recipes/test_libmysqlclient.py
@@ -26,7 +26,7 @@ class TestLibmysqlclientRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we need
         # to mock a little more (`sh.cp` and `sh.rm`)
-        super(TestLibmysqlclientRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()
         mock_sh_rm.assert_called()

--- a/tests/recipes/test_libmysqlclient.py
+++ b/tests/recipes/test_libmysqlclient.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestLibmysqlclientRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libmysqlclient`
+    """
+    recipe_name = "libmysqlclient"
+
+    @mock.patch("pythonforandroid.recipes.libmysqlclient.sh.rm")
+    @mock.patch("pythonforandroid.recipes.libmysqlclient.sh.cp")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_cp,
+        mock_sh_rm,
+    ):
+        # We overwrite the base test method because we need
+        # to mock a little more (`sh.cp` and `sh.rm`)
+        super(TestLibmysqlclientRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_sh_cp.assert_called()
+        mock_sh_rm.assert_called()

--- a/tests/recipes/test_libogg.py
+++ b/tests/recipes/test_libogg.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLiboggRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libogg`
+    """
+    recipe_name = "libogg"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_libpq.py
+++ b/tests/recipes/test_libpq.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibpqRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libpq`
+    """
+    recipe_name = "libpq"
+    sh_command_calls = ["./configure"]
+
+    @mock.patch("pythonforandroid.recipes.libpq.sh.cp")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_cp,
+    ):
+        # We overwrite the base test method because we need to mock a little
+        # more with this recipe (`sh.cp`)
+        super(TestLibpqRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_sh_cp.assert_called()

--- a/tests/recipes/test_libpq.py
+++ b/tests/recipes/test_libpq.py
@@ -25,6 +25,6 @@ class TestLibpqRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we need to mock a little
         # more with this recipe (`sh.cp`)
-        super(TestLibpqRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()

--- a/tests/recipes/test_libsecp256k1.py
+++ b/tests/recipes/test_libsecp256k1.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibsecp256k1Recipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libsecp256k1`
+    """
+    recipe_name = "libsecp256k1"
+    sh_command_calls = ["./autogen.sh", "./configure"]

--- a/tests/recipes/test_libshine.py
+++ b/tests/recipes/test_libshine.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibshineRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libshine`
+    """
+    recipe_name = "libshine"
+    sh_command_calls = ["./bootstrap", "./configure"]

--- a/tests/recipes/test_libvorbis.py
+++ b/tests/recipes/test_libvorbis.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibvorbisRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libvorbis`
+    """
+    recipe_name = "libvorbis"
+    sh_command_calls = ["./configure"]
+    extra_env_flags = {'CFLAGS': 'libogg/include'}
+
+    @mock.patch("pythonforandroid.recipes.libvorbis.sh.cp")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_cp,
+    ):
+        # We overwrite the base test method because we need to mock a little
+        # more with this recipe (`sh.cp`)
+        super(TestLibvorbisRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_sh_cp.assert_called()

--- a/tests/recipes/test_libvorbis.py
+++ b/tests/recipes/test_libvorbis.py
@@ -26,6 +26,6 @@ class TestLibvorbisRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we need to mock a little
         # more with this recipe (`sh.cp`)
-        super(TestLibvorbisRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()

--- a/tests/recipes/test_libx264.py
+++ b/tests/recipes/test_libx264.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibx264Recipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libx264`
+    """
+    recipe_name = "libx264"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_libxml2.py
+++ b/tests/recipes/test_libxml2.py
@@ -1,0 +1,14 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibxml2Recipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libxml2`
+    """
+    recipe_name = "libxml2"
+    sh_command_calls = ["./autogen.sh", "autoreconf", "./configure"]
+    extra_env_flags = {
+        "CONFIG_SHELL": "/bin/bash",
+        "SHELL": "/bin/bash",
+    }

--- a/tests/recipes/test_libxslt.py
+++ b/tests/recipes/test_libxslt.py
@@ -1,0 +1,15 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibxsltRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.libxslt`
+    """
+    recipe_name = "libxslt"
+    sh_command_calls = ["./autogen.sh", "autoreconf", "./configure"]
+    extra_env_flags = {
+        "CONFIG_SHELL": "/bin/bash",
+        "SHELL": "/bin/bash",
+        "LIBS": "-lxml2 -lz -lm",
+    }

--- a/tests/recipes/test_openal.py
+++ b/tests/recipes/test_openal.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.openal`
+    """
+    recipe_name = "openal"
+
+    @mock.patch("pythonforandroid.recipes.openal.sh.cmake")
+    @mock.patch("pythonforandroid.recipes.openal.sh.make")
+    @mock.patch("pythonforandroid.recipes.openal.sh.cp")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_prebuild_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_cp,
+        mock_sh_make,
+        mock_sh_cmake,
+    ):
+        mock_find_executable.return_value = (
+            "/opt/android/android-ndk/toolchains/"
+            "llvm/prebuilt/linux-x86_64/bin/clang"
+        )
+        mock_glob.return_value = ["llvm"]
+        self.recipe.build_arch(self.arch)
+
+        # make sure that the mocked methods are actually called
+        mock_glob.assert_called()
+        mock_ensure_dir.assert_called()
+        mock_current_directory.assert_called()
+        mock_find_executable.assert_called()
+        mock_sh_cp.assert_called()
+        mock_sh_make.assert_called()
+        mock_sh_cmake.assert_called()
+
+    @mock.patch("pythonforandroid.recipes.openal.sh.cp")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_cp,
+    ):
+        # We overwrite the base test method because we need to mock a little
+        # more with this recipe (`sh.cp` and `sh.rm`)
+        super(TestOpenalRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_sh_cp.assert_called()

--- a/tests/recipes/test_openal.py
+++ b/tests/recipes/test_openal.py
@@ -57,6 +57,6 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we need to mock a little
         # more with this recipe (`sh.cp` and `sh.rm`)
-        super(TestOpenalRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()

--- a/tests/recipes/test_openssl.py
+++ b/tests/recipes/test_openssl.py
@@ -26,7 +26,7 @@ class TestOpensslRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     ):
         # We overwrite the base test method because we need to mock a little
         # more with this recipe (`sh.cp` and `sh.rm`)
-        super(TestOpensslRecipe, self).test_build_arch()
+        super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_patch.assert_called()
 

--- a/tests/recipes/test_openssl.py
+++ b/tests/recipes/test_openssl.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest import mock
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestOpensslRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.openssl`
+    """
+
+    recipe_name = "openssl"
+    sh_command_calls = ["perl"]
+
+    @mock.patch("pythonforandroid.recipes.openssl.sh.patch")
+    @mock.patch("pythonforandroid.util.chdir")
+    @mock.patch("pythonforandroid.build.ensure_dir")
+    @mock.patch("pythonforandroid.archs.glob")
+    @mock.patch("pythonforandroid.archs.find_executable")
+    def test_build_arch(
+        self,
+        mock_find_executable,
+        mock_glob,
+        mock_ensure_dir,
+        mock_current_directory,
+        mock_sh_patch,
+    ):
+        # We overwrite the base test method because we need to mock a little
+        # more with this recipe (`sh.cp` and `sh.rm`)
+        super(TestOpensslRecipe, self).test_build_arch()
+        # make sure that the mocked methods are actually called
+        mock_sh_patch.assert_called()
+
+    def test_versioned_url(self):
+        self.assertEqual(
+            self.recipe.url.format(url_version=self.recipe.url_version),
+            self.recipe.versioned_url,
+        )
+
+    def test_include_flags(self):
+        inc = self.recipe.include_flags(self.arch)
+        build_dir = self.recipe.get_build_dir(self.arch)
+        for i in {"include/internal", "include/openssl"}:
+            self.assertIn(f"-I{build_dir}/{i}", inc)
+
+    def test_link_flags(self):
+        build_dir = self.recipe.get_build_dir(self.arch)
+        openssl_version = self.recipe.version
+        self.assertEqual(
+            f" -L{build_dir} -lcrypto{openssl_version} -lssl{openssl_version}",
+            self.recipe.link_flags(self.arch),
+        )
+
+    def test_select_build_arch(self):
+        expected_build_archs = {
+            "armeabi": "android",
+            "armeabi-v7a": "android-arm",
+            "arm64-v8a": "android-arm64",
+            "x86": "android-x86",
+            "x86_64": "android-x86_64",
+        }
+        for arch in self.ctx.archs:
+            self.assertEqual(
+                expected_build_archs[arch.arch],
+                self.recipe.select_build_arch(arch),
+            )

--- a/tests/recipes/test_png.py
+++ b/tests/recipes/test_png.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestPngRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.png`
+    """
+    recipe_name = "png"
+    sh_command_calls = ["./configure"]

--- a/tests/recipes/test_reportlab.py
+++ b/tests/recipes/test_reportlab.py
@@ -12,7 +12,7 @@ class TestReportLabRecipe(RecipeCtx, unittest.TestCase):
         """
         Setups recipe and context.
         """
-        super(TestReportLabRecipe, self).setUp()
+        super().setUp()
         self.recipe_dir = self.recipe.get_build_dir(self.arch.arch)
         ensure_dir(self.recipe_dir)
 

--- a/tests/recipes/test_reportlab.py
+++ b/tests/recipes/test_reportlab.py
@@ -1,34 +1,18 @@
 import os
-import tempfile
 import unittest
 from mock import patch
-from pythonforandroid.archs import ArchARMv7_a
-from pythonforandroid.build import Context
-from pythonforandroid.graph import get_recipe_order_and_bootstrap
-from pythonforandroid.recipe import Recipe
+from tests.recipes.recipe_ctx import RecipeCtx
 from pythonforandroid.util import ensure_dir
 
 
-class TestReportLabRecipe(unittest.TestCase):
+class TestReportLabRecipe(RecipeCtx, unittest.TestCase):
+    recipe_name = "reportlab"
 
     def setUp(self):
         """
         Setups recipe and context.
         """
-        self.context = Context()
-        self.context.ndk_api = 21
-        self.context.android_api = 27
-        self.arch = ArchARMv7_a(self.context)
-        self.recipe = Recipe.get_recipe('reportlab', self.context)
-        self.recipe.ctx = self.context
-        self.bootstrap = None
-        recipe_build_order, python_modules, bootstrap = \
-            get_recipe_order_and_bootstrap(
-                self.context, [self.recipe.name], self.bootstrap)
-        self.context.recipe_build_order = recipe_build_order
-        self.context.python_modules = python_modules
-        self.context.setup_dirs(tempfile.gettempdir())
-        self.bootstrap = bootstrap
+        super(TestReportLabRecipe, self).setUp()
         self.recipe_dir = self.recipe.get_build_dir(self.arch.arch)
         ensure_dir(self.recipe_dir)
 

--- a/tests/recipes/test_snappy.py
+++ b/tests/recipes/test_snappy.py
@@ -1,0 +1,9 @@
+import unittest
+from tests.recipes.recipe_lib_test import BaseTestForCmakeRecipe
+
+
+class TestSnappyRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.snappy`
+    """
+    recipe_name = "snappy"


### PR DESCRIPTION
The main idea is to test as many recipes as we can with the less code possible and without creating any file/directory so our tests can be performed as fast as possible (all this tests will only add between 2 and 3 seconds to our CI tests and will cover almost 100% of the code for each tested recipe)

To do so, we create a couple of modules:
  - `tests.recipe_ctx`: allow us to create a proper `Context` to test our recipes
  - `tests.recipe_lib_test`: which holds some base classes to be used to test a recipe depending on the build method used. For starters we introduce two kind of base classes:
    + `BaseTestForMakeRecipe`: To test an standard library build (this will iinclude the recipes which requires the classical build commands`configure/make`)
    + `BaseTestForCmakeRecipe`: To test an library recipe which is compiled with `cmake`

We also refactor the existing recipes tests, so we can remove some lines in there...the ones that creates a `Context`.

**Notes:**
  - I'm aware that we could go a little further with the testing...but for starters I thing it's fine...we can do it later
  - This will cover most of the library recipes, but still we will have to cover a little more
  - I tried to create a generic tests depending on the build system, I'm sure that we could do something similar with `PythonRecipe`s, `BootstrapNDKRecipe`s...)
  - This could be split into multiple `dependant` PRs but, first let's see if the general idea is good enough ...then we will deal with the details if convenient :smile:
  -  @AndreMiras, sorry man, this time I made use of `Python Inheritance`...I just feel that is the best we can do in this case, but I'm always open to other solutions :wink: