### PR TITLE
:sparkles: Compression libraries - episode II: liblzma

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -52,6 +52,7 @@ RUN dpkg --add-architecture i386 \
     && ${RETRY} apt -y install -qq --no-install-recommends \
     autoconf \
     automake \
+    autopoint \
     build-essential \
     ccache \
     cmake \

--- a/pythonforandroid/recipes/liblzma/__init__.py
+++ b/pythonforandroid/recipes/liblzma/__init__.py
@@ -1,0 +1,78 @@
+import sh
+
+from multiprocessing import cpu_count
+from os.path import exists, join
+
+from pythonforandroid.archs import Arch
+from pythonforandroid.logger import shprint
+from pythonforandroid.recipe import Recipe
+from pythonforandroid.util import current_directory, ensure_dir
+
+
+class LibLzmaRecipe(Recipe):
+
+    version = '5.2.4'
+    url = 'https://tukaani.org/xz/xz-{version}.tar.gz'
+    built_libraries = {'liblzma.so': 'install/lib'}
+
+    def build_arch(self, arch: Arch) -> None:
+        env = self.get_recipe_env(arch)
+        install_dir = join(self.get_build_dir(arch.arch), 'install')
+        with current_directory(self.get_build_dir(arch.arch)):
+            if not exists('configure'):
+                shprint(sh.Command('./autogen.sh'), _env=env)
+            shprint(sh.Command('autoreconf'), '-vif', _env=env)
+            shprint(sh.Command('./configure'),
+                    '--host=' + arch.command_prefix,
+                    '--prefix=' + install_dir,
+                    '--disable-builddir',
+                    '--disable-static',
+                    '--enable-shared',
+
+                    '--disable-xz',
+                    '--disable-xzdec',
+                    '--disable-lzmadec',
+                    '--disable-lzmainfo',
+                    '--disable-scripts',
+                    '--disable-doc',
+
+                    _env=env)
+            shprint(
+                sh.make, '-j', str(cpu_count()),
+                _env=env
+            )
+
+            ensure_dir('install')
+            shprint(sh.make, 'install', _env=env)
+
+    def get_library_includes(self, arch: Arch) -> str:
+        """
+        Returns a string with the appropriate `-I<lib directory>` to link
+        with the lzma lib. This string is usually added to the environment
+        variable `CPPFLAGS`.
+        """
+        return " -I" + join(
+            self.get_build_dir(arch.arch), 'install', 'include',
+        )
+
+    def get_library_ldflags(self, arch: Arch) -> str:
+        """
+        Returns a string with the appropriate `-L<lib directory>` to link
+        with the lzma lib. This string is usually added to the environment
+        variable `LDFLAGS`.
+        """
+        return " -L" + join(
+            self.get_build_dir(arch.arch), self.built_libraries['liblzma.so'],
+        )
+
+    @staticmethod
+    def get_library_libs_flag() -> str:
+        """
+        Returns a string with the appropriate `-l<lib>` flags to link with
+        the lzma lib. This string is usually added to the environment
+        variable `LIBS`.
+        """
+        return " -llzma"
+
+
+recipe = LibLzmaRecipe()

--- a/tests/recipes/test_liblzma.py
+++ b/tests/recipes/test_liblzma.py
@@ -1,0 +1,35 @@
+import unittest
+from os.path import join
+from tests.recipes.recipe_lib_test import BaseTestForMakeRecipe
+
+
+class TestLibLzmaRecipe(BaseTestForMakeRecipe, unittest.TestCase):
+    """TestCase for recipe :mod:`~pythonforandroid.recipes.liblzma`."""
+    recipe_name = "liblzma"
+    sh_command_calls = ["./autogen.sh", "autoreconf", "./configure"]
+
+    def test_get_library_includes(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.liblzma.get_library_includes`.
+        """
+        recipe_build_dir = self.recipe.get_build_dir(self.arch.arch)
+        self.assertEqual(
+            self.recipe.get_library_includes(self.arch),
+            f" -I{join(recipe_build_dir, 'install/include')}",
+        )
+
+    def test_get_library_ldflags(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.liblzma.get_library_ldflags`.
+        """
+        recipe_build_dir = self.recipe.get_build_dir(self.arch.arch)
+        self.assertEqual(
+            self.recipe.get_library_ldflags(self.arch),
+            f" -L{join(recipe_build_dir, 'install/lib')}",
+        )
+
+    def test_link_libs_flags(self):
+        """
+        Test :meth:`~pythonforandroid.recipes.liblzma.get_library_libs_flag`.
+        """
+        self.assertEqual(self.recipe.get_library_libs_flag(), " -llzma")


### PR DESCRIPTION
This is the second part of a set of recipes that will improve our libraries ecosystem, allowing us, in a near future, to build a extra python module: `_lzma.cpython-38.so`, required by some python packages like `pandas`.

**Notes:**
  - tested at #2088
  - this PR is not enough to build the mentioned python module, this will be done at `Compression libraries - episode III`