### PR TITLE
Install already compiled libraries

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -576,10 +576,10 @@ def build_recipes(build_order, python_modules, ctx, project_dir,
             info_main('Building {} for {}'.format(recipe.name, arch.arch))
             if recipe.should_build(arch):
                 recipe.build_arch(arch)
-                recipe.install_libraries(arch)
             else:
                 info('{} said it is already built, skipping'
                      .format(recipe.name))
+            recipe.install_libraries(arch)
 
         # 4) biglink everything
         info_main('# Biglinking object files')


### PR DESCRIPTION
If a library is already compiled, skip compilation, but don't skip actually installing the thing.