### PR TITLE
Fix missing renames of Bootstrap.list_bootstraps -> Bootstrap.all_bootstraps

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -785,7 +785,7 @@ class ToolchainCL(object):
 
     def bootstraps(self, _args):
         """List all the bootstraps available to build with."""
-        for bs in Bootstrap.list_bootstraps():
+        for bs in Bootstrap.all_bootstraps():
             bs = Bootstrap.get_bootstrap(bs, self.ctx)
             print('{Fore.BLUE}{Style.BRIGHT}{bs.name}{Style.RESET_ALL}'
                   .format(bs=bs, Fore=Out_Fore, Style=Out_Style))
@@ -828,7 +828,7 @@ class ToolchainCL(object):
         """Delete all the bootstrap builds."""
         if exists(join(self.ctx.build_dir, 'bootstrap_builds')):
             shutil.rmtree(join(self.ctx.build_dir, 'bootstrap_builds'))
-        # for bs in Bootstrap.list_bootstraps():
+        # for bs in Bootstrap.all_bootstraps():
         #     bs = Bootstrap.get_bootstrap(bs, self.ctx)
         #     if bs.build_dir and exists(bs.build_dir):
         #         info('Cleaning build for {} bootstrap.'.format(bs.name))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -143,7 +143,7 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
 
     def test_all_bootstraps(self):
         """A test which will initialize a bootstrap and will check if the
-        method :meth:`~pythonforandroid.bootstrap.Bootstrap.list_bootstraps`
+        method :meth:`~pythonforandroid.bootstrap.Bootstrap.all_bootstraps `
         returns the expected values, which should be: `empty", `service_only`,
         `webview` and `sdl2`
         """


### PR DESCRIPTION
Fixes `p4a bootstrap` command:
```sh
$ p4a bootstraps
Traceback (most recent call last):
  File "/home/touilleman/projects/buildozer-test/venv/bin/p4a", line 10, in <module>
    sys.exit(main())
  File "/home/touilleman/projects/buildozer-test/venv/lib/python3.7/site-packages/pythonforandroid/entrypoints.py", line 18, in main
    ToolchainCL()
  File "/home/touilleman/projects/buildozer-test/venv/lib/python3.7/site-packages/pythonforandroid/toolchain.py", line 671, in __init__
    getattr(self, args.subparser_name.replace('-', '_'))(args)
  File "/home/touilleman/projects/buildozer-test/venv/lib/python3.7/site-packages/pythonforandroid/toolchain.py", line 788, in bootstraps
    for bs in Bootstrap.list_bootstraps():
AttributeError: type object 'Bootstrap' has no attribute 'list_bootstraps'
```