### PR TITLE
Made on-device unit tests app use the develop branch by default

### DIFF
--- a/testapps/on_device_unit_tests/buildozer.spec
+++ b/testapps/on_device_unit_tests/buildozer.spec
@@ -153,7 +153,7 @@ android.whitelist = unittest/*
 #android.add_activites = com.example.ExampleActivity
 
 # (str) python-for-android branch to use, defaults to master
-p4a.branch = master
+p4a.branch = develop
 
 # (str) OUYA Console category. Should be one of GAME or APP
 # If you leave this blank, OUYA support will not be enabled


### PR DESCRIPTION
Trivial change, better for development.