### PR TITLE
Introduce github-actions (push & pull_requests)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,6 +44,8 @@ jobs:
     - name: Send Coverage to coveralls
       run: |
         coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   build:
     name: Build testapp

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Unit tests & Build Testapp
 
 on: ['push', 'pull_request']
 
@@ -49,3 +49,17 @@ jobs:
         python -m coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+  build:
+    name: Build testapp
+    needs: [flake8]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout python-for-android
+      uses: actions/checkout@master
+    - name: Pull docker image
+      run: |
+        make docker/pull
+    - name: Build apk for Python 3 arm64-v8a
+      run: |
+        make docker/run/make/testapps/python3/arm64-v8a

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,3 +54,17 @@ jobs:
     - name: Build apk for Python 3 arm64-v8a
       run: |
         make docker/run/make/testapps/python3/arm64-v8a
+
+  rebuild_updated_recipes:
+    name: Test updated recipes
+    needs: [flake8]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout python-for-android
+      uses: actions/checkout@master
+    - name: Pull docker image
+      run: |
+        make docker/pull
+    - name: Rebuild updated recipes
+      run: |
+        make docker/run/make/rebuild_updated_recipes

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,11 +15,10 @@ jobs:
       with:
         python-version: 3.7
     - name: Run flake8
-      # we use exactly the same exceptions than tox.ini file
       run: |
         python -m pip install --upgrade pip
-        pip install -U flake8
-        flake8 --ignore=E123,E124,E126,E226,E402,E501,W503,W504 pythonforandroid/ tests/ ci/
+        pip install tox>=2.0
+        tox -e pep8
 
   linting:
     name: Pytest [Python ${{ matrix.python-version }} | ${{ matrix.os }}]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,19 +35,15 @@ jobs:
       uses: actions/setup-python@v1.1.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Tox Python 3
+      # ignores test_pythonpackage.py since it runs for too long
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv pytest pytest-cov backports.tempfile pyOpenSSL coveralls
-        pip install -e .
-    - name: Tests
+        pip install tox>=2.0 pyOpenSSL coveralls
+        tox -e py3 -- tests/ --ignore tests/test_pythonpackage.py
+    - name: Send Coverage to coveralls
       run: |
-        python -m pytest tests/ --ignore tests/test_pythonpackage.py --cov pythonforandroid/ --cov-branch
-    - name: Coveralls
-      run: |
-        python -m coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        coveralls
 
   build:
     name: Build testapp

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
         pip install tox>=2.0
         tox -e pep8
 
-  linting:
+  test:
     name: Pytest [Python ${{ matrix.python-version }} | ${{ matrix.os }}]
     needs: flake8
     runs-on: ${{ matrix.os }}
@@ -35,17 +35,11 @@ jobs:
       uses: actions/setup-python@v1.1.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Tox Python 3
-      # ignores test_pythonpackage.py since it runs for too long
+    - name: Tox tests
       run: |
         python -m pip install --upgrade pip
-        pip install tox>=2.0 pyOpenSSL coveralls
-        tox -e py3 -- tests/ --ignore tests/test_pythonpackage.py
-    - name: Send Coverage to coveralls
-      run: |
-        coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        pip install tox>=2.0
+        make test
 
   build:
     name: Build testapp

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,51 @@
+name: Unit tests
+
+on: ['push', 'pull_request']
+
+jobs:
+
+  flake8:
+    name: Flake8 tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout python-for-android
+      uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1.1.0
+      with:
+        python-version: 3.7
+    - name: Run flake8
+      # we use exactly the same exceptions than tox.ini file
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U flake8
+        flake8 --ignore=E123,E124,E126,E226,E402,E501,W503,W504 pythonforandroid/ tests/ ci/
+
+  linting:
+    name: Pytest [Python ${{ matrix.python-version }} | ${{ matrix.os }}]
+    needs: flake8
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+        os: [ubuntu-latest, macOs-latest]
+    steps:
+    - name: Checkout python-for-android
+      uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1.1.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U virtualenv pytest pytest-cov backports.tempfile pyOpenSSL coveralls
+        pip install -e .
+    - name: Tests
+      run: |
+        python -m pytest tests/ --ignore tests/test_pythonpackage.py --cov pythonforandroid/ --cov-branch
+    - name: Coveralls
+      run: |
+        python -m coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -75,11 +75,7 @@ class LibtorrentRecipe(Recipe):
         # Define build variables
         build_dir = self.get_build_dir(arch.arch)
         ctx_libs_dir = self.ctx.get_libs_dir(arch.arch)
-        encryption = (
-            'openssl'
-            if 'openssl' in recipe.ctx.recipe_build_order
-            else 'built-in'
-        )
+        encryption = 'openssl' if 'openssl' in recipe.ctx.recipe_build_order else 'built-in'
         build_args = [
             '-q',
             # '-a',  # force build, useful to debug the build

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -75,7 +75,11 @@ class LibtorrentRecipe(Recipe):
         # Define build variables
         build_dir = self.get_build_dir(arch.arch)
         ctx_libs_dir = self.ctx.get_libs_dir(arch.arch)
-        encryption = 'openssl' if 'openssl' in recipe.ctx.recipe_build_order else 'built-in'
+        encryption = (
+            'openssl'
+            if 'openssl' in recipe.ctx.recipe_build_order
+            else 'built-in'
+        )
         build_args = [
             '-q',
             # '-a',  # force build, useful to debug the build

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from platform import system
 from tests.recipes.recipe_ctx import RecipeCtx
 
 
@@ -13,7 +14,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
 
     recipe_name = None
     expected_compiler = (
-        "{android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+        "{android_ndk}/toolchains/llvm/prebuilt/{system}-x86_64/bin/clang"
     )
 
     sh_command_calls = ["./configure"]
@@ -48,7 +49,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
         some internal methods has been called.
         """
         mock_find_executable.return_value = self.expected_compiler.format(
-                android_ndk=self.ctx._ndk_dir
+                android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
         mock_glob.return_value = ["llvm"]
         mock_check_recipe_choices.return_value = sorted(
@@ -85,7 +86,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
         mock_current_directory,
     ):
         mock_find_executable.return_value = self.expected_compiler.format(
-                android_ndk=self.ctx._ndk_dir
+                android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
         mock_glob.return_value = ["llvm"]
 
@@ -133,7 +134,7 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
         mock_current_directory,
     ):
         mock_find_executable.return_value = self.expected_compiler.format(
-                android_ndk=self.ctx._ndk_dir
+                android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
         mock_glob.return_value = ["llvm"]
 

--- a/tests/recipes/test_icu.py
+++ b/tests/recipes/test_icu.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from unittest import mock
+from platform import system
 
 from tests.recipes.recipe_ctx import RecipeCtx
 from pythonforandroid.recipes.icu import ICURecipe
@@ -47,7 +48,7 @@ class TestIcuRecipe(RecipeCtx, unittest.TestCase):
     ):
         mock_find_executable.return_value = os.path.join(
             self.ctx._ndk_dir,
-            "toolchains/llvm/prebuilt/linux-x86_64/bin/clang",
+            f"toolchains/llvm/prebuilt/{system().lower()}-x86_64/bin/clang",
         )
         mock_archs_glob.return_value = [
             os.path.join(self.ctx._ndk_dir, "toolchains", "llvm")

--- a/tests/test_archs.py
+++ b/tests/test_archs.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from os import environ
 from unittest import mock
+from platform import system
 
 from pythonforandroid.bootstrap import Bootstrap
 from pythonforandroid.distribution import Distribution
@@ -70,8 +71,8 @@ class ArchSetUpBaseClass(object):
         # Here we define the expected compiler, which, as per ndk >= r19,
         # should be the same for all the tests (no more gcc compiler)
         self.expected_compiler = (
-            "/opt/android/android-ndk/toolchains/"
-            "llvm/prebuilt/linux-x86_64/bin/clang"
+            f"/opt/android/android-ndk/toolchains/"
+            f"llvm/prebuilt/{system().lower()}-x86_64/bin/clang"
         )
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,6 +4,8 @@ import sh
 import unittest
 
 from unittest import mock
+from platform import system
+
 from pythonforandroid.bootstrap import (
     _cmp_bootstraps_by_priority, Bootstrap, expand_dependencies,
 )
@@ -546,7 +548,7 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
     ):
         mock_find_executable.return_value = os.path.join(
             self.ctx._ndk_dir,
-            "toolchains/llvm/prebuilt/linux-x86_64/bin/clang",
+            f"toolchains/llvm/prebuilt/{system().lower()}-x86_64/bin/clang",
         )
         mock_glob.return_value = [
             os.path.join(self.ctx._ndk_dir, "toolchains", "llvm")

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -308,7 +308,9 @@ class TestGetSystemPythonExecutable():
             sys_python_path = self.run__get_system_python_executable(
                 os.path.join(test_dir, "virtualenv", "bin", "python")
             )
-            assert os.path.normpath(sys_python_path) == os.path.normpath(pybin)
+            assert os.path.normpath(sys_python_path).startswith(
+                os.path.normpath(pybin)
+            )
         finally:
             shutil.rmtree(test_dir)
 
@@ -341,6 +343,8 @@ class TestGetSystemPythonExecutable():
             sys_python_path = self.run__get_system_python_executable(
                 os.path.join(test_dir, "venv", "bin", "python")
             )
-            assert os.path.normpath(sys_python_path) == os.path.normpath(pybin)
+            assert os.path.normpath(sys_python_path).startswith(
+                os.path.normpath(pybin)
+            )
         finally:
             shutil.rmtree(test_dir)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -5,6 +5,8 @@ import unittest
 import warnings
 from unittest import mock
 from backports import tempfile
+from platform import system
+
 from pythonforandroid.build import Context
 from pythonforandroid.recipe import Recipe, import_recipe
 from pythonforandroid.archs import ArchAarch_64
@@ -278,8 +280,8 @@ class TesSTLRecipe(BaseClassSetupBootstrap, unittest.TestCase):
                   should be tested in the proper test.
         """
         expected_compiler = (
-            "/opt/android/android-ndk/toolchains/"
-            "llvm/prebuilt/linux-x86_64/bin/clang"
+            f"/opt/android/android-ndk/toolchains/"
+            f"llvm/prebuilt/{system().lower()}-x86_64/bin/clang"
         )
         mock_find_executable.return_value = expected_compiler
         mock_glob.return_value = ["llvm"]

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -78,10 +78,14 @@ class TestToolchainCL:
             m_get_ndk_platform_dir.return_value = (
                 '/tmp/android-ndk/platforms/android-21/arch-arm', True)
             ToolchainCL()
-        assert m_get_available_apis.call_args_list == [
-            mock.call('/tmp/android-sdk')]
-        assert m_get_toolchain_versions.call_args_list == [
-            mock.call('/tmp/android-ndk', mock.ANY)]
+        assert m_get_available_apis.call_args_list in [
+            [mock.call('/tmp/android-sdk')],  # linux case
+            [mock.call('/private/tmp/android-sdk')]  # macos case
+        ]
+        assert m_get_toolchain_versions.call_args_list in [
+            [mock.call('/tmp/android-ndk', mock.ANY)],  # linux case
+            [mock.call('/private/tmp/android-ndk', mock.ANY)],  # macos case
+        ]
         build_order = [
             'hostpython3', 'libffi', 'openssl', 'sqlite3', 'python3',
             'genericndkbuild', 'setuptools', 'six', 'pyjnius', 'android',

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -100,6 +100,10 @@ class TestToolchainCL:
         ]
         assert m_run_distribute.call_args_list == [mock.call()]
 
+    @mock.patch(
+        'pythonforandroid.build.environ',
+        # Make sure that no environ variable modifies `sdk_dir`
+        {'ANDROIDSDK': None, 'ANDROID_HOME': None})
     def test_create_no_sdk_dir(self):
         """
         The `--sdk-dir` is mandatory to `create` a distribution.


### PR DESCRIPTION
**I just want to share some of our travis tests but for `gh-actions`:**

In here we perform the same tox tests that we do in travis but for **linux** and **MacOs** (for **python** versions **3.6** and **3.7**...so we use a matrix) plus an **flake8 test** (which will make stop all the other tests if not succeed). 

Regarding testsapp, we only perform one of the tests (Python3 for arm64-v8a in ubuntu with docker), so we make less tests than travis regarding testapps. The good thing of this is that we run the tox tests in MacOs, which make me notice that we had wrong some of our tests so we solve this in here.

**Why introduce `gh-actions`?**

Well, because it's one more asset that we can use, and this is only one small part of what can be achieved with `gh-actions`. IMHO, I think that we can benefit from `gh-actions`, I wouldn't remove travis tests at all, but I would use `gh-actions` for any operation that requires to use passwords, since it's more easy to deal than with travis. In matter fact, I already used a `github.secret` (`COVERALLS_REPO_TOKEN`, to send coveralls report), that we may need to setup for kivy (I'm not sure of this...it maybe already added to kivy organization...).

**Note:** I leave this PR in `WIP` status because:
  - we never talked about introducing  `gh-actions` for p4a...maybe the kivy/p4a team doesn't want this at all...we will see...
  -  with this we will send the coveralls report with `travis` and with `gh-actions`...probably we only want to send the reports with one of the services...so this PR may require some adjustments...
  - While doing this (some weeks ago), I felt that `gh-actions` was a little clumsy...`gh-actions` was still in beta status...now are official but it still may be a little clumsy...I suppose that it will get better with time...)

**Some references:**
  - https://github.com/features/actions
  - Github actions video presentation: https://www.youtube.com/watch?v=E1OunoCyuhY