### PR TITLE
Fix libcurl with openssl

### DIFF
--- a/pythonforandroid/recipes/libcurl/__init__.py
+++ b/pythonforandroid/recipes/libcurl/__init__.py
@@ -15,8 +15,11 @@ class LibcurlRecipe(Recipe):
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 
-        r = self.get_recipe('openssl', self.ctx)
-        openssl_dir = r.get_build_dir(arch.arch)
+        openssl_recipe = self.get_recipe('openssl', self.ctx)
+        openssl_dir = openssl_recipe.get_build_dir(arch.arch)
+
+        env['LDFLAGS'] += openssl_recipe.link_dirs_flags(arch)
+        env['LIBS'] = env.get('LIBS', '') + openssl_recipe.link_libs_flags()
 
         with current_directory(self.get_build_dir(arch.arch)):
             dst_dir = join(self.get_build_dir(arch.arch), 'dist')


### PR DESCRIPTION
Currently (dunno from when, it was working when i added the recipe), the libcurl doesn't use ssl despite the `--with-ssl` option given, because it is not being able to link with libcrypto.

By adding the flags / libs to the environ like others recipes, everything works again.