### PR TITLE
[recipes] Update harfbuzz to v2.6.4

### DIFF
--- a/pythonforandroid/recipes/harfbuzz/__init__.py
+++ b/pythonforandroid/recipes/harfbuzz/__init__.py
@@ -20,8 +20,8 @@ class HarfbuzzRecipe(Recipe):
         https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/
     """
 
-    version = '0.9.40'
-    url = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-{version}.tar.bz2'  # noqa
+    version = '2.6.4'
+    url = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-{version}.tar.xz'  # noqa
     opt_depends = ['freetype']
     built_libraries = {'libharfbuzz.so': 'src/.libs'}
 
@@ -50,7 +50,6 @@ class HarfbuzzRecipe(Recipe):
             configure = sh.Command('./configure')
             shprint(
                 configure,
-                '--without-icu',
                 '--host={}'.format(arch.command_prefix),
                 '--prefix={}'.format(self.get_build_dir(arch.arch)),
                 '--with-freetype={}'.format(
@@ -58,7 +57,10 @@ class HarfbuzzRecipe(Recipe):
                     if 'freetype' in self.ctx.recipe_build_order
                     else 'no'
                 ),
-                '--without-glib',
+                '--with-icu=no',
+                '--with-cairo=no',
+                '--with-fontconfig=no',
+                '--with-glib=no',
                 _env=env,
             )
             shprint(sh.make, '-j', str(cpu_count()), _env=env)


### PR DESCRIPTION
Tested at runtime with an app of mine for `arm64-v8a` and `Python 3.8.1` (the default for p4a develop branch at the time of writing) using the updated Pillow recipe #2067 alongside an updated freetype recipe #2068