### PR TITLE
:ambulance: Fix `test_should_build`

### DIFF
--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -4,7 +4,8 @@ import subprocess
 
 from multiprocessing import cpu_count
 from os import environ
-from os.path import dirname, exists, join, isfile
+from os.path import dirname, exists, join
+from pathlib import Path
 from shutil import copy2
 
 from pythonforandroid.logger import info, warning, shprint
@@ -165,7 +166,7 @@ class Python3Recipe(TargetPythonRecipe):
         return join(self.get_build_dir(arch_name), 'android-build')
 
     def should_build(self, arch):
-        return not isfile(join(self.link_root(arch.arch), self._libpython))
+        return not Path(self.link_root(arch.arch), self._libpython).is_file()
 
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)

--- a/tests/recipes/test_python3.py
+++ b/tests/recipes/test_python3.py
@@ -22,13 +22,13 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
             f'libpython{self.recipe.major_minor_version_string}m.so'
         )
 
-    def test_should_build(self):
-        expected_include_dir = join(
-            self.recipe.get_build_dir(self.arch.arch), 'Include',
-        )
-        self.assertEqual(
-            expected_include_dir, self.recipe.include_root(self.arch.arch)
-        )
+    @mock.patch('pythonforandroid.recipes.python3.Path.is_file')
+    def test_should_build(self, mock_is_file):
+        # in case that python lib exists, we shouldn't trigger the build
+        self.assertFalse(self.recipe.should_build(self.arch))
+        # in case that python lib doesn't exist, we should trigger the build
+        mock_is_file.return_value = False
+        self.assertTrue(self.recipe.should_build(self.arch))
 
     def test_include_root(self):
         expected_include_dir = join(


### PR DESCRIPTION
Because, I forgot to implement it when I first wrote the test at 535b39d6

**Note:** I replaced `os.path.isfile` by `pathlib.Path(<any-path>).is_file()` because:
  - It seems that when trying to mock `isfile` function, doesn't work as expected (is completely ignored, unless we import the whole `os.path` module)
  - Given the above situation, we must modify the import, so better use the `pathlib` implementation, wich it has several advantages (it handles any kind of path automatically, no matter the platform)