### PR TITLE
Fix error on py2  when `import numpy`

### DIFF
--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -18,14 +18,19 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
 
     call_hostpython_via_targetpython = False
 
+    def apply_patches(self, arch, build_dir=None):
+        if 'python2' in self.ctx.recipe_build_order:
+            self.patches.append(join('patches', 'fix-py2-numpy-import.patch'))
+        super().apply_patches(arch, build_dir=build_dir)
+
     def build_compiled_components(self, arch):
         self.setup_extra_args = ['-j', str(cpu_count())]
-        super(NumpyRecipe, self).build_compiled_components(arch)
+        super().build_compiled_components(arch)
         self.setup_extra_args = []
 
     def rebuild_compiled_components(self, arch, env):
         self.setup_extra_args = ['-j', str(cpu_count())]
-        super(NumpyRecipe, self).rebuild_compiled_components(arch, env)
+        super().rebuild_compiled_components(arch, env)
         self.setup_extra_args = []
 
 

--- a/pythonforandroid/recipes/numpy/patches/fix-py2-numpy-import.patch
+++ b/pythonforandroid/recipes/numpy/patches/fix-py2-numpy-import.patch
@@ -1,0 +1,15 @@
+There is an open issue at numpy talking about the import error with numpy:
+    https://github.com/numpy/numpy/issues/13248
+The solution applied here is mentioned there and it seems to only affect our
+python2 version.
+--- numpy-1.16.4/numpy/core/overrides.py.orig	2019-05-27 12:41:06.000000000 +0200
++++ numpy-1.16.4/numpy/core/overrides.py	2019-10-13 18:51:06.387037239 +0200
+@@ -140,6 +140,8 @@ def array_function_dispatch(dispatcher,
+     -------
+     Function suitable for decorating the implementation of a NumPy function.
+     """
++    if dispatcher.__doc__ is None:
++        dispatcher.__doc__ = ""
+ 
+     if not ENABLE_ARRAY_FUNCTION:
+         # __array_function__ requires an explicit opt-in for now


### PR DESCRIPTION
Also:
  - make use of python3 `super()` for numpy recipe

Closes: #1988