### PR TITLE
Fixes ffmpeg build on ndk 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ jobs:
       script: make docker/run/make/testapps/python2/armeabi-v7a
     - <<: *testapps
       name: Rebuild updated recipes
-      script: make docker/run/make/rebuild_updated_recipes
+      script: travis_wait 20 make docker/run/make/rebuild_updated_recipes

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ jobs:
       script: make docker/run/make/testapps/python2/armeabi-v7a
     - <<: *testapps
       name: Rebuild updated recipes
-      script: travis_wait 20 make docker/run/make/rebuild_updated_recipes
+      script: travis_wait 30 make docker/run/make/rebuild_updated_recipes

--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -4,7 +4,7 @@ import sh
 
 
 class FFMpegRecipe(Recipe):
-    version = 'n3.4.5'
+    version = 'n4.3-dev'
     # Moved to github.com instead of ffmpeg.org to improve download speed
     url = 'https://github.com/FFmpeg/FFmpeg/archive/{version}.zip'
     depends = ['sdl2']  # Need this to build correct recipe order
@@ -38,7 +38,7 @@ class FFMpegRecipe(Recipe):
                     '--enable-protocol=https,tls_openssl',
                 ]
                 build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
-                cflags += ['-I' + build_dir + '/include/']
+                cflags += ['-I' + build_dir + '/include/', '-DOPENSSL_API_COMPAT=0x10002000L']
                 ldflags += ['-L' + build_dir]
 
             if 'ffpyplayer_codecs' in self.ctx.recipe_build_order:
@@ -49,10 +49,13 @@ class FFMpegRecipe(Recipe):
                 ldflags += ['-lx264', '-L' + build_dir + '/lib/']
 
                 # libshine
+
+                """
                 flags += ['--enable-libshine']
                 build_dir = Recipe.get_recipe('libshine', self.ctx).get_build_dir(arch.arch)
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lshine', '-L' + build_dir + '/lib/']
+                """
 
                 # Enable all codecs:
                 flags += [
@@ -79,17 +82,14 @@ class FFMpegRecipe(Recipe):
 
             # disable binaries / doc
             flags += [
-                '--disable-ffmpeg',
-                '--disable-ffplay',
-                '--disable-ffprobe',
-                '--disable-ffserver',
+                '--disable-programs',
                 '--disable-doc',
             ]
 
             # other flags:
             flags += [
                 '--enable-filter=aresample,resample,crop,adelay,volume,scale',
-                '--enable-protocol=file,http',
+                '--enable-protocol=file,http,hls',
                 '--enable-small',
                 '--enable-hwaccels',
                 '--enable-gpl',
@@ -105,16 +105,22 @@ class FFMpegRecipe(Recipe):
                 cross_prefix = 'arm-linux-androideabi-'
                 arch_flag = 'arm'
 
+
             # android:
             flags += [
                 '--target-os=android',
-                '--cross-prefix={}'.format(cross_prefix),
+                '--enable-cross-compile',
+                '--cross-prefix={}-'.format(arch.target),
                 '--arch={}'.format(arch_flag),
-                '--sysroot=' + self.ctx.ndk_platform,
+                '--strip={}strip'.format(cross_prefix),
+                '--sysroot={}'.format(join(self.ctx.ndk_dir, 'toolchains',
+                                        'llvm', 'prebuilt', 'linux-x86_64',
+                                        'sysroot')),
                 '--enable-neon',
                 '--prefix={}'.format(realpath('.')),
             ]
 
+            
             if arch_flag == 'arm':
                 cflags += [
                     '-mfpu=vfpv3-d16',

--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -144,4 +144,5 @@ class FFMpegRecipe(Recipe):
             sh.cp('-a', sh.glob('./lib/lib*.so'),
                   self.ctx.get_libs_dir(arch.arch))
 
+
 recipe = FFMpegRecipe()

--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -4,7 +4,7 @@ import sh
 
 
 class FFMpegRecipe(Recipe):
-    version = 'n4.3-dev'
+    version = '007e03348dbd8d3de3eb09022d72c734a8608144'
     # Moved to github.com instead of ffmpeg.org to improve download speed
     url = 'https://github.com/FFmpeg/FFmpeg/archive/{version}.zip'
     depends = ['sdl2']  # Need this to build correct recipe order
@@ -48,13 +48,16 @@ class FFMpegRecipe(Recipe):
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lx264', '-L' + build_dir + '/lib/']
 
-                # libshine
-
                 """
+                WARNING: DISABLED during migration to ndk19, cause We're
+                getting a runtime error for a missing symbol.
+
+                # libshine
                 flags += ['--enable-libshine']
                 build_dir = Recipe.get_recipe('libshine', self.ctx).get_build_dir(arch.arch)
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lshine', '-L' + build_dir + '/lib/']
+                ldflags += ['-lm']
                 """
 
                 # Enable all codecs:
@@ -95,6 +98,7 @@ class FFMpegRecipe(Recipe):
                 '--enable-gpl',
                 '--enable-pic',
                 '--disable-static',
+                '--disable-debug',
                 '--enable-shared',
             ]
 

--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -37,14 +37,17 @@ class FFMpegRecipe(Recipe):
                     '--enable-nonfree',
                     '--enable-protocol=https,tls_openssl',
                 ]
-                build_dir = Recipe.get_recipe('openssl', self.ctx).get_build_dir(arch.arch)
-                cflags += ['-I' + build_dir + '/include/', '-DOPENSSL_API_COMPAT=0x10002000L']
+                build_dir = Recipe.get_recipe(
+                    'openssl', self.ctx).get_build_dir(arch.arch)
+                cflags += ['-I' + build_dir + '/include/',
+                           '-DOPENSSL_API_COMPAT=0x10002000L']
                 ldflags += ['-L' + build_dir]
 
             if 'ffpyplayer_codecs' in self.ctx.recipe_build_order:
                 # libx264
                 flags += ['--enable-libx264']
-                build_dir = Recipe.get_recipe('libx264', self.ctx).get_build_dir(arch.arch)
+                build_dir = Recipe.get_recipe(
+                    'libx264', self.ctx).get_build_dir(arch.arch)
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lx264', '-L' + build_dir + '/lib/']
 
@@ -109,7 +112,6 @@ class FFMpegRecipe(Recipe):
                 cross_prefix = 'arm-linux-androideabi-'
                 arch_flag = 'arm'
 
-
             # android:
             flags += [
                 '--target-os=android',
@@ -118,13 +120,12 @@ class FFMpegRecipe(Recipe):
                 '--arch={}'.format(arch_flag),
                 '--strip={}strip'.format(cross_prefix),
                 '--sysroot={}'.format(join(self.ctx.ndk_dir, 'toolchains',
-                                        'llvm', 'prebuilt', 'linux-x86_64',
-                                        'sysroot')),
+                                           'llvm', 'prebuilt', 'linux-x86_64',
+                                           'sysroot')),
                 '--enable-neon',
                 '--prefix={}'.format(realpath('.')),
             ]
 
-            
             if arch_flag == 'arm':
                 cflags += [
                     '-mfpu=vfpv3-d16',
@@ -142,6 +143,5 @@ class FFMpegRecipe(Recipe):
             # copy libs:
             sh.cp('-a', sh.glob('./lib/lib*.so'),
                   self.ctx.get_libs_dir(arch.arch))
-
 
 recipe = FFMpegRecipe()

--- a/pythonforandroid/recipes/ffmpeg/patches/configure.patch
+++ b/pythonforandroid/recipes/ffmpeg/patches/configure.patch
@@ -1,40 +1,20 @@
---- ./configure.orig	2017-12-11 00:35:18.000000000 +0300
-+++ ./configure	2017-12-19 09:47:54.104914600 +0300
-@@ -4841,9 +4841,6 @@
-     add_cflags -std=c11 ||
-     check_cflags -std=c99
-
--check_cppflags -D_FILE_OFFSET_BITS=64
--check_cppflags -D_LARGEFILE_SOURCE
--
- add_host_cppflags -D_ISOC99_SOURCE
- check_host_cflags -std=c99
- check_host_cflags -Wall
-@@ -5979,7 +5976,7 @@
+--- ./configure	2019-07-21 18:36:31.000000000 +0200
++++ ./configure_new	2019-10-04 12:43:41.798448200 +0200
+@@ -6222,7 +6222,7 @@
  enabled librsvg           && require_pkg_config librsvg librsvg-2.0 librsvg-2.0/librsvg/rsvg.h rsvg_handle_render_cairo
  enabled librtmp           && require_pkg_config librtmp librtmp librtmp/rtmp.h RTMP_Socket
- enabled librubberband     && require_pkg_config librubberband "rubberband >= 1.8.1" rubberband/rubberband-c.h rubberband_new
+ enabled librubberband     && require_pkg_config librubberband "rubberband >= 1.8.1" rubberband/rubberband-c.h rubberband_new -lstdc++ && append librubberband_extralibs "-lstdc++"
 -enabled libshine          && require_pkg_config libshine shine shine/layer3.h shine_encode_buffer
-+enabled libshine          && require "shine" shine/layer3.h shine_encode_buffer -lshine
- enabled libsmbclient      && { use_pkg_config libsmbclient smbclient libsmbclient.h smbc_init ||
-                                require smbclient libsmbclient.h smbc_init -lsmbclient; }
- enabled libsnappy         && require libsnappy snappy-c.h snappy_compress -lsnappy
-
-diff -Naur ffmpeg/configure ffmpeg-1/configure
---- ffmpeg/configure	2019-01-11 09:30:02.824961600 +0100
-+++ ffmpeg-1/configure	2019-01-11 09:29:54.976149600 +0100
-@@ -6068,11 +6068,11 @@
-                                { ! enabled cross_compile && add_cflags -isystem/opt/vc/include/IL && check_header OMX_Core.h ; } ||
-                                die "ERROR: OpenMAX IL headers not found"; }
- enabled omx               && require_header OMX_Core.h
--enabled openssl           && { use_pkg_config openssl openssl openssl/ssl.h OPENSSL_init_ssl ||
-+enabled openssl           && { use_pkg_config openssl openssl openssl/ssl.h OPENSSL_init_ssl ||
-                                use_pkg_config openssl openssl openssl/ssl.h SSL_library_init ||
--                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto ||
--                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl32 -leay32 ||
--                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto -lws2_32 -lgdi32 ||
-+                               check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
-+                               check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
-+                               check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
++enabled libshine          && require "shine" shine/layer3.h shine_encode_buffer -lshine -lm
+ enabled libsmbclient      && { check_pkg_config libsmbclient smbclient libsmbclient.h smbc_init ||
+                                require libsmbclient libsmbclient.h smbc_init -lsmbclient; }
+ enabled libsnappy         && require libsnappy snappy-c.h snappy_compress -lsnappy -lstdc++
+@@ -6322,7 +6322,7 @@
+                                die "ERROR: OpenMAX IL headers not found"; } && enable omx
+ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OPENSSL_init_ssl ||
+                                check_pkg_config openssl openssl openssl/ssl.h SSL_library_init ||
+-                               check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
++                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
                                 die "ERROR: openssl not found"; }
- enabled rkmpp             && { { require_pkg_config rockchip_mpp rockchip_mpp rockchip/rk_mpi.h mpp_create ||

--- a/pythonforandroid/recipes/ffpyplayer_codecs/__init__.py
+++ b/pythonforandroid/recipes/ffpyplayer_codecs/__init__.py
@@ -2,7 +2,8 @@ from pythonforandroid.toolchain import Recipe
 
 
 class FFPyPlayerCodecsRecipe(Recipe):
-    depends = ['libshine', 'libx264']
+    depends = ['libx264']
+    # disabled libshine due a missing symbol error (see ffmpeg recipe)
 
     def build_arch(self, arch):
         pass


### PR DESCRIPTION
Targets issue #1996 .

- [x] ffmpeg builds
- [x] ffmpeg builds w/ openssl
- [x] ffmpeg builds w/ libx264
- [x] ffmpeg builds w/ libshine
- [x] disabled `libshine` due to the missing symbol error and added a comment for it

Known issues:
- if `libshine` is enabled `libavcodec` is throwing an exception during runtime: `ffpyplayer - ImportError: dlopen failed: cannot locate symbol "shine_set_config_mpeg_defaults" referenced by "/data/app/myapp==/lib/arm/libavcodec.so"..` ( disabled `libshine` as a workaround)

Tested over a `https/hls` stream on both `arm64-v8a` and `armeabi-v7a` .