### PR TITLE
Exposes ANDROID_SDK_HOME to rebuild_updated_recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:
 	@if test -n "$$CI"; then .tox/py$(PYTHON_MAJOR_MINOR)/bin/coveralls; fi; \
 
 rebuild_updated_recipes: virtualenv
+	ANDROID_SDK_HOME=$(ANDROID_SDK_HOME) ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
 	$(PYTHON) ci/rebuild_updated_recipes.py
 
 testapps/python2/armeabi-v7a: virtualenv


### PR DESCRIPTION
The error was:
```
Traceback (most recent call last):
  File "ci/rebuild_updated_recipes.py", line 112, in <module>
    main()
  File "ci/rebuild_updated_recipes.py", line 108, in main
    build(target_python, recipes)
  File "ci/rebuild_updated_recipes.py", line 59, in build
    android_sdk_home = os.environ['ANDROID_SDK_HOME']
  File "/home/user/app/venv/lib/python3.6/os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'ANDROID_SDK_HOME'
```
https://travis-ci.org/kivy/python-for-android/jobs/609719811