### PR TITLE
:sparkles: Compression libraries - episode I: libbz2

### DIFF
--- a/pythonforandroid/recipes/libbz2/__init__.py
+++ b/pythonforandroid/recipes/libbz2/__init__.py
@@ -1,0 +1,59 @@
+import sh
+
+from multiprocessing import cpu_count
+
+from pythonforandroid.archs import Arch
+from pythonforandroid.logger import shprint
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory
+
+
+class LibBz2Recipe(Recipe):
+
+    version = "1.0.8"
+    url = "https://sourceware.org/pub/bzip2/bzip2-{version}.tar.gz"
+    built_libraries = {"libbz2.so": ""}
+    patches = ["lib_android.patch"]
+
+    def build_arch(self, arch: Arch) -> None:
+        env = self.get_recipe_env(arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            shprint(
+                sh.make,
+                "-j",
+                str(cpu_count()),
+                f'CC={env["CC"]}',
+                f'AR={env["AR"]}',
+                f'RANLIB={env["RANLIB"]}',
+                "-f",
+                "Makefile-libbz2_so",
+                _env=env,
+            )
+
+    def get_library_includes(self, arch: Arch) -> str:
+        """
+        Returns a string with the appropriate `-I<lib directory>` to link
+        with the bz2 lib. This string is usually added to the environment
+        variable `CPPFLAGS`.
+        """
+        return " -I" + self.get_build_dir(arch.arch)
+
+    def get_library_ldflags(self, arch: Arch) -> str:
+        """
+        Returns a string with the appropriate `-L<lib directory>` to link
+        with the bz2 lib. This string is usually added to the environment
+        variable `LDFLAGS`.
+        """
+        return " -L" + self.get_build_dir(arch.arch)
+
+    @staticmethod
+    def get_library_libs_flag() -> str:
+        """
+        Returns a string with the appropriate `-l<lib>` flags to link with
+        the bz2 lib. This string is usually added to the environment
+        variable `LIBS`.
+        """
+        return " -lbz2"
+
+
+recipe = LibBz2Recipe()

--- a/pythonforandroid/recipes/libbz2/lib_android.patch
+++ b/pythonforandroid/recipes/libbz2/lib_android.patch
@@ -1,0 +1,29 @@
+Set default compiler to `clang` and disable versioned shared library
+--- bzip2-1.0.8/Makefile-libbz2_so.orig	2019-07-13 19:50:05.000000000 +0200
++++ bzip2-1.0.8/Makefile-libbz2_so	2020-03-13 20:10:32.336990786 +0100
+@@ -22,7 +22,7 @@
+ 
+ 
+ SHELL=/bin/sh
+-CC=gcc
++CC=clang
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+ CFLAGS=-fpic -fPIC -Wall -Winline -O2 -g $(BIGFILES)
+ 
+@@ -35,13 +35,11 @@ OBJS= blocksort.o  \
+       bzlib.o
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
+-	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+-	rm -f libbz2.so.1.0
+-	ln -s libbz2.so.1.0.8 libbz2.so.1.0
++	$(CC) -shared -Wl,-soname=libbz2.so -o libbz2.so $(OBJS)
++	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so
+ 
+ clean: 
+-	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
++	rm -f $(OBJS) bzip2.o libbz2.so bzip2-shared
+ 
+ blocksort.o: blocksort.c
+ 	$(CC) $(CFLAGS) -c blocksort.c

--- a/tests/recipes/test_libbz2.py
+++ b/tests/recipes/test_libbz2.py
@@ -1,0 +1,33 @@
+import unittest
+
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibBz2Recipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """TestCase for recipe :mod:`~pythonforandroid.recipes.libbz2`."""
+    recipe_name = "libbz2"
+    sh_command_calls = []
+
+    def test_get_library_includes(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.libbz2.get_library_includes`.
+        """
+        self.assertEqual(
+            self.recipe.get_library_includes(self.arch),
+            f" -I{self.recipe.get_build_dir(self.arch.arch)}",
+        )
+
+    def test_get_library_ldflags(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.libbz2.get_library_ldflags`.
+        """
+        self.assertEqual(
+            self.recipe.get_library_ldflags(self.arch),
+            f" -L{self.recipe.get_build_dir(self.arch.arch)}",
+        )
+
+    def test_link_libs_flags(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.libbz2.get_library_ldflags`.
+        """
+        self.assertEqual(self.recipe.get_library_libs_flag(), " -lbz2")


### PR DESCRIPTION
This is the first part of a set of recipes that will improve our libraries ecosystem, allowing us, in a near future, to build a extra python module: `_bz2.cpython-38.so`, required by some python packages like `pandas`.

**Notes:**
  - tested at #2088
  - this PR is not enough to build the mentioned python module, this will be done at `Compression libraries - episode III`
  - @AndreMiras, I applied [the corrections you made at #2088](https://github.com/kivy/python-for-android/pull/2088#discussion_r394260228), **thanks!!** :smile: