### PR TITLE
Fix recipe `kiwisolver` (add `cppy` recipe)

### DIFF
--- a/pythonforandroid/recipes/cppy/__init__.py
+++ b/pythonforandroid/recipes/cppy/__init__.py
@@ -1,0 +1,17 @@
+from pythonforandroid.recipe import PythonRecipe
+
+
+class CppyRecipe(PythonRecipe):
+    site_packages_name = 'cppy'
+
+    # Pin to commit: `Nucleic migration and project documentation`,
+    # because the official releases are too old, at time of writing
+    version = '4e0b956'
+    url = 'https://github.com/nucleic/cppy/archive/{version}.zip'
+    call_hostpython_via_targetpython = False
+    # to be detected by the matplotlib install script
+    install_in_hostpython = True
+    depends = ['setuptools']
+
+
+recipe = CppyRecipe()

--- a/pythonforandroid/recipes/kiwisolver/__init__.py
+++ b/pythonforandroid/recipes/kiwisolver/__init__.py
@@ -3,9 +3,28 @@ from pythonforandroid.recipe import CppCompiledComponentsPythonRecipe
 
 class KiwiSolverRecipe(CppCompiledComponentsPythonRecipe):
     site_packages_name = 'kiwisolver'
-    version = '0.1.3'
-    url = 'https://github.com/nucleic/kiwi/archive/master.zip'
-    depends = ['setuptools']
+    # Pin to commit `docs: attempt to fix doc building`, the latest one
+    # at the time of writing, just to be sure that we have te most up to date
+    # version, but it should be pinned to an official release once the c++
+    # changes that we want to include are merged to master branch
+    #   Note: the commit we want to include is
+    #         `Cppy use update and c++11 compatibility` (4858730)
+    version = '0846189'
+    url = 'https://github.com/nucleic/kiwi/archive/{version}.zip'
+    depends = ['cppy']
+
+    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+        env = super().get_recipe_env(arch, with_flags_in_cc)
+        if self.need_stl_shared:
+            # kiwisolver compile flags does not honor the standard flags:
+            # `CPPFLAGS` and `LDLIBS`, so we put in `CFLAGS` and `LDFLAGS` to
+            # correctly link with the `c++_shared` library
+            env['CFLAGS'] += f' -I{self.stl_include_dir}'
+            env['CFLAGS'] += ' -frtti -fexceptions'
+
+            env['LDFLAGS'] += f' -L{self.get_stl_lib_dir(arch)}'
+            env['LDFLAGS'] += f' -l{self.stl_lib_name}'
+        return env
 
 
 recipe = KiwiSolverRecipe()


### PR DESCRIPTION
This is the first step that we have to do to fix the `matplotlib` recipe, since it is a direct dependency.

**See also:** #2073 and [this comment](https://github.com/kivy/python-for-android/pull/2073#issuecomment-593102184)