### PR TITLE
[gh-actions] Add new testapp and upload artifacts...

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,15 +45,23 @@ jobs:
     name: Build testapp
     needs: [flake8]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-arch: ['arm64-v8a', 'armeabi-v7a']
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@master
     - name: Pull docker image
       run: |
         make docker/pull
-    - name: Build apk for Python 3 arm64-v8a
+    - name: Build apk for Python 3 ${{ matrix.build-arch }}
       run: |
-        make docker/run/make/testapps/python3/arm64-v8a
+        mkdir -p apks
+        make docker/run/make/with-artifact/testapps/python3/${{ matrix.build-arch }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: bdisttest_python3_sqlite_openssl_googlendk__${{ matrix.build-arch }}-debug-1.1.apk
+        path: apks
 
   rebuild_updated_recipes:
     name: Test updated recipes

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout python-for-android
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1.1.0
       with:
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest, macOs-latest]
     steps:
     - name: Checkout python-for-android
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1.1.0
       with:
@@ -50,7 +50,7 @@ jobs:
         build-arch: ['arm64-v8a', 'armeabi-v7a']
     steps:
     - name: Checkout python-for-android
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
     - name: Pull docker image
       run: |
         make docker/pull
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout python-for-android
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
     - name: Pull docker image
       run: |
         make docker/pull

--- a/Makefile
+++ b/Makefile
@@ -76,5 +76,16 @@ docker/run/command: docker/build
 docker/run/make/%: docker/build
 	docker run --rm --env-file=.env $(DOCKER_IMAGE) make $*
 
+docker/run/make/with-artifact/%: docker/build
+ifeq (,$(findstring python3,$($*)))
+	$(eval $@_APP_NAME := bdisttest_python3_sqlite_openssl_googlendk)
+else
+	$(eval $@_APP_NAME := bdisttest_python2_sqlite_openssl)
+endif
+	$(eval $@_APP_ARCH := $(shell basename $*))
+	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
+	docker cp p4a-latest:/home/user/app/testapps/$($@_APP_NAME)__$($@_APP_ARCH)-debug-1.1-.apk ./apks
+	docker rm -fv p4a-latest
+
 docker/run/shell: docker/build
 	docker run --rm --env-file=.env -it $(DOCKER_IMAGE)


### PR DESCRIPTION
So we can dowload the built testapp for each job we make, at gh-actions tab, (via a button on the top right after the job is completed)

In here we do:
  - Add a new testapp for `armeabi-v7a` via a `matrix`
  - Create artifacts for both testapps: `arm64-v8a ` & `armeabi-v7a`
  - Pin `actions/checkout` to v1 (because I started to get git failures with `rebuild_updated_recipes.py` script, and pinning to v1 solved the problem)

**See also:** The [mentioned git error at my fork](https://github.com/opacam/python-for-android/runs/332889072#step:4:250)