### PR TITLE
:bug: Fixes flake8 errors post update

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -145,9 +145,9 @@ class Arch:
             + " ".join(
                 [
                     "-L'"
-                    + l.replace("'", "'\"'\"'")
+                    + link_path.replace("'", "'\"'\"'")
                     + "'"  # no shlex.quote in py2
-                    for l in self.extra_global_link_paths
+                    for link_path in self.extra_global_link_paths
                 ]
             )
             + ' ' + ' '.join(self.common_ldflags).format(

--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -130,7 +130,7 @@ def find_order(graph):
     '''
     while graph:
         # Find all items without a parent
-        leftmost = [l for l, s in graph.items() if not s]
+        leftmost = [name for name, dep in graph.items() if not dep]
         if not leftmost:
             raise ValueError('Dependency cycle detected! %s' % graph)
         # If there is more than one, sort them for predictable order

--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -199,9 +199,9 @@ def shprint(command, *args, **kwargs):
                           re_filter_in=None, re_filter_out=None):
                 lines = out.splitlines()
                 if re_filter_in is not None:
-                    lines = [l for l in lines if re_filter_in.search(l)]
+                    lines = [line for line in lines if re_filter_in.search(line)]
                 if re_filter_out is not None:
-                    lines = [l for l in lines if not re_filter_out.search(l)]
+                    lines = [line for line in lines if not re_filter_out.search(line)]
                 if tail_n == 0 or len(lines) <= tail_n:
                     info('{}:\n{}\t{}{}'.format(
                         name, forecolor, '\t\n'.join(lines), Out_Fore.RESET))

--- a/pythonforandroid/pythonpackage.py
+++ b/pythonforandroid/pythonpackage.py
@@ -688,7 +688,7 @@ def get_package_dependencies(package,
             new_reqs = set()
             if verbose:
                 print("get_package_dependencies: resolving dependency "
-                      "to package name: ".format(package_dep))
+                      f"to package name: {package_dep}")
             package = get_package_name(package_dep)
             if package.lower() in packages_processed:
                 continue

--- a/pythonforandroid/recipes/android/src/android/_ctypes_library_finder.py
+++ b/pythonforandroid/recipes/android/src/android/_ctypes_library_finder.py
@@ -53,7 +53,7 @@ def find_library(name):
         lib_search_dirs.insert(0, lib_dir_2)
 
     # Now scan the lib dirs:
-    for lib_dir in [l for l in lib_search_dirs if os.path.exists(l)]:
+    for lib_dir in [ldir for ldir in lib_search_dirs if os.path.exists(ldir)]:
         filelist = [
             f for f in os.listdir(lib_dir)
             if does_libname_match_filename(name, f)

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -22,9 +22,9 @@ class ReportLabRecipe(CompiledComponentsPythonRecipe):
             font_dir = os.path.join(recipe_dir,
                                     "src", "reportlab", "fonts")
             if os.path.exists(font_dir):
-                for l in os.listdir(font_dir):
-                    if l.lower().startswith('darkgarden'):
-                        os.remove(os.path.join(font_dir, l))
+                for file in os.listdir(font_dir):
+                    if file.lower().startswith('darkgarden'):
+                        os.remove(os.path.join(font_dir, file))
 
             # Apply patches:
             self.apply_patch('patches/fix-setup.patch', arch.arch)

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -216,10 +216,10 @@ def build_dist_from_args(ctx, dist, args):
          .format(join(ctx.dist_dir, ctx.distribution.dist_dir)))
 
 
-def split_argument_list(l):
-    if not len(l):
+def split_argument_list(arg_list):
+    if not len(arg_list):
         return []
-    return re.split(r'[ ,]+', l)
+    return re.split(r'[ ,]+', arg_list)
 
 
 class NoAbbrevParser(argparse.ArgumentParser):
@@ -1144,7 +1144,7 @@ class ToolchainCL:
 
         if dists:
             print('{Style.BRIGHT}Distributions currently installed are:'
-                  '{Style.RESET_ALL}'.format(Style=Out_Style, Fore=Out_Fore))
+                  '{Style.RESET_ALL}'.format(Style=Out_Style))
             pretty_log_dists(dists, print)
         else:
             print('{Style.BRIGHT}There are no dists currently built.'


### PR DESCRIPTION
The recent `flake8==3.8.0` update reported new errors:
```
pythonforandroid/graph.py:133:27: E741 ambiguous variable name 'l'
pythonforandroid/toolchain.py:219:25: E741 ambiguous variable name 'l'
pythonforandroid/toolchain.py:1146:19: F522 '...'.format(...) has unused named argument(s): Fore
pythonforandroid/pythonpackage.py:690:23: F523 '...'.format(...) has unused arguments at position(s): 0
pythonforandroid/logger.py:202:36: E741 ambiguous variable name 'l'
pythonforandroid/logger.py:204:36: E741 ambiguous variable name 'l'
pythonforandroid/archs.py:150:25: E741 ambiguous variable name 'l'
pythonforandroid/recipes/android/src/android/_ctypes_library_finder.py:56:27: E741 ambiguous variable name 'l'
pythonforandroid/recipes/reportlab/__init__.py:25:21: E741 ambiguous variable name 'l'
```