### PR TITLE
make the virtual keyboard accept various languages

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2002,7 +2002,7 @@ class DummyEdit extends View implements View.OnKeyListener {
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         ic = new SDLInputConnection(this, true);
 
-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+        outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
 


### PR DESCRIPTION
Currently, Japanese (and Chinese) keyboard doesn't show up on Android 9. (I don't know about other versions, but at least it *does* show up on  Android 5.0.3). This PR fix it.

Please take a look at [this discussion](https://bugzilla.libsdl.org/show_bug.cgi?id=4775).