### PR TITLE
bump zeroconf version to 0.24.5, fix depends

### DIFF
--- a/pythonforandroid/recipes/zeroconf/__init__.py
+++ b/pythonforandroid/recipes/zeroconf/__init__.py
@@ -3,9 +3,9 @@ from pythonforandroid.recipe import PythonRecipe
 
 class ZeroconfRecipe(PythonRecipe):
     name = 'zeroconf'
-    version = '0.17.4'
+    version = '0.24.5'
     url = 'https://pypi.python.org/packages/source/z/zeroconf/zeroconf-{version}.tar.gz'
-    depends = ['setuptools', 'enum34', 'six']
+    depends = ['setuptools', 'ifaddr', 'typing;python_version<"3.5"']
     call_hostpython_via_targetpython = False
 
 


### PR DESCRIPTION
python-zeroconf bumped to 0.24.5(latest version via pip)
package depends only on 'ifaddr' and 'typing'. Special recipes not required