### PR TITLE
Recipes tests enhancements

### DIFF
--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -12,8 +12,6 @@ class BaseTestForMakeRecipe(RecipeCtx):
     """
 
     recipe_name = None
-    recipes = ["python3", "kivy"]
-    recipe_build_order = ["hostpython3", "python3", "sdl2", "kivy"]
     expected_compiler = (
         "{android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
     )
@@ -28,9 +26,10 @@ class BaseTestForMakeRecipe(RecipeCtx):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.recipe_name not in self.recipes:
-            self.recipes.append(self.recipe_name)
-            self.recipe_build_order.insert(1, self.recipe_name)
+        self.recipes = ["python3", "kivy", self.recipe_name]
+        self.recipe_build_order = [
+            "hostpython3", self.recipe_name, "python3", "sdl2", "kivy"
+        ]
         print(f"We are testing recipe: {self.recipe_name}")
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -26,13 +26,12 @@ class BaseTestForMakeRecipe(RecipeCtx):
     This must be a dictionary containing pairs of key (env var) and value.
     """
 
-    def __new__(cls, *args):
-        obj = super().__new__(cls)
-        if obj.recipe_name is not None:
-            print(f"We are testing recipe: {obj.recipe_name}")
-            obj.recipes.append(obj.recipe_name)
-            obj.recipe_build_order.insert(1, obj.recipe_name)
-            return obj
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.recipe_name not in self.recipes:
+            self.recipes.append(self.recipe_name)
+            self.recipe_build_order.insert(1, self.recipe_name)
+        print(f"We are testing recipe: {self.recipe_name}")
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
     @mock.patch("pythonforandroid.build.ensure_dir")

--- a/tests/recipes/test_gevent.py
+++ b/tests/recipes/test_gevent.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from unittest.mock import patch
 from tests.recipes.recipe_ctx import RecipeCtx
 
 

--- a/tests/recipes/test_icu.py
+++ b/tests/recipes/test_icu.py
@@ -12,8 +12,6 @@ class TestIcuRecipe(RecipeCtx, unittest.TestCase):
     """
 
     recipe_name = "icu"
-    recipes = ["python3", "kivy", "icu"]
-    recipe_build_order = ["hostpython3", "icu", "python3", "sdl2", "kivy"]
 
     def test_url(self):
         self.assertTrue(self.recipe.versioned_url.startswith("http"))

--- a/tests/recipes/test_pyicu.py
+++ b/tests/recipes/test_pyicu.py
@@ -9,15 +9,6 @@ class TestPyIcuRecipe(RecipeCtx, unittest.TestCase):
     An unittest for recipe :mod:`~pythonforandroid.recipes.pyicu`
     """
     recipe_name = "pyicu"
-    recipes = ["python3", "kivy", "pyicu"]
-    recipe_build_order = [
-            "hostpython3",
-            "icu",
-            "python3",
-            "sdl2",
-            "pyicu",
-            "kivy",
-    ]
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
     @mock.patch("pythonforandroid.build.ensure_dir")

--- a/tests/recipes/test_reportlab.py
+++ b/tests/recipes/test_reportlab.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from mock import patch
+from unittest.mock import patch
 from tests.recipes.recipe_ctx import RecipeCtx
 from pythonforandroid.util import ensure_dir
 

--- a/tests/test_archs.py
+++ b/tests/test_archs.py
@@ -1,13 +1,7 @@
 import os
 import unittest
 from os import environ
-
-try:
-    from unittest import mock
-except ImportError:
-    # `Python 2` or lower than `Python 3.3` does not
-    # have the `unittest.mock` module built-in
-    import mock
+from unittest import mock
 
 from pythonforandroid.bootstrap import Bootstrap
 from pythonforandroid.distribution import Distribution

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,12 +3,7 @@ import os
 import sh
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    # `Python 2` or lower than `Python 3.3` does not
-    # have the `unittest.mock` module built-in
-    import mock
+from unittest import mock
 from pythonforandroid.bootstrap import (
     _cmp_bootstraps_by_priority, Bootstrap, expand_dependencies,
 )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,11 +1,6 @@
 import unittest
+from unittest import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    # `Python 2` or lower than `Python 3.3` does not
-    # have the `unittest.mock` module built-in
-    import mock
 from pythonforandroid.build import run_pymodules_install
 
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,13 +1,8 @@
 import os
 import json
 import unittest
+from unittest import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    # `Python 2` or lower than `Python 3.3` does not
-    # have the `unittest.mock` module built-in
-    import mock
 from pythonforandroid.bootstrap import Bootstrap
 from pythonforandroid.distribution import Distribution
 from pythonforandroid.recipe import Recipe

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -8,7 +8,7 @@ from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import BuildInterruptingException
 from itertools import product
 
-import mock
+from unittest import mock
 import pytest
 
 ctx = Context()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from pythonforandroid import logger
 
 

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -5,7 +5,6 @@ These are in a separate file because these were picked to run in travis,
 while the other additional ones aren't (for build time reasons).
 """
 
-import mock
 import os
 import pytest
 import shutil
@@ -13,6 +12,7 @@ import sys
 import subprocess
 import tempfile
 import textwrap
+from unittest import mock
 
 from pythonforandroid.pythonpackage import (
     _extract_info_from_package,

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -3,7 +3,7 @@ import pytest
 import types
 import unittest
 import warnings
-import mock
+from unittest import mock
 from backports import tempfile
 from pythonforandroid.build import Context
 from pythonforandroid.recipe import Recipe, import_recipe

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -1,7 +1,7 @@
 import io
 import sys
 import pytest
-import mock
+from unittest import mock
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import ToolchainCL
 from pythonforandroid.util import BuildInterruptingException

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,13 +1,8 @@
 import os
 import types
 import unittest
+from unittest import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    # `Python 2` or lower than `Python 3.3` does not
-    # have the `unittest.mock` module built-in
-    import mock
 from pythonforandroid import util
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ basepython = python3
 
 [testenv]
 deps =
-    mock
+    py27: mock
     pytest
     virtualenv
     py3: coveralls


### PR DESCRIPTION
This is a follow up of #1982

In here we do:
  - Move from `__new__` to `__init__` for `BaseTestForMakeRecipe` ([discussed at here](https://github.com/kivy/python-for-android/pull/1982#discussion_r324419892))
  - Convert cls attributes to instance attributes ([discussed at here](https://github.com/kivy/python-for-android/pull/1982#discussion_r324419973))
  -  Remove `mock` dependency for py3 tests (Because, as per Python 3.3+, `mock` it's a built-in-module). (Unfortunately we still will have a couple of `import mock` entries that we cannot remove until we completely remove python2 from our tests)