### PR TITLE
Fix vibration for testapps

### DIFF
--- a/testapps/testapp/main.py
+++ b/testapps/testapp/main.py
@@ -123,21 +123,34 @@ class TestApp(App):
 
     def test_pyjnius(self, *args):
         try:
-            from jnius import autoclass
+            from jnius import autoclass, cast
         except ImportError:
             raise_error('Could not import pyjnius')
             return
-
         print('Attempting to vibrate with pyjnius')
-        # PythonActivity = autoclass('org.renpy.android.PythonActivity')
-        # activity = PythonActivity.mActivity
+        ANDROID_VERSION = autoclass('android.os.Build$VERSION')
+        SDK_INT = ANDROID_VERSION.SDK_INT
+
+        Context = autoclass("android.content.Context")
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
         activity = PythonActivity.mActivity
-        Intent = autoclass('android.content.Intent')
-        Context = autoclass('android.content.Context')
-        vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)
 
-        vibrator.vibrate(1000)
+        vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+        vibrator = cast("android.os.Vibrator", vibrator_service)
+
+        if vibrator and SDK_INT >= 26:
+            print("Using android's `VibrationEffect` (SDK >= 26)")
+            VibrationEffect = autoclass("android.os.VibrationEffect")
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(
+                    1000, VibrationEffect.DEFAULT_AMPLITUDE,
+                ),
+            )
+        elif vibrator:
+            print("Using deprecated android's vibrate (SDK < 26)")
+            vibrator.vibrate(1000)
+        else:
+            print('Something happened...vibrator service disabled?')
 
     def test_ctypes(self, *args):
         import ctypes

--- a/testapps/testapp_encryption/main.py
+++ b/testapps/testapp_encryption/main.py
@@ -324,19 +324,34 @@ class TestApp(App):
 
     def test_pyjnius(self, *args):
         try:
-            from jnius import autoclass
+            from jnius import autoclass, cast
         except ImportError:
             raise_error('Could not import pyjnius')
             return
-
         print('Attempting to vibrate with pyjnius')
-        python_activity = autoclass('org.kivy.android.PythonActivity')
-        activity = python_activity.mActivity
-        intent = autoclass('android.content.Intent')
-        context = autoclass('android.content.Context')
-        vibrator = activity.getSystemService(context.VIBRATOR_SERVICE)
+        ANDROID_VERSION = autoclass('android.os.Build$VERSION')
+        SDK_INT = ANDROID_VERSION.SDK_INT
 
-        vibrator.vibrate(1000)
+        Context = autoclass("android.content.Context")
+        PythonActivity = autoclass('org.kivy.android.PythonActivity')
+        activity = PythonActivity.mActivity
+
+        vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+        vibrator = cast("android.os.Vibrator", vibrator_service)
+
+        if vibrator and SDK_INT >= 26:
+            print("Using android's `VibrationEffect` (SDK >= 26)")
+            VibrationEffect = autoclass("android.os.VibrationEffect")
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(
+                    1000, VibrationEffect.DEFAULT_AMPLITUDE,
+                ),
+            )
+        elif vibrator:
+            print("Using deprecated android's vibrate (SDK < 26)")
+            vibrator.vibrate(1000)
+        else:
+            print('Something happened...vibrator service disabled?')
 
     def test_ctypes(self, *args):
         import ctypes

--- a/testapps/testapp_flask/main.py
+++ b/testapps/testapp_flask/main.py
@@ -26,12 +26,16 @@ from flask import (Flask, url_for, render_template, request, redirect,
 print('imported flask etc')
 print('importing pyjnius')
 
-from jnius import autoclass
+from jnius import autoclass, cast
+
+ANDROID_VERSION = autoclass('android.os.Build$VERSION')
+SDK_INT = ANDROID_VERSION.SDK_INT
 Context = autoclass('android.content.Context')
 PythonActivity = autoclass('org.kivy.android.PythonActivity')
 activity = PythonActivity.mActivity
 
-vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)
+vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+vibrator = cast("android.os.Vibrator", vibrator_service)
 
 ActivityInfo = autoclass('android.content.pm.ActivityInfo')
 
@@ -50,7 +54,20 @@ def vibrate():
         print('ERROR: asked to vibrate but without time argument')
     print('asked to vibrate', args['time'])
 
-    vibrator.vibrate(float(args['time']) * 1000)
+    if vibrator and SDK_INT >= 26:
+        print("Using android's `VibrationEffect` (SDK >= 26)")
+        VibrationEffect = autoclass("android.os.VibrationEffect")
+        vibrator.vibrate(
+            VibrationEffect.createOneShot(
+                int(float(args['time']) * 1000),
+                VibrationEffect.DEFAULT_AMPLITUDE,
+            ),
+        )
+    elif vibrator:
+        print("Using deprecated android's vibrate (SDK < 26)")
+        vibrator.vibrate(int(float(args['time']) * 1000))
+    else:
+        print('Something happened...vibrator service disabled?')
     print('vibrated')
 
 @app.route('/loadUrl')

--- a/testapps/testapp_keyboard/main.py
+++ b/testapps/testapp_keyboard/main.py
@@ -121,21 +121,34 @@ class TestApp(App):
 
     def test_pyjnius(self, *args):
         try:
-            from jnius import autoclass
+            from jnius import autoclass, cast
         except ImportError:
             raise_error('Could not import pyjnius')
             return
-        
         print('Attempting to vibrate with pyjnius')
-        # PythonActivity = autoclass('org.renpy.android.PythonActivity')
-        # activity = PythonActivity.mActivity
+        ANDROID_VERSION = autoclass('android.os.Build$VERSION')
+        SDK_INT = ANDROID_VERSION.SDK_INT
+
+        Context = autoclass("android.content.Context")
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
         activity = PythonActivity.mActivity
-        Intent = autoclass('android.content.Intent')
-        Context = autoclass('android.content.Context')
-        vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)
 
-        vibrator.vibrate(1000)
+        vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+        vibrator = cast("android.os.Vibrator", vibrator_service)
+
+        if vibrator and SDK_INT >= 26:
+            print("Using android's `VibrationEffect` (SDK >= 26)")
+            VibrationEffect = autoclass("android.os.VibrationEffect")
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(
+                    1000, VibrationEffect.DEFAULT_AMPLITUDE,
+                ),
+            )
+        elif vibrator:
+            print("Using deprecated android's vibrate (SDK < 26)")
+            vibrator.vibrate(1000)
+        else:
+            print('Something happened...vibrator service disabled?')
 
     def test_ctypes(self, *args):
         import ctypes

--- a/testapps/testapp_sqlite_openssl/main.py
+++ b/testapps/testapp_sqlite_openssl/main.py
@@ -192,24 +192,37 @@ class TestApp(App):
 
     def test_pyjnius(self, *args):
         try:
-            from jnius import autoclass
+            from jnius import autoclass, cast
         except ImportError:
             raise_error('Could not import pyjnius')
             return
-        
         print('Attempting to vibrate with pyjnius')
-        # PythonActivity = autoclass('org.renpy.android.PythonActivity')
-        # activity = PythonActivity.mActivity
+        ANDROID_VERSION = autoclass('android.os.Build$VERSION')
+        SDK_INT = ANDROID_VERSION.SDK_INT
+
+        Context = autoclass("android.content.Context")
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
         activity = PythonActivity.mActivity
-        Intent = autoclass('android.content.Intent')
-        Context = autoclass('android.content.Context')
-        vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)
 
-        vibrator.vibrate(1000)
+        vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+        vibrator = cast("android.os.Vibrator", vibrator_service)
+
+        if vibrator and SDK_INT >= 26:
+            print("Using android's `VibrationEffect` (SDK >= 26)")
+            VibrationEffect = autoclass("android.os.VibrationEffect")
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(
+                    1000, VibrationEffect.DEFAULT_AMPLITUDE,
+                ),
+            )
+        elif vibrator:
+            print("Using deprecated android's vibrate (SDK < 26)")
+            vibrator.vibrate(1000)
+        else:
+            print('Something happened...vibrator service disabled?')
 
     def test_ctypes(self, *args):
-        import ctypes
+        pass
             
     def test_numpy(self, *args):
         import numpy


### PR DESCRIPTION
Method `vibrate(milliseconds)` was deprecated in API level 26,
now we should use ` vibrate(android.os.VibrationEffect)`.

I labeled this `WIP` because I thing that we should consider the possibility to use `plyer` instead of using the more low level way of `pyjnius`, because we are repeating the code a lot with all the testapps (except for the flask testapp...which uses the same solution but written slightly differently). But the vibration fix for `plyer` it was merged recently, and we still not have a release with it, so it will force us to put a github requirement in our testapp setup.py files and pin it to a commit or master branch...so...
@inclement and @AndreMiras, what do you think about this, `plyer` or `pyjnius`?

**Note:**
  - This solution is based on the kivy/plyer#523 and was adapted to our needs
  - I tested the `testapp_flask` and the standard one `testapp_sqlite_openssl` and this last one, you could also test it, without building it, via the corresponding job, you can download the testapps built with gh-actions via the `Artificats` button :smile:

**See also:** https://developer.android.com/reference/android/os/Vibrator#vibrate(long)