### PR TITLE
:bug: Add `-fPIC` to  `CFLAGS` for Arch `x86_64`

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -289,6 +289,7 @@ class Archx86_64(Arch):
         '-mpopcnt',
         '-m64',
         '-mtune=intel',
+        '-fPIC',
     ]
 
 


### PR DESCRIPTION
This commit is extracted from the tests we made at #2073 (commit message slightly modified, not the content) and it seems that solves the build problems detected in there...unfortunatelly I cannot test any `apk` with this fix, but it solves the build problem...so I recommend to merge it :wink:

**See also:**
  - https://github.com/kivy/python-for-android/pull/2073#issuecomment-592998163