### PR TITLE
Update AndroidManifest.tmpl.xml to support HTTP

### DIFF
--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -49,7 +49,9 @@
                  android:icon="@drawable/icon"
                  android:allowBackup="true"
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
-                 android:hardwareAccelerated="true" >
+                 android:hardwareAccelerated="true"
+                 android:usesCleartextTraffic="true"
+                 >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />
         {% endfor %}


### PR DESCRIPTION
https://stackoverflow.com/questions/52707918/webview-showing-err-cleartext-not-permitted-although-site-is-https

https://www.google.com/search?q=net%3A%3AERR_CLEARTEXT_NOT_PERMITTED&oq=net%3A%3AERR_CLEARTEXT_NOT_PERMITTED&aqs=chrome..69i57j69i58.788j0j7&sourceid=chrome-mobile&ie=UTF-8

**This is a key update for webview, without it, webview can't work for android 8 and beyond.**