### PR TITLE
Added a build.py argument to add arbitrary xml to the AndroidManifest.xml

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -767,6 +767,9 @@ tools directory of the Android SDK.
                     action='store_false', default=True,
                     help=('Whether to compile to optimised .pyo files, using -OO '
                           '(strips docstrings and asserts)'))
+    ap.add_argument('--extra-manifest-xml', default='',
+                    help=('Extra xml to write directly inside the <manifest> element of'
+                          'AndroidManifest.xml'))
 
     # Put together arguments, and add those from .p4a config file:
     if args is None:

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -42,6 +42,9 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     {% endif %}
 
+    {{ args.extra_manifest_xml }}
+
+
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under src matching the package, e.g.
          	src/com/gamemaker/game/MyGame.java


### PR DESCRIPTION
The XML is added within the <manifest> tag.

I've always said we should support this, but I couldn't see it in the AndroidManifest.xml as it stands - maybe I'm missing it?

If this sounds good, I'll add it to the other templates as well.