### PR TITLE
Get --add-source working for dirs in Gradle builds

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -381,8 +381,8 @@ main.py that loads it.''')
             if ':' in spec:
                 specdir, specincludes = spec.split(':')
                 print('WARNING: Currently gradle builds only support including source '
-                      'directories, so when building using gradle, all files in '
-                      '{} will be incldued.',format(specdir))
+                      'directories, so when building using gradle all files in '
+                      '{} will be included.'.format(specdir))
             else:
                 specdir = spec
                 specincludes = '**'

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -380,6 +380,9 @@ main.py that loads it.''')
         for spec in args.extra_source_dirs:
             if ':' in spec:
                 specdir, specincludes = spec.split(':')
+                print('WARNING: Currently gradle builds only support including source '
+                      'directories, so when building using gradle, all files in '
+                      '{} will be incldued.',format(specdir))
             else:
                 specdir = spec
                 specincludes = '**'

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -85,6 +85,13 @@ android {
     sourceSets {
         main {
             jniLibs.srcDir 'libs'
+            java {
+
+                {%- for adir, pattern in args.extra_source_dirs -%}
+                    srcDir '{{adir}}'
+                {%- endfor -%}
+
+            }
         }
     }
 


### PR DESCRIPTION
I had trouble making the file patterns work using `include` (no errors, but files didn't get included). However, this approach works for specifying source directories, which was our use case. Figured I'd post what we have now and see if anyone knows how to fix the patterns case, or knows if that case is used often? 