### PR TITLE
:sparkles: Compression libraries - episode III: add support for libbz2 & liblzma to python3

### DIFF
--- a/pythonforandroid/python.py
+++ b/pythonforandroid/python.py
@@ -169,6 +169,14 @@ class GuestPythonRecipe(TargetPythonRecipe):
             add_flags(recipe.include_flags(arch),
                       recipe.link_dirs_flags(arch), recipe.link_libs_flags())
 
+        for library_name in {'libbz2', 'liblzma'}:
+            if library_name in self.ctx.recipe_build_order:
+                info(f'Activating flags for {library_name}')
+                recipe = Recipe.get_recipe(library_name, self.ctx)
+                add_flags(recipe.get_library_includes(arch),
+                          recipe.get_library_ldflags(arch),
+                          recipe.get_library_libs_flag())
+
         # python build system contains hardcoded zlib version which prevents
         # the build of zlib module, here we search for android's zlib version
         # and sets the right flags, so python can be build with android's zlib

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -6,14 +6,29 @@ from pythonforandroid.patching import version_starts_with
 
 class Python3Recipe(GuestPythonRecipe):
     '''
-    The python3's recipe.
+    The python3's recipe
+    ^^^^^^^^^^^^^^^^^^^^
 
-    .. note:: This recipe can be built only against API 21+. Also, in order to
-        build certain python modules, we need to add some extra recipes to our
-        build requirements:
+    The python 3 recipe can be built with some extra python modules, but do so,
+    we need some libraries. Per default, we ship the python3 recipe with some
+    common libraries, defined at ``depends``.We also support some optional
+    libraries, which are less common that the ones defined at ``depends``, so
+    we added them as optional dependencies (``opt_depends``).
 
-            - ctypes: you must add the recipe for ``libffi``.
+    Below you have a relationship between the python modules and the recipe
+    libraries::
 
+        - _ctypes: you must add the recipe for ``libffi``.
+        - _sqlite3: you must add the recipe for ``sqlite3``.
+        - _ssl: you must add the recipe for ``openssl``.
+        - _bz2: you must add the recipe for ``libbz2`` (optional).
+        - _lzma: you must add the recipe for ``liblzma`` (optional).
+
+    .. note:: This recipe can be built only against API 21+.
+
+    .. versionchanged:: 2019.10.06.post0
+        Added optional dependencies: :mod:`~pythonforandroid.recipes.libbz2`
+        and :mod:`~pythonforandroid.recipes.liblzma`
     .. versionchanged:: 0.6.0
         Refactored into class
         :class:`~pythonforandroid.python.GuestPythonRecipe`

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -9,10 +9,10 @@ class Python3Recipe(GuestPythonRecipe):
     The python3's recipe
     ^^^^^^^^^^^^^^^^^^^^
 
-    The python 3 recipe can be built with some extra python modules, but do so,
-    we need some libraries. Per default, we ship the python3 recipe with some
-    common libraries, defined at ``depends``.We also support some optional
-    libraries, which are less common that the ones defined at ``depends``, so
+    The python 3 recipe can be built with some extra python modules, but to do
+    so, we need some libraries. By default, we ship the python3 recipe with
+    some common libraries, defined in ``depends``. We also support some optional
+    libraries, which are less common that the ones defined in ``depends``, so
     we added them as optional dependencies (``opt_depends``).
 
     Below you have a relationship between the python modules and the recipe

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -39,6 +39,10 @@ class Python3Recipe(GuestPythonRecipe):
         ]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
+    # those optional depends allow us to build python compression modules:
+    #   - _bz2.so
+    #   - _lzma.so
+    opt_depends = ['libbz2', 'liblzma']
     conflicts = ['python2']
 
     configure_args = (


### PR DESCRIPTION
This is the third part and last of a set of recipes that will add add support for libbz2 & liblzma to python3 recipe, allowing us to build some extra python modules:
  - `_bz2.cpython-38.so`
  - `_lzma.cpython-38.so`

Also I put up-to-date the python3 recipe documentation :pencil:

These libraries are required by some python packages, like `pandas`, which I plan to create a PR later :wink:


**Notes:**
  - tested at #2088
  - **this PR should not be merged before previous PRs, named `Compression libraries...`**: #2095 and #2096