### PR TITLE
twisted: updated to 19.7.0 + removed inceremental.path

### DIFF
--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import CythonRecipe
 
 
 class TwistedRecipe(CythonRecipe):
-    version = '17.9.0'
+    version = '19.7.0'
     url = 'https://github.com/twisted/twisted/archive/twisted-{version}.tar.gz'
 
     depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']

--- a/pythonforandroid/recipes/twisted/incremental.patch
+++ b/pythonforandroid/recipes/twisted/incremental.patch
@@ -1,13 +1,15 @@
-diff -Naur twisted-twisted-17.9.0/src/twisted/python/_setup.py twisted-twisted-17.9.0_patched/src/twisted/python/_setup.py
---- twisted-twisted-17.9.0/src/twisted/python/_setup.py	2017-09-23 07:56:08.000000000 +0200
-+++ twisted-twisted-17.9.0_patched/src/twisted/python/_setup.py	2018-10-05 11:06:23.305860722 +0200
-@@ -227,14 +227,11 @@
-         requirements = ["zope.interface >= 3.6.0"]
- 
-     requirements.append("constantly >= 15.1")
--    requirements.append("incremental >= 16.10.1")
-     requirements.append("Automat >= 0.3.0")
-     requirements.append("hyperlink >= 17.1.1")
+diff -Naur twisted-twisted-19.7.0/src/twisted/python/_setup.py twisted-twisted-19.7.0_patched/src/twisted/python/_setup.py
+--- twisted-twisted-19.7.0/src/twisted/python/_setup.py	2019-07-28 11:17:29.000000000 +0200
++++ twisted-twisted-19.7.0_patched/src/twisted/python/_setup.py	2019-10-21 22:10:03.643068863 +0200
+@@ -282,7 +282,6 @@
+     requirements = [
+         "zope.interface >= 4.4.2",
+         "constantly >= 15.1",
+-        "incremental >= 16.10.1",
+         "Automat >= 0.3.0",
+         "hyperlink >= 17.1.1",
+         "PyHamcrest >= 1.9.0",
+@@ -291,8 +290,6 @@
  
      arguments.update(dict(
          packages=find_packages("src"),


### PR DESCRIPTION
Last version is building fine with p4a. Also incremental.patch doesn't
seem needed anymore (using Python 3), I could build without it.