### PR TITLE
recipe: update 'cryptography' and rm unnecessary dependencies

### DIFF
--- a/pythonforandroid/recipes/cryptography/__init__.py
+++ b/pythonforandroid/recipes/cryptography/__init__.py
@@ -3,10 +3,9 @@ from pythonforandroid.recipe import CompiledComponentsPythonRecipe, Recipe
 
 class CryptographyRecipe(CompiledComponentsPythonRecipe):
     name = 'cryptography'
-    version = '2.6.1'
+    version = '2.8'
     url = 'https://github.com/pyca/cryptography/archive/{version}.tar.gz'
-    depends = ['openssl', 'idna', 'asn1crypto', 'six', 'setuptools',
-               'enum34', 'ipaddress', 'cffi']
+    depends = ['openssl', 'six', 'setuptools', 'cffi']
     call_hostpython_via_targetpython = False
 
     def get_recipe_env(self, arch):


### PR DESCRIPTION
Update the `cryptography` recipe to a newer version, and remove unnecessary dependencies.

- `idna` no longer needed [since version 2.5](https://github.com/pyca/cryptography/blob/e687b8f7f40e30ef88e9de889c55cd7fdec99762/CHANGELOG.rst#25---2019-01-22)
- `asn1crypto` no longer needed [since version 2.8](https://github.com/pyca/cryptography/blob/e687b8f7f40e30ef88e9de889c55cd7fdec99762/CHANGELOG.rst#28---2019-10-16)
- `enum34` is just a backport of python 3.4+ functionality
- `ipaddress` is just a backport of python 3.3+ functionality

(I am assuming py2 and old versions of py3 are no longer supported)