### PR TITLE
Fix a problem with the way we were calling virtualenv

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,7 +767,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-p={}'.format(
+                '-p=python{}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -764,10 +764,10 @@ def run_pymodules_install(ctx, modules, project_dir=None,
             project_has_setup_py(project_dir) and not ignore_setup_py:
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
-    venv = sh.Command('virtualenv')
+    venv = sh.Command('python3')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-p python{}'.format(
+                '-m venv'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -775,7 +775,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
                         ),
                     'venv'
                    )
-        except:
+        except ModuleNotFoundError:
             shprint(venv,
                     '-m virtualenv --python={}'.format(
                         ctx.python_recipe.major_minor_version_string.

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -765,7 +765,6 @@ def run_pymodules_install(ctx, modules, project_dir=None,
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
     venv = sh.Command('python3')
-    
     with current_directory(join(ctx.build_dir)):
         try:
             shprint(venv,

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,7 +767,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('python3')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-m virtualenv --python {}'.format(
+                '-m virtualenv --python={}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,7 +767,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('python3')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-m virtualenv --python={}'.format(
+                '-m venv --python={}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -783,8 +783,6 @@ def run_pymodules_install(ctx, modules, project_dir=None,
                         ),
                     'venv'
                    )
-            
-
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,10 +767,6 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-p=python{}'.format(
-                    ctx.python_recipe.major_minor_version_string.
-                    partition(".")[0]
-                    ),
                 'venv'
                )
         # Prepare base environment and upgrade pip:

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,11 +767,11 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                 '-p python{}'.format(
-                    ctx.python_recipe.major_minor_version_string.
-                    partition(".")[0]
-                    ),
-                'venv'
+            '-p python{}'.format(
+                ctx.python_recipe.major_minor_version_string.
+                partition(".")[0]
+            ),
+            'venv'
                )
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -765,14 +765,25 @@ def run_pymodules_install(ctx, modules, project_dir=None,
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
     venv = sh.Command('python3')
+    
     with current_directory(join(ctx.build_dir)):
-        shprint(venv,
-                '-m venv --python={}'.format(
-                    ctx.python_recipe.major_minor_version_string.
-                    partition(".")[0]
-                    ),
-                'venv'
-               )
+        try:
+            shprint(venv,
+                    '-m venv --python={}'.format(
+                        ctx.python_recipe.major_minor_version_string.
+                        partition(".")[0]
+                        ),
+                    'venv'
+                   )
+         except:
+            shprint(venv,
+                    '-m virtualenv --python={}'.format(
+                        ctx.python_recipe.major_minor_version_string.
+                        partition(".")[0]
+                        ),
+                    'venv'
+                   )
+            
 
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,7 +767,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '-p=python{}'.format(
+                '-p python{}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -767,6 +767,10 @@ def run_pymodules_install(ctx, modules, project_dir=None,
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
+                 '-p python{}'.format(
+                    ctx.python_recipe.major_minor_version_string.
+                    partition(".")[0]
+                    ),
                 'venv'
                )
         # Prepare base environment and upgrade pip:

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -765,7 +765,6 @@ def run_pymodules_install(ctx, modules, project_dir=None,
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
     venv = sh.Command('python3')
-   
     with current_directory(join(ctx.build_dir)):
         try:
             shprint(venv,
@@ -783,7 +782,6 @@ def run_pymodules_install(ctx, modules, project_dir=None,
                         ),
                     'venv'
                    )
-            
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -764,24 +764,16 @@ def run_pymodules_install(ctx, modules, project_dir=None,
             project_has_setup_py(project_dir) and not ignore_setup_py:
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
-    venv = sh.Command('python3')
-    with current_directory(join(ctx.build_dir)):
-        try:
-            shprint(venv,
-                    '-m venv --python={}'.format(
-                        ctx.python_recipe.major_minor_version_string.
-                        partition(".")[0]
-                        ),
-                    'venv'
-                   )
-        except ModuleNotFoundError:
-            shprint(venv,
-                    '-m virtualenv --python={}'.format(
-                        ctx.python_recipe.major_minor_version_string.
-                        partition(".")[0]
-                        ),
-                    'venv'
-                   )
+    venv = sh.Command('virtualenv')
+       
+    shprint(venv,
+            '-p={}'.format(
+                ctx.python_recipe.major_minor_version_string.
+                partition(".")[0]
+                ),
+            'venv'
+           )
+ 
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -765,15 +765,14 @@ def run_pymodules_install(ctx, modules, project_dir=None,
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
     venv = sh.Command('virtualenv')
-       
-    shprint(venv,
-            '-p={}'.format(
-                ctx.python_recipe.major_minor_version_string.
-                partition(".")[0]
-                ),
-            'venv'
-           )
- 
+    with current_directory(join(ctx.build_dir)):
+        shprint(venv,
+                '-p={}'.format(
+                    ctx.python_recipe.major_minor_version_string.
+                    partition(".")[0]
+                    ),
+                'venv'
+               )
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -764,11 +764,10 @@ def run_pymodules_install(ctx, modules, project_dir=None,
             project_has_setup_py(project_dir) and not ignore_setup_py:
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
-
-    venv = sh.Command(ctx.virtualenv)
+    venv = sh.Command('python3')
     with current_directory(join(ctx.build_dir)):
         shprint(venv,
-                '--python=python{}'.format(
+                '-m virtualenv --python {}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -765,14 +765,25 @@ def run_pymodules_install(ctx, modules, project_dir=None,
         info('Will process project install, if it fails then the '
              'project may not be compatible for Android install.')
     venv = sh.Command('python3')
+   
     with current_directory(join(ctx.build_dir)):
-        shprint(venv,
-                '-m venv'.format(
-                    ctx.python_recipe.major_minor_version_string.
-                    partition(".")[0]
-                    ),
-                'venv'
-               )
+        try:
+            shprint(venv,
+                    '-m venv'.format(
+                        ctx.python_recipe.major_minor_version_string.
+                        partition(".")[0]
+                        ),
+                    'venv'
+                   )
+        except sh.ErrorReturnCode_1:
+            shprint(venv,
+                    '-m virtualenv'.format(
+                        ctx.python_recipe.major_minor_version_string.
+                        partition(".")[0]
+                        ),
+                    'venv'
+                   )
+            
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -766,13 +766,14 @@ def run_pymodules_install(ctx, modules, project_dir=None,
              'project may not be compatible for Android install.')
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
-        shprint(venv,
-            '-p python{}'.format(
-                ctx.python_recipe.major_minor_version_string.
-                partition(".")[0]
-            ),
-            'venv'
-               )
+        shprint(venv
+            '-p=python{}'.format(
+                    ctx.python_recipe.major_minor_version_string.
+                    partition(".")[0]
+                    ),
+                'venv'
+               )                
+             )
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -766,14 +766,13 @@ def run_pymodules_install(ctx, modules, project_dir=None,
              'project may not be compatible for Android install.')
     venv = sh.Command('virtualenv')
     with current_directory(join(ctx.build_dir)):
-        shprint(venv
-            '-p=python{}'.format(
+        shprint(venv,
+                '-p=python{}'.format(
                     ctx.python_recipe.major_minor_version_string.
                     partition(".")[0]
                     ),
                 'venv'
-               )                
-             )
+               )
         # Prepare base environment and upgrade pip:
         base_env = copy.copy(os.environ)
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir()

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -775,7 +775,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
                         ),
                     'venv'
                    )
-         except:
+        except:
             shprint(venv,
                     '-m virtualenv --python={}'.format(
                         ctx.python_recipe.major_minor_version_string.


### PR DESCRIPTION
This PR fixes a problem where any buildozer build errors with `Can not import virtualenv.__main__; virtualenv is not a package` as I tested and when I made this modification it worked.