### PR TITLE
Auto deploys to PyPI using Travis on tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ python_for_android.egg-info
 /build/
 doc/build
 __pycache__/
+venv/
 
 #idea/pycharm
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,15 @@ jobs:
     - <<: *testapps
       name: Rebuild updated recipes
       script: travis_wait 30 make docker/run/make/rebuild_updated_recipes
+
+# Deploy to PyPI using token set in `PYPI_PASSWORD` environment variable
+# https://pypi.org/manage/account/token/
+# https://travis-ci.org/github/kivy/python-for-android/settings
+deploy:
+  provider: pypi
+  distributions: sdist bdist_wheel
+  user: "__token__"
+  on:
+    tags: true
+    repo: kivy/python-for-android
+    python: 3.7


### PR DESCRIPTION
Uses PyPI `__token__` and Travis auto deployment to publish to PyPI
upon tagging.
https://pypi.org/help/#apitoken
Travis uses the not so well documented `PYPI_PASSWORD` environment
variable to store the password.
https://github.com/travis-ci/dpl/blob/v1.10.15/lib/dpl/provider/pypi.rb#L12
The variable was set with a valid token prior this change.
https://travis-ci.org/github/kivy/python-for-android/settings
This is more secure than user and password as tokens are generated with
uploaded only permissions and can be scoped to a given project.