### PR TITLE
Fixes linting errors in runnable.py

### DIFF
--- a/pythonforandroid/recipes/android/src/android/runnable.py
+++ b/pythonforandroid/recipes/android/src/android/runnable.py
@@ -1,7 +1,6 @@
 '''
 Runnable
 ========
-
 '''
 
 from jnius import PythonJavaClass, java_method, autoclass
@@ -13,6 +12,7 @@ _PythonActivity = autoclass(JAVA_NAMESPACE + '.PythonActivity')
 # Cache of functions table. In older Android versions the number of JNI references
 # is limited, so by caching them we avoid running out.
 __functionstable__ = {}
+
 
 class Runnable(PythonJavaClass):
     '''Wrapper around Java Runnable class. This class can be used to schedule a
@@ -30,7 +30,6 @@ class Runnable(PythonJavaClass):
         self.args = args
         self.kwargs = kwargs
         Runnable.__runnables__.append(self)
-        
         _PythonActivity.mActivity.runOnUiThread(self)
 
     @java_method('()V')
@@ -42,24 +41,18 @@ class Runnable(PythonJavaClass):
             traceback.print_exc()
 
         Runnable.__runnables__.remove(self)
-        
-        
 
 
 def run_on_ui_thread(f):
     '''Decorator to create automatically a :class:`Runnable` object with the
     function. The function will be delayed and call into the Activity thread.
     '''
-    
     if f not in __functionstable__:
-        
-        rfunction = Runnable(f) #store the runnable function
-        
-        __functionstable__[f] = {"rfunction":rfunction}
-        
+        rfunction = Runnable(f)  # store the runnable function
+        __functionstable__[f] = {"rfunction": rfunction}
     rfunction = __functionstable__[f]["rfunction"]
-    
+
     def f2(*args, **kwargs):
         rfunction(*args, **kwargs)
-            
+
     return f2


### PR DESCRIPTION
https://travis-ci.org/github/kivy/python-for-android/jobs/668867999
```
runnable.py:17:1: E302 expected 2 blank lines, found 1
runnable.py:33:1: W293 blank line contains whitespace
runnable.py:45:1: W293 blank line contains whitespace
runnable.py:46:1: W293 blank line contains whitespace
runnable.py:49:1: E303 too many blank lines (4)
runnable.py:53:1: W293 blank line contains whitespace
runnable.py:55:1: W293 blank line contains whitespace
runnable.py:56:32: E261 at least two spaces before inline comment
runnable.py:56:33: E262 inline comment should start with '# '
runnable.py:57:1: W293 blank line contains whitespace
runnable.py:58:45: E231 missing whitespace after ':'
runnable.py:59:1: W293 blank line contains whitespace
runnable.py:61:1: W293 blank line contains whitespace
runnable.py:64:1: W293 blank line contains whitespace
```