### PR TITLE
Fix libshine and re-enable it for ffmpeg & ffpyplayer_codecs

### DIFF
--- a/pythonforandroid/recipes/ffmpeg/__init__.py
+++ b/pythonforandroid/recipes/ffmpeg/__init__.py
@@ -51,17 +51,12 @@ class FFMpegRecipe(Recipe):
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lx264', '-L' + build_dir + '/lib/']
 
-                """
-                WARNING: DISABLED during migration to ndk19, cause We're
-                getting a runtime error for a missing symbol.
-
                 # libshine
                 flags += ['--enable-libshine']
                 build_dir = Recipe.get_recipe('libshine', self.ctx).get_build_dir(arch.arch)
                 cflags += ['-I' + build_dir + '/include/']
                 ldflags += ['-lshine', '-L' + build_dir + '/lib/']
                 ldflags += ['-lm']
-                """
 
                 # Enable all codecs:
                 flags += [

--- a/pythonforandroid/recipes/ffpyplayer_codecs/__init__.py
+++ b/pythonforandroid/recipes/ffpyplayer_codecs/__init__.py
@@ -2,8 +2,7 @@ from pythonforandroid.toolchain import Recipe
 
 
 class FFPyPlayerCodecsRecipe(Recipe):
-    depends = ['libx264']
-    # disabled libshine due a missing symbol error (see ffmpeg recipe)
+    depends = ['libx264', 'libshine']
 
     def build_arch(self, arch):
         pass


### PR DESCRIPTION
Since the recent fix for the ffmpeg recipe #1997, we detected that the libshine recipe wasn't working properly at runtime (libavcodec complains about missing symbols), so here we have the fix for that.

In here we:
  - build libshine as a shared library
  - move to python3's f-strings
  - fix LDLIBS/LDFLAGS (which is the main reason of the runtime error described at #1997)
  - Re-enable libshine for ffpyplayer_codes and ffmpeg

I tested the build for archs: `armeabi-v7a` and `arm64-v8a`...both builds succeed. Also checked the symbols via command `readelf -a libshine.so` and it seems that the missing func is in there, see 264:

```
....
   254: 00003ae5   100 FUNC    GLOBAL DEFAULT   11 shine_check_config
   255: 00003ee7    20 FUNC    GLOBAL DEFAULT   11 shine_close
   256: 00003d69   184 FUNC    GLOBAL DEFAULT   11 shine_encode_buffer
   257: 00003e21   184 FUNC    GLOBAL DEFAULT   11 shine_encode_buffer_inter
   258: 00003a1d   200 FUNC    GLOBAL DEFAULT   11 shine_find_bitrate_index
   259: 000039b1   108 FUNC    GLOBAL DEFAULT   11 shine_find_samplerate_ind
   260: 00003ed9    14 FUNC    GLOBAL DEFAULT   11 shine_flush
   261: 00003b59   528 FUNC    GLOBAL DEFAULT   11 shine_initialise
   262: 00003999    22 FUNC    GLOBAL DEFAULT   11 shine_mpeg_version
   263: 00003b49    10 FUNC    GLOBAL DEFAULT   11 shine_samples_per_pass
   264: 00003989    16 FUNC    GLOBAL DEFAULT   11 shine_set_config_mpeg_def
...
```

Also checked the libabcodec.so library with `readelf -d libavcodec.so`:

```
La section dynamique à l'offset 0x6bfedc contient 31 entrées :
  Seny       Tipus                        Nom/Valor
 0x00000003 (PLTGOT)                     0x6d8880
 0x00000002 (PLTRELSZ)                   2872 (bytes)
 0x00000017 (JMPREL)                     0x256c4
 0x00000014 (PLTREL)                     REL
 0x00000011 (REL)                        0x68dc
 0x00000012 (RELSZ)                      126440 (bytes)
 0x00000013 (RELENT)                     8 (bytes)
 0x6ffffffa (RELCOUNT)                   15659
 0x00000006 (SYMTAB)                     0x1cc
 0x0000000b (SYMENT)                     16 (bytes)
 0x00000005 (STRTAB)                     0x279c
 0x0000000a (STRSZ)                      10761 (bytes)
 0x00000004 (HASH)                       0x51a8
 0x00000001 (NEEDED)                     Biblioteca compartida: [libshine.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libm.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libswresample.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libavutil.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libz.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libdl.so]
 0x00000001 (NEEDED)                     Biblioteca compartida: [libc.so]
 0x0000000e (SONAME)                     soname de la biblioteca: [libavcodec.so]
 0x0000001a (FINI_ARRAY)                 0x69fe90
 0x0000001c (FINI_ARRAYSZ)               8 (bytes)
 0x00000010 (SYMBOLIC)                   0x0
 0x0000001e (FLAGS)                      SYMBOLIC
 0x6ffffff0 (VERSYM)                     0x6348
 0x6ffffffc (VERDEF)                     0x6804
 0x6ffffffd (VERDEFNUM)                  2
 0x6ffffffe (VERNEED)                    0x683c
 0x6fffffff (VERNEEDNUM)                 5
 0x00000000 (NULL)                       0x0
```
It seem that libshine is linked to it as a shared library, so I think that the errors described at #1997 should not happen anymore...hope that we don't have any other error :crossed_fingers:

I think that this PR should solve the ffmpeg problem with libshine, but I cannot test it runtime, so it would be great that someone could test it at runtime...

**Note:** Aaa...my terminal throws the messages with a mix of languages (Catalan, french and english)...I'm guessing that the debian translations are not good enough for catalan :<, anyway, in order to not alter the terminal output, here I give the relevant translations from catalan to english:
  - Biblioteca compartida: Shared library
  - Nom/Valor: Name/Value
  - Tipus: Type