### PR TITLE
Fixes libiconv & libzbar configure host

### DIFF
--- a/pythonforandroid/recipes/libiconv/__init__.py
+++ b/pythonforandroid/recipes/libiconv/__init__.py
@@ -20,7 +20,7 @@ class LibIconvRecipe(Recipe):
         with current_directory(self.get_build_dir(arch.arch)):
             shprint(
                 sh.Command('./configure'),
-                '--host=' + arch.toolchain_prefix,
+                '--host=' + arch.command_prefix,
                 '--prefix=' + self.ctx.get_python_install_dir(),
                 _env=env)
             shprint(sh.make, '-j' + str(cpu_count()), _env=env)

--- a/pythonforandroid/recipes/libzbar/__init__.py
+++ b/pythonforandroid/recipes/libzbar/__init__.py
@@ -32,7 +32,7 @@ class LibZBarRecipe(Recipe):
             shprint(sh.Command('autoreconf'), '-vif', _env=env)
             shprint(
                 sh.Command('./configure'),
-                '--host=' + arch.toolchain_prefix,
+                '--host=' + arch.command_prefix,
                 '--target=' + arch.toolchain_prefix,
                 '--prefix=' + self.ctx.get_python_install_dir(),
                 # Python bindings are compiled in a separated recipe


### PR DESCRIPTION
Having `--host=x86` was making the configure script fail at enabling
shared library build on `x86`. This was resulting in failing to copy
`libiconv.so` and `libzbar.so` on `x86` arch.