### PR TITLE
:lock: Bump twisted version to `20.3.0`

### DIFF
--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import CythonRecipe
 
 
 class TwistedRecipe(CythonRecipe):
-    version = '19.7.0'
+    version = '20.3.0'
     url = 'https://github.com/twisted/twisted/archive/twisted-{version}.tar.gz'
 
     depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']


### PR DESCRIPTION
Because of a detected vulnerability with prior versions of twisted:

**See also**: https://github.com/advisories/GHSA-h96w-mmrf-2h6v