### PR TITLE
Update bootstrap.py

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -297,9 +297,6 @@ class Bootstrap:
             libs = glob.glob(join(src_dir, wildcard))
             if libs:
                 shprint(sh.cp, '-a', *libs, tgt_dir)
-            else:
-                debug("No libs found at {}".format(src_dirs))
-                debug("We were trying to copy this folders files to {}".format(tgt_dir))
 
     def distribute_javaclasses(self, javaclass_dir, dest_dir="src"):
         '''Copy existing javaclasses from build dir to current dist dir.'''

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -295,7 +295,11 @@ class Bootstrap:
         ensure_dir(tgt_dir)
         for src_dir in src_dirs:
             libs = glob.glob(join(src_dir, wildcard))
-            shprint(sh.cp, '-a', *libs, tgt_dir)
+            if libs:
+                shprint(sh.cp, '-a', *libs, tgt_dir)
+            else:
+                debug("No libs found at {}".format(src_dirs))
+                debug("We were trying to copy this folders files to {}".format(tgt_dir))
 
     def distribute_javaclasses(self, javaclass_dir, dest_dir="src"):
         '''Copy existing javaclasses from build dir to current dist dir.'''


### PR DESCRIPTION
Try to fix a bug that I meet during compiling.

This is how I met this bug:

### Step 1
Follow this tutorial to build an apk, succeeded.

https://yingshaoxo.blogspot.com/2020/03/how-to-use-docker-to-build-kivy-to.html

### Step 2
Run `p4a clean_dists`, then run the compile command again:
```
p4a apk --private . --package=xyz.yingshaoxo.kivydiary --name "KivyDiary" --version 0.2 --bootstrap=sdl2 --requirements=python3,kivy,jnius --blacklist-requirements=sqlite3,libffi,openssl --orientation=portrait --add-source . --presplash=./data/flash.png --icon=./data/icon.png --permission INTERNET --permission WRITE_EXTERNAL_STORAGE --debug
```

### Step 3
This is the error I got:
```
[INFO]:    *** PYTHON PACKAGE / PROJECT INSTALL STAGE ***
[INFO]:    No Python modules and no setup.py to process, skipping
[INFO]:    # Creating Android project (sdl2)
[INFO]:    Copying SDL2/gradle build for armeabi-v7a
[DEBUG]:   -> running rm -rf /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a
[DEBUG]:   -> running cp -r /home/user/.local/share/python-for-android/build/bootstrap_builds/sdl2 /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a
[INFO]:    -> directory context /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a
[INFO]:    <- directory context /home/user/host/app
[INFO]:    -> directory context /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a
[INFO]:    Copying Python distribution
[INFO]:    Copying libs
[DEBUG]:   -> running cp -a libs/armeabi-v7a
[DEBUG]:   	/bin/cp: missing destination file operand after 'libs/armeabi-v7a'
[DEBUG]:   	Try '/bin/cp --help' for more information.
Exception in thread background thread for pid 19790:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 1540, in wrap
    fn(*args, **kwargs)
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 2459, in background_thread
    handle_exit_code(exit_code)
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 2157, in fn
    return self.command.handle_command_exit_code(exit_code)
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 815, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 

  RAN: /bin/cp -a libs/armeabi-v7a

  STDOUT:
/bin/cp: missing destination file operand after 'libs/armeabi-v7a'
Try '/bin/cp --help' for more information.


  STDERR:


Traceback (most recent call last):
  File "/home/user/app/venv/bin/p4a", line 11, in <module>
    load_entry_point('python-for-android', 'console_scripts', 'p4a')()
  File "/home/user/app/pythonforandroid/entrypoints.py", line 18, in main
    ToolchainCL()
  File "/home/user/app/pythonforandroid/toolchain.py", line 680, in __init__
    getattr(self, args.subparser_name.replace('-', '_'))(args)
  File "/home/user/app/pythonforandroid/toolchain.py", line 154, in wrapper_func
    build_dist_from_args(ctx, dist, args)
  File "/home/user/app/pythonforandroid/toolchain.py", line 216, in build_dist_from_args
    ctx.bootstrap.run_distribute()
  File "/home/user/app/pythonforandroid/bootstraps/sdl2/__init__.py", line 38, in run_distribute
    self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
  File "/home/user/app/pythonforandroid/bootstrap.py", line 298, in distribute_libs
    shprint(sh.cp, '-a', *libs, tgt_dir)
  File "/home/user/app/pythonforandroid/logger.py", line 167, in shprint
    for line in output:
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 863, in next
    self.wait()
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 792, in wait
    self.handle_command_exit_code(exit_code)
  File "/home/user/app/venv/lib/python3.6/site-packages/sh.py", line 815, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 

  RAN: /bin/cp -a libs/armeabi-v7a

  STDOUT:
/bin/cp: missing destination file operand after 'libs/armeabi-v7a'
Try '/bin/cp --help' for more information.


  STDERR:
```

____

But when I modified the `bootstrip.py` as I did in this pull request. Everything works again.