### PR TITLE
Adds pygame recipe

### DIFF
--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -1,0 +1,64 @@
+from os.path import join
+
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+from pythonforandroid.toolchain import current_directory
+
+
+class Pygame2Recipe(CompiledComponentsPythonRecipe):
+    """
+    Recipe to build apps based on SDL2-based pygame.
+
+    .. warning:: Some pygame functionality is still untested, and some
+        dependencies like freetype, postmidi and libjpeg are currently
+        not part of the build. It's usable, but not complete.
+    """
+
+    version = '2.0.0-dev7'
+    url = 'https://github.com/pygame/pygame/archive/android-{version}.tar.gz'
+
+    site_packages_name = 'pygame'
+    name = 'pygame'
+
+    depends = ['sdl2', 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf', 'setuptools', 'jpeg', 'png']
+    call_hostpython_via_targetpython = False  # Due to setuptools
+    install_in_hostpython = False
+
+    def prebuild_arch(self, arch):
+        super().prebuild_arch(arch)
+        with current_directory(self.get_build_dir(arch.arch)):
+            setup_template = open(join("buildconfig", "Setup.Android.SDL2.in")).read()
+            env = self.get_recipe_env(arch)
+            env['ANDROID_ROOT'] = join(self.ctx.ndk_platform, 'usr')
+
+            ndk_lib_dir = join(self.ctx.ndk_platform, 'usr', 'lib')
+
+            png = self.get_recipe('png', self.ctx)
+            png_lib_dir = join(png.get_build_dir(arch.arch), '.libs')
+            png_inc_dir = png.get_build_dir(arch)
+
+            jpeg = self.get_recipe('jpeg', self.ctx)
+            jpeg_inc_dir = jpeg_lib_dir = jpeg.get_build_dir(arch.arch)
+
+            setup_file = setup_template.format(
+                sdl_includes=(
+                    " -I" + join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include') +
+                    " -L" + join(self.ctx.bootstrap.build_dir, "libs", str(arch)) +
+                    " -L" + png_lib_dir + " -L" + jpeg_lib_dir + " -L" + ndk_lib_dir),
+                sdl_ttf_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
+                sdl_image_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_image'),
+                sdl_mixer_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer'),
+                jpeg_includes="-I"+jpeg_inc_dir,
+                png_includes="-I"+png_inc_dir,
+                freetype_includes=""
+            )
+            open("Setup", "w").write(setup_file)
+
+    def get_recipe_env(self, arch):
+        env = super().get_recipe_env(arch)
+        env['USE_SDL2'] = '1'
+        env["PYGAME_CROSS_COMPILE"] = "TRUE"
+        env["PYGAME_ANDROID"] = "TRUE"
+        return env
+
+
+recipe = Pygame2Recipe()


### PR DESCRIPTION
Edit: this authored by @robertpfeiffer I've just copy/pasted his description in the commit message, rebased and made few edits to give an example of what the PR could look like.

As discussed on the Discord, this is a recipe to build apps based on
SDL2-based pygame.

It currently references https://github.com/pygame/pygame/tree/android,
a branch that will continue to live until we have an official stable
release of pygame based on SDL2 with android support.

Simple examples have been tested by other pygame users (it doesn't just
build on my own machine) but some pygame functionality is still untested,
and some dependencies like freetype, postmidi and libjpeg are currently
not part of the build. It's usable, but not complete.