### PR TITLE
Update recommended NDK version to 19c

### DIFF
--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -12,7 +12,7 @@ MIN_NDK_VERSION = 19
 MAX_NDK_VERSION = 20
 
 # DO NOT CHANGE LINE FORMAT: buildozer parses the existence of a RECOMMENDED_NDK_VERSION
-RECOMMENDED_NDK_VERSION = "19b"
+RECOMMENDED_NDK_VERSION = "19c"
 
 NDK_DOWNLOAD_URL = "https://developer.android.com/ndk/downloads/"
 


### PR DESCRIPTION
Probably newer versions are also fine, but making this change in particular because the buildozer download url for 19b no longer exists. I think the 19c one should work fine though.