### PR TITLE
Fixes hostpython build with macOS venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         # installs java 1.8, android's SDK/NDK and p4a
         - make -f ci/makefiles/osx.mk
         - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-      script: make testapps-no-venv/armeabi-v7a
+      script: make testapps/armeabi-v7a
     - <<: *testapps
       name: Rebuild updated recipes
       script: travis_wait 30 make docker/run/make/rebuild_updated_recipes

--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,6 @@ testapps/%: virtualenv
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
     --arch=$($@_APP_ARCH)
 
-testapps-no-venv/%:
-	pip3 install Cython==0.28.6
-	pip3 install -e .
-	$(eval $@_APP_ARCH := $(shell basename $*))
-	cd testapps/on_device_unit_tests/ && \
-    python3 setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --arch=$($@_APP_ARCH)
-
 clean:
 	find . -type d -name "__pycache__" -exec rm -r {} +
 	find . -type d -name "*.egg-info" -exec rm -r {} +

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -4,6 +4,7 @@ from multiprocessing import cpu_count
 from os.path import exists, join, isfile
 
 from pythonforandroid.logger import shprint
+from pythonforandroid.patching import is_version_lt
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import (
     BuildInterruptingException,
@@ -34,6 +35,10 @@ class Hostpython3Recipe(Recipe):
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     '''The default url to download our host python recipe. This url will
     change depending on the python version set in attribute :attr:`version`.'''
+
+    patches = (
+        ('patches/pyconfig_detection.patch', is_version_lt("3.8.3")),
+    )
 
     @property
     def _exe_name(self):

--- a/pythonforandroid/recipes/hostpython3/patches/pyconfig_detection.patch
+++ b/pythonforandroid/recipes/hostpython3/patches/pyconfig_detection.patch
@@ -1,0 +1,13 @@
+diff -Nru Python-3.8.2/Lib/site.py Python-3.8.2-new/Lib/site.py
+--- Python-3.8.2/Lib/site.py    2020-04-28 12:48:38.000000000 -0700
++++ Python-3.8.2-new/Lib/site.py        2020-04-28 12:52:46.000000000 -0700
+@@ -487,7 +487,8 @@
+                     if key == 'include-system-site-packages':
+                         system_site = value.lower()
+                     elif key == 'home':
+-                        sys._home = value
++                        # this is breaking pyconfig.h path detection with venv
++                        print('Ignoring "sys._home = value" override')
+ 
+         sys.prefix = sys.exec_prefix = site_prefix
+ 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -8,7 +8,7 @@ from os.path import dirname, exists, join, isfile
 from shutil import copy2
 
 from pythonforandroid.logger import info, warning, shprint
-from pythonforandroid.patching import version_starts_with
+from pythonforandroid.patching import version_starts_with, is_version_lt
 from pythonforandroid.recipe import Recipe, TargetPythonRecipe
 from pythonforandroid.util import (
     current_directory,
@@ -55,6 +55,8 @@ class Python3Recipe(TargetPythonRecipe):
     name = 'python3'
 
     patches = [
+        ('patches/pyconfig_detection.patch', is_version_lt("3.8.3")),
+
         # Python 3.7.1
         ('patches/py3.7.1_fix-ctypes-util-find-library.patch', version_starts_with("3.7")),
         ('patches/py3.7.1_fix-zlib-version.patch', version_starts_with("3.7")),

--- a/pythonforandroid/recipes/python3/patches/pyconfig_detection.patch
+++ b/pythonforandroid/recipes/python3/patches/pyconfig_detection.patch
@@ -1,0 +1,13 @@
+diff -Nru Python-3.8.2/Lib/site.py Python-3.8.2-new/Lib/site.py
+--- Python-3.8.2/Lib/site.py    2020-04-28 12:48:38.000000000 -0700
++++ Python-3.8.2-new/Lib/site.py        2020-04-28 12:52:46.000000000 -0700
+@@ -487,7 +487,8 @@
+                     if key == 'include-system-site-packages':
+                         system_site = value.lower()
+                     elif key == 'home':
+-                        sys._home = value
++                        # this is breaking pyconfig.h path detection with venv
++                        print('Ignoring "sys._home = value" override')
+ 
+         sys.prefix = sys.exec_prefix = site_prefix
+ 


### PR DESCRIPTION
Running the freshly compiled host python binary from another Python
process (e.g. sh module or os.system()) may get wrongly detected as
if it was ran directly from the venv.
This happens when `pyvenv.cfg` is present (e.g. venv/pyvenv.cfg).
It makes `sysconfig.is_python_build()` returns `False` instead of `True`
since it's using the compiled interpreter (e.g. ./build-dir/python).
https://docs.python.org/3/library/sysconfig.html#sysconfig.is_python_build
https://github.com/python/cpython/blob/v3.8.2/Lib/sysconfig.py#L127
This is because the `sys._home` attribute is used during the detection.
The issue was first seen in macOS venv which generates the `pyvenv.cfg`.
To compare both behaviours, try the following within and without a venv:
```python
import os
os.system("./build-dir/python -E -c 'import sysconfig; print(sysconfig._sys_home)'")
```
One would return `/usr/local/bin` and the other `None`

Refs:
- https://github.com/kivy/kivy-ios/issues/401
- https://github.com/kivy/python-for-android/pull/2063