### PR TITLE
update pyproj recipe

### DIFF
--- a/pythonforandroid/recipes/pyproj/__init__.py
+++ b/pythonforandroid/recipes/pyproj/__init__.py
@@ -2,8 +2,8 @@ from pythonforandroid.recipe import CythonRecipe
 
 
 class PyProjRecipe(CythonRecipe):
-    version = '1.9.5.1'
-    url = 'https://github.com/jswhit/pyproj/archive/master.zip'
+    version = '1.9.6'
+    url = 'https://github.com/pyproj4/pyproj/archive/v{version}rel.zip'
     depends = ['setuptools']
     call_hostpython_via_targetpython = False
 


### PR DESCRIPTION
bumps pyproj version to 1.9.6 and fixes the source url. Previously the url pointed to the latest pyproj version, which 

1. did not match the recipe version and 
2. seems not to be compatible with `hostpython3`