### PR TITLE
Fix for 'ImportError: No module named setuptools', encountered when building with buildozer

### DIFF
--- a/pythonforandroid/recipes/psycopg2/__init__.py
+++ b/pythonforandroid/recipes/psycopg2/__init__.py
@@ -12,7 +12,7 @@ class Psycopg2Recipe(PythonRecipe):
     """
     version = '2.8.4'
     url = 'https://pypi.python.org/packages/source/p/psycopg2/psycopg2-{version}.tar.gz'
-    depends = ['libpq']
+    depends = ['libpq', 'setuptools']
     site_packages_name = 'psycopg2'
     call_hostpython_via_targetpython = False
 


### PR DESCRIPTION
Added setuptools as a dependency for psycopg2. This fixed the 'ImportError: No module named setuptools' error I encountered while building the package with buildozer.