### PR TITLE
Fixes gevent recipe on arm64-v8a arch

### DIFF
--- a/pythonforandroid/recipes/gevent/__init__.py
+++ b/pythonforandroid/recipes/gevent/__init__.py
@@ -13,9 +13,10 @@ class GeventRecipe(CythonRecipe):
         """
         - Moves all -I<inc> -D<macro> from CFLAGS to CPPFLAGS environment.
         - Moves all -l<lib> from LDFLAGS to LIBS environment.
+        - Copies all -l<lib> from LDLIBS to LIBS environment.
         - Fixes linker name (use cross compiler)  and flags (appends LIBS)
         """
-        env = super(GeventRecipe, self).get_recipe_env(arch, with_flags_in_cc)
+        env = super().get_recipe_env(arch, with_flags_in_cc)
         # CFLAGS may only be used to specify C compiler flags, for macro definitions use CPPFLAGS
         regex = re.compile(r'(?:\s|^)-[DI][\S]+')
         env['CPPFLAGS'] = ''.join(re.findall(regex, env['CFLAGS'])).strip()
@@ -24,6 +25,7 @@ class GeventRecipe(CythonRecipe):
         # LDFLAGS may only be used to specify linker flags, for libraries use LIBS
         regex = re.compile(r'(?:\s|^)-l[\w\.]+')
         env['LIBS'] = ''.join(re.findall(regex, env['LDFLAGS'])).strip()
+        env['LIBS'] += ' {}'.format(''.join(re.findall(regex, env['LDLIBS'])).strip())
         env['LDFLAGS'] = re.sub(regex, '', env['LDFLAGS'])
         info('Moved "{}" from LDFLAGS to LIBS.'.format(env['LIBS']))
         return env

--- a/tests/recipes/test_gevent.py
+++ b/tests/recipes/test_gevent.py
@@ -29,9 +29,11 @@ class TestGeventRecipe(RecipeCtx, unittest.TestCase):
             # checks the regex doesn't parse `python3-libffi-openssl` as a `-libffi`
             '-L/path/to/python3-libffi-openssl/library3 '
         )
+        mocked_ldlibs = ' -lm'
         mocked_env = {
             'CFLAGS': mocked_cflags,
             'LDFLAGS': mocked_ldflags,
+            'LDLIBS': mocked_ldlibs,
         }
         with patch('pythonforandroid.recipe.CythonRecipe.get_recipe_env') as m_get_recipe_env:
             m_get_recipe_env.return_value = mocked_env
@@ -53,11 +55,13 @@ class TestGeventRecipe(RecipeCtx, unittest.TestCase):
             ' -L/path/to/library2'
             ' -L/path/to/python3-libffi-openssl/library3 '
         )
-        expected_libs = '-lm -lpython3.7m'
+        expected_ldlibs = mocked_ldlibs
+        expected_libs = '-lm -lpython3.7m -lm'
         expected_env = {
             'CFLAGS': expected_cflags,
             'CPPFLAGS': expected_cppflags,
             'LDFLAGS': expected_ldflags,
+            'LDLIBS': expected_ldlibs,
             'LIBS': expected_libs,
         }
         self.assertEqual(expected_env, env)


### PR DESCRIPTION
Adding `libm.so` to the `arm64-v8a` build fixes undefined reference
errors. The (truncated) config.log errors were:
```
...
libpython3.7m.so: undefined reference to `hypot@LIBC'
libpython3.7m.so: undefined reference to `frexp@LIBC'
libpython3.7m.so: undefined reference to `cos@LIBC'
libpython3.7m.so: undefined reference to `pow@LIBC'
libpython3.7m.so: undefined reference to `atan2@LIBC'
libpython3.7m.so: undefined reference to `modf@LIBC'
libpython3.7m.so: undefined reference to `exp@LIBC'
libpython3.7m.so: undefined reference to `sin@LIBC'
libpython3.7m.so: undefined reference to `log@LIBC'
libpython3.7m.so: undefined reference to `fmod@LIBC'
clang: error: linker command failed with exit code 1 (use -v to see
invocation)
...
```
Refs: https://github.com/kivy/python-for-android/pull/1722#issuecomment-524550920