### PR TITLE
Java code linting using PMD 6.23.0

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import android.util.Log;
 import java.util.ArrayList;
-import java.io.FilenameFilter;
 import java.util.regex.Pattern;
 
 
@@ -45,7 +44,6 @@ public class PythonUtil {
     }
 
     public static void loadLibraries(File filesDir, File libsDir) {
-        String filesDirPath = filesDir.getAbsolutePath();
         boolean foundPython = false;
 
         for (String lib : getLibraries(libsDir)) {
@@ -61,7 +59,7 @@ public class PythonUtil {
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
                 if (lib.startsWith("python3.8") && !foundPython) {
-                    throw new java.lang.RuntimeException("Could not load any libpythonXXX.so");
+                    throw new RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;
                 } else {

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/AssetExtract.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/AssetExtract.java
@@ -2,8 +2,6 @@
 // spaces amount
 package org.renpy.android;
 
-import java.io.*;
-
 import android.content.Context;
 import android.util.Log;
 
@@ -11,15 +9,16 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.FileInputStream;
+import java.io.OutputStream;
 import java.io.FileOutputStream;
+import java.io.FileNotFoundException;
 import java.io.File;
 
 import java.util.zip.GZIPInputStream;
 
 import android.content.res.AssetManager;
-
-import org.kamranzafar.jtar.*;
+import org.kamranzafar.jtar.TarEntry;
+import org.kamranzafar.jtar.TarInputStream;
 
 public class AssetExtract {
 
@@ -49,7 +48,7 @@ public class AssetExtract {
 
             try {
                 entry = tis.getNextEntry();
-            } catch ( java.io.IOException e ) {
+            } catch ( IOException e ) {
                 Log.e("python", "extracting tar", e);
                 return false;
             }
@@ -95,7 +94,7 @@ public class AssetExtract {
 
                 out.flush();
                 out.close();
-            } catch ( java.io.IOException e ) {
+            } catch ( IOException e ) {
                 Log.e("python", "extracting zip", e);
                 return false;
             }

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/Hardware.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/Hardware.java
@@ -8,11 +8,9 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.DisplayMetrics;
 import android.view.inputmethod.InputMethodManager;
-import android.view.inputmethod.EditorInfo;
 import android.view.View;
 
 import java.util.List;
-import java.util.ArrayList;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiManager;
 import android.content.BroadcastReceiver;
@@ -223,9 +221,6 @@ public class Hardware {
 
         // Now you can call this and it should execute the broadcastReceiver's
         // onReceive()
-        WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-        boolean a = wm.startScan();
-
         if (latestResult != null){
 
             String latestResultString = "";

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -8,7 +8,6 @@ import java.io.FileWriter;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.UnsatisfiedLinkError;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -21,26 +20,19 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ApplicationInfo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
-import android.Manifest;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
-import android.view.SurfaceHolder;
 import android.view.SurfaceView;
-import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
-import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.Toast;
 
-import org.libsdl.app.SDL;
 import org.libsdl.app.SDLActivity;
 
 import org.kivy.android.PythonUtil;
@@ -58,7 +50,6 @@ public class PythonActivity extends SDLActivity {
     private ResourceManager resourceManager = null;
     private Bundle mMetaData = null;
     private PowerManager.WakeLock mWakeLock = null;
-    private static boolean appliedWindowedModeHack = false;
 
     public String getAppRoot() {
         String app_root =  getFilesDir().getAbsolutePath() + "/app";
@@ -393,7 +384,6 @@ public class PythonActivity extends SDLActivity {
             ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
-        String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);
@@ -646,7 +636,7 @@ public class PythonActivity extends SDLActivity {
 
         try {
             java.lang.reflect.Method methodCheckPermission =
-                Activity.class.getMethod("checkSelfPermission", java.lang.String.class);
+                Activity.class.getMethod("checkSelfPermission", String.class);
             Object resultObj = methodCheckPermission.invoke(this, permission);
             int result = Integer.parseInt(resultObj.toString());
             if (result == PackageManager.PERMISSION_GRANTED) 
@@ -666,7 +656,7 @@ public class PythonActivity extends SDLActivity {
         try {
             java.lang.reflect.Method methodRequestPermission =
                 Activity.class.getMethod("requestPermissions",
-                java.lang.String[].class, int.class);
+                String[].class, int.class);
             methodRequestPermission.invoke(this, permissions, requestCode);
         } catch (IllegalAccessException | NoSuchMethodException |
                  InvocationTargetException e) {

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import android.util.Log;
 import java.util.ArrayList;
-import java.io.FilenameFilter;
 import java.util.regex.Pattern;
 
 public class PythonUtil {
@@ -49,7 +48,6 @@ public class PythonUtil {
     }
 
     public static void loadLibraries(File filesDir, File libsDir) {
-        String filesDirPath = filesDir.getAbsolutePath();
         boolean foundPython = false;
 
         for (String lib : getLibraries(libsDir)) {
@@ -65,7 +63,7 @@ public class PythonUtil {
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
                 if (lib.startsWith("python3.8") && !foundPython) {
-                    throw new java.lang.RuntimeException("Could not load any libpythonXXX.so");
+                    throw new RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;
                 } else {

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/launcher/ProjectAdapter.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/launcher/ProjectAdapter.java
@@ -1,29 +1,20 @@
 package org.kivy.android.launcher;
 
 import android.app.Activity;
-import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Gravity;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
-import android.widget.LinearLayout;
 import android.widget.ImageView;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.util.Log;
 
 import org.renpy.android.ResourceManager;
 
 public class ProjectAdapter extends ArrayAdapter<Project> {
 
-    private Activity mContext;
     private ResourceManager resourceManager;
     
     public ProjectAdapter(Activity context) {
         super(context, 0);
-
-        mContext = context;
         resourceManager = new ResourceManager(context);
     }
 

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/launcher/ProjectChooser.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/launcher/ProjectChooser.java
@@ -1,11 +1,8 @@
 package org.kivy.android.launcher;
 
 import android.app.Activity;
-import android.os.Bundle;
 
 import android.content.Intent;
-import android.content.res.Resources;
-import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -13,7 +10,6 @@ import android.widget.AdapterView;
 import android.os.Environment;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import android.net.Uri;
 

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -1,51 +1,25 @@
 
 package org.kivy.android;
 
-import java.net.Socket;
-import java.net.InetSocketAddress;
-
 import android.os.SystemClock;
 
 import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 
-import android.app.*;
-import android.content.*;
-import android.view.*;
-import android.view.SurfaceView;
 import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
 import android.widget.Toast;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
-import android.graphics.PixelFormat;
-import android.view.SurfaceHolder;
 import android.content.Context;
-import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ApplicationInfo;
-import android.content.Intent;
-import android.widget.ImageView;
-import java.io.InputStream;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Color;
-
-import android.widget.AbsoluteLayout;
-
-import android.webkit.WebViewClient;
-import android.webkit.WebView;
-
 import org.kivy.android.PythonUtil;
 
 import org.renpy.android.ResourceManager;
@@ -408,7 +382,6 @@ public class PythonActivity extends Activity {
             ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
-        String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -1,15 +1,10 @@
-
 package org.kivy.android;
-
-import java.net.Socket;
-import java.net.InetSocketAddress;
 
 import android.os.SystemClock;
 
 import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -17,11 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 
-import android.app.*;
-import android.content.*;
-import android.view.*;
 import android.view.ViewGroup;
-import android.view.SurfaceView;
 import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
@@ -29,15 +20,9 @@ import android.widget.Toast;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
-import android.graphics.PixelFormat;
-import android.view.SurfaceHolder;
 import android.content.Context;
-import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ApplicationInfo;
-import android.content.Intent;
 import android.widget.ImageView;
-import java.io.InputStream;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -536,7 +521,6 @@ public class PythonActivity extends Activity {
             ) {
         Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
         String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
-        String filesDirectory = argument;
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
         serviceIntent.putExtra("androidPrivate", argument);


### PR DESCRIPTION
- Avoid duplicate imports
- Avoid importing anything from the package java.lang
- Avoid unused imports
- Avoid unused local variables
- Avoid unused private fields
- No need to import a type that lives in the same package
- Unnecessary use of fully qualified name due to existing import

In the future we may want to add a dedicated Java linting job in the CI.