### PR TITLE
Fix Python 3.8.1 patch naming and content

### DIFF
--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -35,7 +35,7 @@ class Python3Recipe(GuestPythonRecipe):
     if sh.which('lld') is not None:
         patches = patches + [
             ("patches/py3.7.1_fix_cortex_a8.patch", version_starts_with("3.7")),
-            ("patches/py3.8.1_fix-cortex-a8.patch", version_starts_with("3.8"))
+            ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.8"))
         ]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']

--- a/pythonforandroid/recipes/python3/patches/py3.8.1_fix_cortex_a8.patch
+++ b/pythonforandroid/recipes/python3/patches/py3.8.1_fix_cortex_a8.patch
@@ -1,3 +1,5 @@
+This patch removes --fix-cortex-a8 from the linker flags in order to support linking
+with lld, as lld does not support this flag (https://github.com/android-ndk/ndk/issues/766).
 diff --git a/configure b/configure
 index 0914e24..7517168 100755
 --- a/configure
@@ -11,8 +13,3 @@ index 0914e24..7517168 100755
    fi
  else
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: not Android" >&5
-@@ -18673,4 +18673,3 @@ if test "$Py_OPT" = 'false' -a "$Py_DEBUG" != 'true'; then
-     echo "" >&6
-     echo "" >&6
- fi
--


### PR DESCRIPTION
Because:
   - the name does not match the file
   - `py3.8.1_fix-cortex-a8.patch` contains unneeded changes which provokes the patching to fail

Also we add a comment to `py3.8.1_fix_cortex_a8.patch` file, explaining why we need that patch (imho, very useful after a while...)

**Note:** The github user @Sanialtian, found this bug and notified me via email...so thanks for your debugging session and the testing!!  :raised_hands: