### PR TITLE
:arrow_up: Update `pytz` to version `2019.3`

### DIFF
--- a/pythonforandroid/recipes/pytz/__init__.py
+++ b/pythonforandroid/recipes/pytz/__init__.py
@@ -3,8 +3,8 @@ from pythonforandroid.recipe import PythonRecipe
 
 class PytzRecipe(PythonRecipe):
     name = 'pytz'
-    version = '2015.7'
-    url = 'https://pypi.python.org/packages/source/p/pytz/pytz-{version}.tar.bz2'
+    version = '2019.3'
+    url = 'https://pypi.python.org/packages/source/p/pytz/pytz-{version}.tar.gz'
 
     depends = []
 


### PR DESCRIPTION
Because is one of the dependencies of `pandas` recipe #2100,
and despite that the old version seems to work fine,
I think it's better to go for to the latest available version.