### PR TITLE
When bootstraps were unified, sources moved from src to src/main/java…

### DIFF
--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -34,7 +34,8 @@ class ServiceOnlyBootstrap(Bootstrap):
 
             self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
             self.distribute_aars(arch)
-            self.distribute_javaclasses(self.ctx.javaclass_dir)
+            self.distribute_javaclasses(self.ctx.javaclass_dir,
+                                        dest_dir=join("src", "main", "java"))
 
             python_bundle_dir = join('_python_bundle', '_python_bundle')
             ensure_dir(python_bundle_dir)

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -31,7 +31,8 @@ class WebViewBootstrap(Bootstrap):
 
             self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
             self.distribute_aars(arch)
-            self.distribute_javaclasses(self.ctx.javaclass_dir)
+            self.distribute_javaclasses(self.ctx.javaclass_dir,
+                                        dest_dir=join("src", "main", "java"))
 
             python_bundle_dir = join('_python_bundle', '_python_bundle')
             ensure_dir(python_bundle_dir)


### PR DESCRIPTION
… for webview and service boostraps, so copy `self.ctx.javaclass_dir` sources there as well.

This is needed for jnius, as it adds `org.jnius.NativeInvocationHandler` to `self.ctx.javaclass_dir`, but currently those sources get copied to the old root dir, `src`, rather than the current `src/main/java`, which causes `jnius` to be unable to find that file.