### PR TITLE
Compile version SDK should match target SDK so webview can support Android versions 5-10.

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -163,7 +163,7 @@ class Bootstrap:
 
         with current_directory(self.build_dir):
             with open('project.properties', 'w') as fileh:
-                fileh.write('target=android-{}'.format(self.ctx.android_api))
+                fileh.write('target=android-{}'.format(self.ctx.ndk_api))
 
     def prepare_dist_dir(self):
         ensure_dir(self.dist_dir)

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -422,17 +422,20 @@ main.py that loads it.''')
         )
 
     # Find the SDK directory and target API
-    with open('project.properties', 'r') as fileh:
-        target = fileh.read().strip()
-    android_api = target.split('-')[1]
-    try:
-        int(android_api)
-    except (ValueError, TypeError):
-        raise ValueError(
-            "failed to extract the Android API level from " +
-            "build.properties. expected int, got: '" +
-            str(android_api) + "'"
-        )
+    if 'ANDROIDAPI' in os.environ:
+        android_api = os.environ['ANDROID_API']
+    else:
+        with open('project.properties', 'r') as fileh:
+            target = fileh.read().strip()
+        android_api = target.split('-')[1]
+        try:
+            int(android_api)
+        except (ValueError, TypeError):
+            raise ValueError(
+                "failed to extract the Android API level from " +
+                "build.properties. expected int, got: '" +
+                str(android_api) + "'"
+            )
     with open('local.properties', 'r') as fileh:
         sdk_dir = fileh.read().strip()
     sdk_dir = sdk_dir[8:]


### PR DESCRIPTION
How to reproduce this problem on current develop:

1. Compile with `usesClearTextTraffic` property in `AndroidManifest.xml`, and find it requires a min SDK of 26 to compile since it was added in that SDK. 
2. Run the built apk on a device with Android 5-7 and get missing symbol errors. 

We've most commonly seen ones about `DT_HASH`, but there are several that could appear, based on NDK backwards-incompatible changes listed here:

https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md

This PR changes the `compileSDKVersion` to match the `targetSDKVersion` in order to allow us to use features like `usesClearTextTraffic` while still maintaining compatible down to the min SDK version (21).