### PR TITLE
Fixes service only unittest loading

### DIFF
--- a/testapps/on_device_unit_tests/test_app/main.py
+++ b/testapps/on_device_unit_tests/test_app/main.py
@@ -92,5 +92,5 @@ elif 'flask' in requirements:
 else:
     # we don't have kivy or flask in our
     # requirements, so we run unittests in terminal
-    suite = unittest.TestLoader().loadTestsFromNames(list(tests_to_perform))
+    suite = unittest.TestLoader().loadTestsFromNames(list(tests_to_perform.values()))
     unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
See adb logcat trace after the fix:
```
Android kivy bootstrap done. __name__ is __main__
AND: Ran string
Run user program, change dir and execute entrypoint
Imported unittest
App requirements are:  {'sqlite3', 'python3', 'openssl', 'requests', 'pyjnius', 'libffi'}
Defined test case
Adding Testcase:  tests.test_requirements.Sqlite3TestCase
Adding Testcase:  tests.test_requirements.OpensslTestCase
Adding Testcase:  tests.test_requirements.RequestsTestCase
Adding Testcase:  tests.test_requirements.PyjniusTestCase
Adding Testcase:  tests.test_requirements.LibffiTestCase
Tests to perform are:  {'sqlite3': 'tests.test_requirements.Sqlite3TestCase', 'openssl': 'tests.test_requirements.OpensslTestCase', 'requests': 'tests.test_requirements.RequestsTestCase', 'pyjnius': 'tests.test_requirements.PyjniusTestCase', 'libffi': 'tests.test_requirements.LibffiTestCase'}
..........
----------------------------------------------------------------------
Ran 10 tests in 4.130s

OK
Python for android ended.
```