### PR TITLE
Simplifies Dockerfile and fix GitHub runner space

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,6 +52,15 @@ jobs:
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
+    # helps with GitHub runner getting out of space
+    - name: Free disk space
+      run: |
+        df -h
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt -y clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Pull docker image
       run: |
         make docker/pull
@@ -75,6 +84,15 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: 'develop'
+    # helps with GitHub runner getting out of space
+    - name: Free disk space
+      run: |
+        df -h
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt -y clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Pull docker image
       run: |
         make docker/pull

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #   - python-for-android dependencies
 #
 # Build with:
-#     docker build --tag=p4a --file Dockerfile.py3 .
+#     docker build --tag=p4a --file Dockerfile .
 #
 # Run with:
 #     docker run -it --rm p4a /bin/sh -c '. venv/bin/activate && p4a apk --help'
@@ -71,8 +71,6 @@ RUN dpkg --add-architecture i386 \
     openjdk-8-jdk \
     patch \
     pkg-config \
-    python \
-    python-pip \
     python3 \
     python3-dev \
     python3-pip \
@@ -94,10 +92,6 @@ RUN useradd --create-home --shell /bin/bash ${USER}
 # with sudo access and no password
 RUN usermod -append --groups sudo ${USER}
 RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-# install cython for python 2 (for python 3 it's inside the venv)
-RUN pip2 install --upgrade Cython==0.28.6 \
-    && rm -rf ~/.cache/
 
 WORKDIR ${WORK_DIR}
 RUN mkdir ${ANDROID_HOME} && chown --recursive ${USER} ${HOME_DIR} ${ANDROID_HOME}

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docker/pull:
 	docker pull $(DOCKER_IMAGE):latest || true
 
 docker/build:
-	docker build --cache-from=$(DOCKER_IMAGE) --tag=$(DOCKER_IMAGE) --file=Dockerfile.py3 .
+	docker build --cache-from=$(DOCKER_IMAGE) --tag=$(DOCKER_IMAGE) .
 
 docker/push:
 	docker push $(DOCKER_IMAGE)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ python-for-android
 ==================
 
 [![Build Status](https://travis-ci.org/kivy/python-for-android.svg?branch=develop)](https://travis-ci.org/kivy/python-for-android)
+[![Unit tests & build apps](https://github.com/kivy/python-for-android/workflows/Unit%20tests%20&%20build%20apps/badge.svg?branch=develop)](https://github.com/kivy/python-for-android/actions?query=workflow%3A%22Unit+tests+%26+build+apps%22)
 [![Coverage Status](https://coveralls.io/repos/github/kivy/python-for-android/badge.svg?branch=develop&kill_cache=1)](https://coveralls.io/github/kivy/python-for-android?branch=develop)
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)


### PR DESCRIPTION
Simplifies the Dockerfile as Python 2 was dropped.
Renames to default "Dockerfile" so it's picked up by docker hub automatically.
This is a follow-up for: #2105
Adds the GitHub action build badge.

Free up space before building the APKs to avoid the GitHub Action runner being full.
The error was:
```
mkdir -p /home/user/.android/android-ndk-r19b \
&& unzip -q android-ndk-r19b-linux-x86_64.zip -d /home/user/.android \
&& ln -sfn /home/user/.android/android-ndk-r19b /home/user/.android/android-ndk \
&& rm -f android-ndk-r19b-linux-x86_64.zip
Error processing tar file(exit status 1): write /home/user/.android/android-ndk-r19b/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/lib/bfd-plugins/LLVMgold.so: no space left on device
Makefile:61: recipe for target 'docker/build' failed
make: *** [docker/build] Error 1
````
https://github.com/kivy/python-for-android/actions/runs/81658805
The "Free disk space" step could clear about ~10G and helped making the build pass.
See output logs for details.