### PR TITLE
Fix coveralls error on GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ virtualenv: $(VIRTUAL_ENV)
 # ignores test_pythonpackage.py since it runs for too long
 test:
 	$(TOX) -- tests/ --ignore tests/test_pythonpackage.py
-	@if test -n "$$CI"; then .tox/py$(PYTHON_MAJOR_MINOR)/bin/coveralls; fi; \
 
 rebuild_updated_recipes: virtualenv
 	. $(ACTIVATE) && \


### PR DESCRIPTION
Coveralls started failing suddenly in GitHub Actions Worflows.
This feels like a bug on their side (at least their documentation)
because the `CI` environment variable is not supposed to be set refs:
https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
Disabling the `coveralls` conditional run from the `Makefile` fixes it.
It wasn't needed as Travis already calls it explicitly without going
through the `test` target.
Error was:
```
/bin/sh: 1: .tox/py36/bin/coveralls: not found
Makefile:30: recipe for target 'test' failed
make: *** [test] Error 127
```