### PR TITLE
Update `numpy` to v1.18.1 (add `cython` recipe)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,12 @@ jobs:
       after_success:
         - coveralls
     - &testapps
-      name: Python 3 arm64-v8a
+      name: Python 3 arm64-v8a (with numpy)
       stage: build testapps
       before_script: make docker/pull
       script: make docker/run/make/testapps/python3/arm64-v8a
     - <<: *testapps
-      name: Python 3 armeabi-v7a (with numpy)
+      name: Python 3 armeabi-v7a
       os: osx
       osx_image: xcode11  # since xcode1.3, python3 is the default interpreter
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
       before_script: make docker/pull
       script: make docker/run/make/testapps/python3/arm64-v8a
     - <<: *testapps
-      name: Python 3 armeabi-v7a
+      name: Python 3 armeabi-v7a (with numpy)
       os: osx
       osx_image: xcode11  # since xcode1.3, python3 is the default interpreter
       before_script:
@@ -61,7 +61,7 @@ jobs:
         - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       script: make testapps/python3/armeabi-v7a PYTHON_WITH_VERSION=python3
     - <<: *testapps
-      name: Python 2 armeabi-v7a (with numpy)
+      name: Python 2 armeabi-v7a
       script: make docker/run/make/testapps/python2/armeabi-v7a
     - <<: *testapps
       name: Rebuild updated recipes

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ rebuild_updated_recipes: virtualenv
 testapps/python2/armeabi-v7a: virtualenv
 	. $(ACTIVATE) && cd testapps/ && \
     python setup_testapp_python2_sqlite_openssl.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools,numpy
+    --requirements sdl2,pyjnius,kivy,python2,openssl,requests,sqlite3,setuptools
 
 testapps/python3/arm64-v8a: virtualenv
 	. $(ACTIVATE) && cd testapps/ && \
@@ -48,7 +48,7 @@ testapps/python3/arm64-v8a: virtualenv
 testapps/python3/armeabi-v7a: virtualenv
 	. $(ACTIVATE) && cd testapps/ && \
     python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
     --arch=armeabi-v7a
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ testapps/python2/armeabi-v7a: virtualenv
 testapps/python3/arm64-v8a: virtualenv
 	. $(ACTIVATE) && cd testapps/ && \
     python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
     --arch=arm64-v8a
 
 testapps/python3/armeabi-v7a: virtualenv
 	. $(ACTIVATE) && cd testapps/ && \
     python setup_testapp_python3_sqlite_openssl.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
     --arch=armeabi-v7a
 
 clean:

--- a/pythonforandroid/recipes/cython/__init__.py
+++ b/pythonforandroid/recipes/cython/__init__.py
@@ -1,0 +1,14 @@
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+
+
+class CythonRecipe(CompiledComponentsPythonRecipe):
+
+    version = '0.29.15'
+    url = 'https://github.com/cython/cython/archive/{version}.tar.gz'
+    site_packages_name = 'cython'
+    depends = ['setuptools']
+    call_hostpython_via_targetpython = False
+    install_in_hostpython = True
+
+
+recipe = CythonRecipe()

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -5,10 +5,10 @@ from os.path import join
 
 class NumpyRecipe(CompiledComponentsPythonRecipe):
 
-    version = '1.16.4'
+    version = '1.18.1'
     url = 'https://pypi.python.org/packages/source/n/numpy/numpy-{version}.zip'
     site_packages_name = 'numpy'
-    depends = ['setuptools']
+    depends = ['setuptools', 'cython']
 
     patches = [
         join('patches', 'add_libm_explicitly_to_build.patch'),

--- a/pythonforandroid/recipes/numpy/patches/add_libm_explicitly_to_build.patch
+++ b/pythonforandroid/recipes/numpy/patches/add_libm_explicitly_to_build.patch
@@ -1,22 +1,8 @@
-diff --git a/numpy/fft/setup.py b/numpy/fft/setup.py
-index cd99a82..cd7c1ef 100644
---- a/numpy/fft/setup.py
-+++ b/numpy/fft/setup.py
-@@ -9,7 +9,8 @@ def configuration(parent_package='',top_path=None):
- 
-     # Configure fftpack_lite
-     config.add_extension('fftpack_lite',
--                         sources=['fftpack_litemodule.c', 'fftpack.c']
-+                         sources=['fftpack_litemodule.c', 'fftpack.c'],
-+                         libraries=['m'],
-                          )
- 
-     return config
 diff --git a/numpy/linalg/setup.py b/numpy/linalg/setup.py
 index 66c07c9..d34bd93 100644
 --- a/numpy/linalg/setup.py
 +++ b/numpy/linalg/setup.py
-@@ -43,6 +43,7 @@ def configuration(parent_package='', top_path=None):
+@@ -46,6 +46,7 @@ def configuration(parent_package='', top_path=None):
          sources=['lapack_litemodule.c', get_lapack_lite_sources],
          depends=['lapack_lite/f2c.h'],
          extra_info=lapack_info,
@@ -24,7 +10,7 @@ index 66c07c9..d34bd93 100644
      )
  
      # umath_linalg module
-@@ -51,7 +52,7 @@ def configuration(parent_package='', top_path=None):
+@@ -54,7 +54,7 @@ def configuration(parent_package='', top_path=None):
          sources=['umath_linalg.c.src', get_lapack_lite_sources],
          depends=['lapack_lite/f2c.h'],
          extra_info=lapack_info,
@@ -32,17 +18,3 @@ index 66c07c9..d34bd93 100644
 +        libraries=['npymath', 'm'],
      )
      return config
- 
-diff --git a/numpy/random/setup.py b/numpy/random/setup.py
-index 394a70e..44af180 100644
---- a/numpy/random/setup.py
-+++ b/numpy/random/setup.py
-@@ -39,7 +39,7 @@ def configuration(parent_package='',top_path=None):
-     if needs_mingw_ftime_workaround():
-         defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
- 
--    libs = []
-+    libs = ['m']
-     # Configure mtrand
-     config.add_extension('mtrand',
-                          sources=[join('mtrand', x) for x in

--- a/pythonforandroid/recipes/numpy/patches/do_not_use_system_libs.patch
+++ b/pythonforandroid/recipes/numpy/patches/do_not_use_system_libs.patch
@@ -2,7 +2,7 @@ diff --git a/numpy/distutils/system_info.py b/numpy/distutils/system_info.py
 index 806f4f7..0d51cfa 100644
 --- a/numpy/distutils/system_info.py
 +++ b/numpy/distutils/system_info.py
-@@ -734,6 +734,7 @@ class system_info(object):
+@@ -823,6 +823,7 @@ class system_info(object):
          return self.get_paths(self.section, key)
 
      def get_libs(self, key, default):


### PR DESCRIPTION
We add the `cython` recipe because the last version of `numpy` (at time of writing v1.18.1), requires `cython` installed as a Python module during the build stage of the `numpy` recipe.

Also this will make the `numpy` recipe only available for `Python3` since it requires python>=3.5.

