### PR TITLE
Bumps cffi==1.13.2 fixes under Python 3.8

### DIFF
--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -7,7 +7,7 @@ class CffiRecipe(CompiledComponentsPythonRecipe):
     Extra system dependencies: autoconf, automake and libtool.
     """
     name = 'cffi'
-    version = '1.11.5'
+    version = '1.13.2'
     url = 'https://pypi.python.org/packages/source/c/cffi/cffi-{version}.tar.gz'
 
     depends = ['setuptools', 'pycparser', 'libffi']


### PR DESCRIPTION
- https://bitbucket.org/cffi/cffi/issues/403/build-fails-on-38-dev-pyinterpreterstate
- https://github.com/kivy/python-for-android/pull/2130#issuecomment-608988477
The error was:
```
c/call_python.c:20:30: error: incomplete definition of type 'struct _is'
```