### PR TITLE
Add keyboard input type customization for SDL2

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -31,6 +31,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
+import android.view.inputmethod.InputMethodManager;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
@@ -421,7 +422,7 @@ public class PythonActivity extends SDLActivity {
     /** Whether main routine/actual app has started yet **/
     protected boolean mAppConfirmedActive = false;
     /** Timer for delayed loading screen removal. **/
-    protected Timer loadingScreenRemovalTimer = null; 
+    protected Timer loadingScreenRemovalTimer = null;
 
     // Overridden since it's called often, to check whether to remove the
     // loading screen:
@@ -431,7 +432,7 @@ public class PythonActivity extends SDLActivity {
         considerLoadingScreenRemoval();
         return result;
     }
-   
+
     /** Confirm that the app's main routine has been launched.
      **/
     @Override
@@ -484,7 +485,7 @@ public class PythonActivity extends SDLActivity {
     public void removeLoadingScreen() {
         runOnUiThread(new Runnable() {
             public void run() {
-                if (PythonActivity.mImageView != null && 
+                if (PythonActivity.mImageView != null &&
                         PythonActivity.mImageView.getParent() != null) {
                     ((ViewGroup)PythonActivity.mImageView.getParent()).removeView(
                         PythonActivity.mImageView);
@@ -548,7 +549,7 @@ public class PythonActivity extends SDLActivity {
                 try {
                     mImageView.setBackgroundColor(Color.parseColor(backgroundColor));
                 } catch (IllegalArgumentException e) {}
-            }   
+            }
             mImageView.setLayoutParams(new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.FILL_PARENT,
                 ViewGroup.LayoutParams.FILL_PARENT));
@@ -568,7 +569,7 @@ public class PythonActivity extends SDLActivity {
             // You must call removeView() on the child's parent first.")
         }
     }
-    
+
     @Override
     protected void onPause() {
         if (this.mWakeLock != null && mWakeLock.isHeld()) {
@@ -649,7 +650,7 @@ public class PythonActivity extends SDLActivity {
                 Activity.class.getMethod("checkSelfPermission", java.lang.String.class);
             Object resultObj = methodCheckPermission.invoke(this, permission);
             int result = Integer.parseInt(resultObj.toString());
-            if (result == PackageManager.PERMISSION_GRANTED) 
+            if (result == PackageManager.PERMISSION_GRANTED)
                 return true;
         } catch (IllegalAccessException | NoSuchMethodException |
                  InvocationTargetException e) {
@@ -675,5 +676,13 @@ public class PythonActivity extends SDLActivity {
 
     public void requestPermissions(String[] permissions) {
         requestPermissionsWithRequestCode(permissions, 1);
+    }
+
+    public static void changeKeyboard(int inputType) {
+      if (SDLActivity.keyboardInputType != inputType){
+          SDLActivity.keyboardInputType = inputType;
+          InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+          imm.restartInput(mTextEdit);
+          }
     }
 }

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/libsdl/app/SDLActivity.java
@@ -94,11 +94,13 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     // This is what SDL runs in. It invokes SDL_main(), eventually
     protected static Thread mSDLThread;
 
+    public static int keyboardInputType = InputType.TYPE_CLASS_TEXT;
+
     protected static SDLGenericMotionListener_API12 getMotionListener() {
         if (mMotionListener == null) {
             if (Build.VERSION.SDK_INT >= 26) {
                 mMotionListener = new SDLGenericMotionListener_API26();
-            } else 
+            } else
             if (Build.VERSION.SDK_INT >= 24) {
                 mMotionListener = new SDLGenericMotionListener_API24();
             } else {
@@ -326,15 +328,15 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             case Surface.ROTATION_0:
                 result = SDL_ORIENTATION_PORTRAIT;
                 break;
-    
+
             case Surface.ROTATION_90:
                 result = SDL_ORIENTATION_LANDSCAPE;
                 break;
-    
+
             case Surface.ROTATION_180:
                 result = SDL_ORIENTATION_PORTRAIT_FLIPPED;
                 break;
-    
+
             case Surface.ROTATION_270:
                 result = SDL_ORIENTATION_LANDSCAPE_FLIPPED;
                 break;
@@ -584,7 +586,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                                         View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
                                         View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
                                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
-                            window.getDecorView().setSystemUiVisibility(flags);        
+                            window.getDecorView().setSystemUiVisibility(flags);
                             window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                             window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
                             SDLActivity.mFullscreenModeActive = true;
@@ -609,7 +611,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
                     InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
                     imm.hideSoftInputFromWindow(mTextEdit.getWindowToken(), 0);
-                    
+
                     mScreenKeyboardShown = false;
                 }
                 break;
@@ -650,14 +652,14 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             // or 500ms have passed.
 
             boolean bShouldWait = false;
-            
+
             if (data instanceof Integer) {
                 // Let's figure out if we're already laid out fullscreen or not.
                 Display display = ((WindowManager)getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
                 android.util.DisplayMetrics realMetrics = new android.util.DisplayMetrics();
                 display.getRealMetrics( realMetrics );
-        
-                boolean bFullscreenLayout = ((realMetrics.widthPixels == mSurface.getWidth()) && 
+
+                boolean bFullscreenLayout = ((realMetrics.widthPixels == mSurface.getWidth()) &&
                                              (realMetrics.heightPixels == mSurface.getHeight()));
 
                 if (((Integer)data).intValue() == 1) {
@@ -682,7 +684,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                 // size we need, instead of grabbing a size that's still got
                 // the navigation and/or status bars before they're hidden.
                 //
-                // We'll wait for up to half a second, because some devices 
+                // We'll wait for up to half a second, because some devices
                 // take a surprisingly long time for the surface resize, but
                 // then we'll just give up and return.
                 //
@@ -743,7 +745,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     /**
      * This method is called by SDL using JNI.
      * This is a static method for JNI convenience, it calls a non-static method
-     * so that is can be overridden  
+     * so that is can be overridden
      */
     public static void setOrientation(int w, int h, boolean resizable, String hint)
     {
@@ -751,11 +753,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             mSingleton.setOrientationBis(w, h, resizable, hint);
         }
     }
-   
+
     /**
      * This can be overridden
      */
-    public void setOrientationBis(int w, int h, boolean resizable, String hint) 
+    public void setOrientationBis(int w, int h, boolean resizable, String hint)
     {
         int orientation = -1;
 
@@ -795,7 +797,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     /**
      * This method is called by SDL using JNI.
      */
-    public static boolean isScreenKeyboardShown() 
+    public static boolean isScreenKeyboardShown()
     {
         if (mTextEdit == null) {
             return false;
@@ -820,7 +822,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             return false;
         }
 
-        // DeX mode in Samsung Experience 9.0 and earlier doesn't support relative mice properly under 
+        // DeX mode in Samsung Experience 9.0 and earlier doesn't support relative mice properly under
         // Android 7 APIs, and simply returns no data under Android 8 APIs.
         //
         // This is fixed in Samsung Experience 9.5, which corresponds to Android 8.1.0, and
@@ -902,7 +904,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
      */
     public static boolean isChromebook() {
         return getContext().getPackageManager().hasSystemFeature("org.chromium.arc.device_management");
-    }    
+    }
 
     /**
      * This method is called by SDL using JNI.
@@ -948,7 +950,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                 }
             }
             /* environment variables set! */
-            return true; 
+            return true;
         } catch (Exception e) {
            Log.v("SDL", "exception " + e.toString());
         }
@@ -956,7 +958,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     }
 
     // This method is called by SDLControllerManager's API 26 Generic Motion Handler.
-    public static View getContentView() 
+    public static View getContentView()
     {
         return mSingleton.mLayout;
     }
@@ -1011,12 +1013,12 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     }
 
     public static boolean isTextInputEvent(KeyEvent event) {
-      
+
         // Key pressed with Ctrl should be sent as SDL_KEYDOWN/SDL_KEYUP and not SDL_TEXTINPUT
         if (Build.VERSION.SDK_INT >= 11) {
             if (event.isCtrlPressed()) {
                 return false;
-            }  
+            }
         }
 
         return event.isPrintingKey() || event.getKeyCode() == KeyEvent.KEYCODE_SPACE;
@@ -1350,7 +1352,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             }
 
         }
-    }    
+    }
 
     /**
      * This method is called by SDL using JNI.
@@ -1862,7 +1864,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
             // Since we may have an orientation set, we won't receive onConfigurationChanged events.
             // We thus should check here.
             int newOrientation = SDLActivity.SDL_ORIENTATION_UNKNOWN;
-    
+
             float x, y;
             switch (mDisplay.getRotation()) {
                 case Surface.ROTATION_90:
@@ -1896,7 +1898,7 @@ class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                                       y / SensorManager.GRAVITY_EARTH,
                                       event.values[2] / SensorManager.GRAVITY_EARTH);
 
-            
+
         }
     }
 
@@ -1964,7 +1966,7 @@ class DummyEdit extends View implements View.OnKeyListener {
 
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
-        /* 
+        /*
          * This handles the hardware keyboard input
          */
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
@@ -2002,7 +2004,7 @@ class DummyEdit extends View implements View.OnKeyListener {
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         ic = new SDLInputConnection(this, true);
 
-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+        outAttrs.inputType = SDLActivity.keyboardInputType;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
 
@@ -2084,7 +2086,7 @@ class SDLInputConnection extends BaseInputConnection {
             while (beforeLength-- > 0) {
                boolean ret_key = sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
                               && sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL));
-               ret = ret && ret_key; 
+               ret = ret && ret_key;
             }
             return ret;
         }
@@ -2103,7 +2105,7 @@ interface SDLClipboardHandler {
 
 
 class SDLClipboardHandler_API11 implements
-    SDLClipboardHandler, 
+    SDLClipboardHandler,
     android.content.ClipboardManager.OnPrimaryClipChangedListener {
 
     protected android.content.ClipboardManager mClipMgr;
@@ -2134,7 +2136,7 @@ class SDLClipboardHandler_API11 implements
        mClipMgr.setText(string);
        mClipMgr.addPrimaryClipChangedListener(this);
     }
-    
+
     @Override
     public void onPrimaryClipChanged() {
         SDLActivity.onNativeClipboardChanged();
@@ -2144,9 +2146,9 @@ class SDLClipboardHandler_API11 implements
 
 class SDLClipboardHandler_Old implements
     SDLClipboardHandler {
-   
+
     protected android.text.ClipboardManager mClipMgrOld;
-  
+
     SDLClipboardHandler_Old() {
        mClipMgrOld = (android.text.ClipboardManager) SDL.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
     }
@@ -2171,4 +2173,3 @@ class SDLClipboardHandler_Old implements
        mClipMgrOld.setText(string);
     }
 }
-


### PR DESCRIPTION
This is the continuation of kivy/kivy#6716. With these changes, 
applications using SDL2 as window provider will be able to change the 
keyboard input type. This is achieved replacing the default value of 
outAttrs.inputType on SDLActivity.java for keyboardInputType. 
PythonActivity.java now has changeKeyboard, a function that basically 
allows the switching of the input type, modifying keyboardInputType to a 
given value. This function is called in Kivy through the android module.

Closes #2015, Fixes #796