### PR TITLE
Twisted recipe

### DIFF
--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 from pythonforandroid.recipe import CythonRecipe
 
 
@@ -6,7 +9,7 @@ class TwistedRecipe(CythonRecipe):
     url = 'https://github.com/twisted/twisted/archive/twisted-{version}.tar.gz'
 
     depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']
-    patches = ['incremental.patch']
+    patches = ['incremental.patch', 'remove_tests.patch']
 
     call_hostpython_via_targetpython = False
     install_in_hostpython = False
@@ -14,7 +17,13 @@ class TwistedRecipe(CythonRecipe):
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)
         # TODO Need to whitelist tty.pyo and termios.so here
-        print('Should remove twisted tests etc. here, but skipping for now')
+
+        # remove the unit test dirs
+        source_dir = os.path.join(self.get_build_dir(arch.arch), 'src/twisted')
+        for item in os.walk(source_dir):
+            if os.path.basename(item[0]) == 'test':
+                full_path = os.path.join(source_dir, item[0])
+                shutil.rmtree(full_path, ignore_errors=True)
 
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)

--- a/pythonforandroid/recipes/twisted/remove_tests.patch
+++ b/pythonforandroid/recipes/twisted/remove_tests.patch
@@ -1,0 +1,16 @@
+diff --git a/src/twisted/python/_setup.py b/src/twisted/python/_setup.py
+index 32cb096c7..a607fef07 100644
+--- a/src/twisted/python/_setup.py
++++ b/src/twisted/python/_setup.py
+@@ -160,11 +160,6 @@ class ConditionalExtension(Extension, object):
+ 
+ # The C extensions used for Twisted.
+ _EXTENSIONS = [
+-    ConditionalExtension(
+-        "twisted.test.raiser",
+-        sources=["src/twisted/test/raiser.c"],
+-        condition=lambda _: _isCPython),
+-
+     ConditionalExtension(
+         "twisted.internet.iocpreactor.iocpsupport",
+         sources=[


### PR DESCRIPTION
Update of the recipe for Twisted so that it removes the unit tests in the `prebuild_arch` hook. This should decrease the size from 11 down to 4 MB for the uncompressed APK directory.