### PR TITLE
Narrows some context manager scopes

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -11,6 +11,7 @@ import re
 import sh
 import shutil
 import subprocess
+from contextlib import suppress
 
 from pythonforandroid.util import (
     current_directory, ensure_dir,
@@ -621,10 +622,8 @@ def run_setuppy_install(ctx, project_dir, env=None):
             ),
             "freeze"
         ], env=copy.copy(env))
-        try:
+        with suppress(AttributeError):
             constraints = constraints.decode("utf-8", "replace")
-        except AttributeError:
-            pass
         info(constraints)
 
         # Make sure all packages found are fixed in version

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -956,9 +956,9 @@ class PythonRecipe(Recipe):
 
         info('Installing {} into site-packages'.format(self.name))
 
+        hostpython = sh.Command(self.hostpython_location)
+        hpenv = env.copy()
         with current_directory(self.get_build_dir(arch.arch)):
-            hostpython = sh.Command(self.hostpython_location)
-            hpenv = env.copy()
             shprint(hostpython, 'setup.py', 'install', '-O2',
                     '--root={}'.format(self.ctx.get_python_install_dir()),
                     '--install-lib=.',
@@ -999,8 +999,8 @@ class CompiledComponentsPythonRecipe(PythonRecipe):
         info('Building compiled components in {}'.format(self.name))
 
         env = self.get_recipe_env(arch)
+        hostpython = sh.Command(self.hostpython_location)
         with current_directory(self.get_build_dir(arch.arch)):
-            hostpython = sh.Command(self.hostpython_location)
             if self.install_in_hostpython:
                 shprint(hostpython, 'setup.py', 'clean', '--all', _env=env)
             shprint(hostpython, 'setup.py', self.build_cmd, '-v',

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -86,12 +86,12 @@ class Hostpython3Recipe(Recipe):
         build_dir = join(recipe_build_dir, self.build_subdir)
         ensure_dir(build_dir)
 
-        with current_directory(recipe_build_dir):
-            # Configure the build
-            with current_directory(build_dir):
-                if not exists('config.status'):
-                    shprint(sh.Command(join(recipe_build_dir, 'configure')))
+        # Configure the build
+        with current_directory(build_dir):
+            if not exists('config.status'):
+                shprint(sh.Command(join(recipe_build_dir, 'configure')))
 
+        with current_directory(recipe_build_dir):
             # Create the Setup file. This copying from Setup.dist is
             # the normal and expected procedure before Python 3.8, but
             # after this the file with default options is already named "Setup"

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -283,14 +283,14 @@ class Python3Recipe(TargetPythonRecipe):
         sys_prefix = '/usr/local'
         sys_exec_prefix = '/usr/local'
 
+        env = self.get_recipe_env(arch)
+        env = self.set_libs_flags(env, arch)
+
+        android_build = sh.Command(
+            join(recipe_build_dir,
+                 'config.guess'))().stdout.strip().decode('utf-8')
+
         with current_directory(build_dir):
-            env = self.get_recipe_env(arch)
-            env = self.set_libs_flags(env, arch)
-
-            android_build = sh.Command(
-                join(recipe_build_dir,
-                     'config.guess'))().stdout.strip().decode('utf-8')
-
             if not exists('config.status'):
                 shprint(
                     sh.Command(join(recipe_build_dir, 'configure')),

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1051,7 +1051,7 @@ class ToolchainCL:
                     "Unknown build mode {} for apk()".format(args.build_mode))
             output = shprint(gradlew, gradle_task, _tail=20,
                              _critical=True, _env=env)
-            return output, build_args
+        return output, build_args
 
     def _finish_package(self, args, output, build_args, package_type, output_dir):
         """


### PR DESCRIPTION
Tries to keep the `current_directory` context manager as scoped as
possible. Also use the `contextlib.suppress` context manager when
appropriated as it's more concise.