### PR TITLE
Content providers

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -86,6 +86,8 @@ options (this list may not be exhaustive):
   include multiple jar files, pass this argument multiple times.
 - ``--intent-filters``: A file path containing intent filter xml to be
   included in AndroidManifest.xml.
+- ``--content-providers``: A file path containing provider xml to be
+  included in AndroidManifest.xml.
 - ``--service``: A service name and the Python script it should
   run. See :ref:`arbitrary_scripts_services`.
 - ``--add-source``: Add a source directory to the app's Java code.

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -511,6 +511,11 @@ main.py that loads it.''')
         join(res_dir, 'values/strings.xml'),
         **render_args)
 
+    # extra resources
+    if args.add_resource:
+        for file_path in args.add_resource:
+            shutil.copy(file_path, join(res_dir, basename(file_path)))
+
     if exists(join("templates", "custom_rules.tmpl.xml")):
         render(
             'custom_rules.tmpl.xml',
@@ -717,6 +722,9 @@ tools directory of the Android SDK.
                           'filename containing xml. The filename should be '
                           'located relative to the python-for-android '
                           'directory'))
+    ap.add_argument('--add-resource', dest='add_resource', action='append',
+                    help=('Copy this file at this path to the src/main/res '
+                          'subdirectory of the build.'))
     ap.add_argument('--with-billing', dest='billing_pubkey',
                     help='If set, the billing service will be added (not implemented)')
     ap.add_argument('--add-source', dest='extra_source_dirs', action='append',

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -511,10 +511,13 @@ main.py that loads it.''')
         join(res_dir, 'values/strings.xml'),
         **render_args)
 
-    # extra resources
-    if args.add_resource:
-        for file_path in args.add_resource:
-            shutil.copy(file_path, join(res_dir, basename(file_path)))
+    # extra xml resources
+    if args.add_xml_resource:
+        xml_res_dir = join(res_dir, 'xml')
+        if not exists(xml_res_dir):
+            os.mkdir(xml_res_dir)
+        for file_path in args.add_xml_resource:
+            shutil.copy(file_path, join(xml_res_dir, basename(file_path)))
 
     if exists(join("templates", "custom_rules.tmpl.xml")):
         render(
@@ -722,8 +725,9 @@ tools directory of the Android SDK.
                           'filename containing xml. The filename should be '
                           'located relative to the python-for-android '
                           'directory'))
-    ap.add_argument('--add-resource', dest='add_resource', action='append',
-                    help=('Copy this file at this path to the src/main/res '
+    ap.add_argument('--add-xml-resource', dest='add_xml_resource',
+                    action='append',
+                    help=('Copy this file to the src/main/res/xml '
                           'subdirectory of the build.'))
     ap.add_argument('--with-billing', dest='billing_pubkey',
                     help='If set, the billing service will be added (not implemented)')

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -372,6 +372,10 @@ main.py that loads it.''')
         with open(args.intent_filters) as fd:
             args.intent_filters = fd.read()
 
+    if args.content_providers:
+        with open(args.content_providers) as f:
+            args.content_providers = f.read()
+
     if not args.add_activity:
         args.add_activity = []
 
@@ -703,6 +707,12 @@ tools directory of the Android SDK.
                           'the discovered ndk_api in the dist'))
     ap.add_argument('--intent-filters', dest='intent_filters',
                     help=('Add intent-filters xml rules to the '
+                          'AndroidManifest.xml file. The argument is a '
+                          'filename containing xml. The filename should be '
+                          'located relative to the python-for-android '
+                          'directory'))
+    ap.add_argument('--content-providers', dest='content_providers',
+                    help=('Add providers xml rules to the '
                           'AndroidManifest.xml file. The argument is a '
                           'filename containing xml. The filename should be '
                           'located relative to the python-for-android '

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -129,9 +129,14 @@
             </intent-filter>
         </receiver>
         {% endif %}
-    {% for a in args.add_activity  %}
-    <activity android:name="{{ a }}"></activity>
-    {% endfor %}
+
+        {% for a in args.add_activity  %}
+        <activity android:name="{{ a }}"></activity>
+        {% endfor %}
+
+        {%- if args.content_providers -%}
+        {{- args.content_providers -}}
+        {%- endif -%}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -92,6 +92,10 @@
             </intent-filter>
         </receiver>
         {% endif %}
+
+        {%- if args.content_providers -%}
+        {{- args.content_providers -}}
+        {%- endif -%}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -94,6 +94,10 @@
             </intent-filter>
         </receiver>
         {% endif %}
+
+        {%- if args.content_providers -%}
+        {{- args.content_providers -}}
+        {%- endif -%}
     </application>
 
 </manifest>


### PR DESCRIPTION
This PR should make it possible to add [content providers](https://developer.android.com/guide/topics/manifest/provider-element) to the Android manifest. Two options are added to the common `build.py` script:

- `--content-providers` is practically identical to the `--intent-filters` option, it expects the path to an XML file the contents of which are included in the `AndroidManifest.xml`.
- `--add-xml-resource` can be used to copy one or more files over to the `src/main/res/xml` subdir of the build dir. This is needed because `<provider>` elements in the Android manifest usually have to refer to another XML file that defines the paths the app is allowed to "export".

If approved, I will also prepare a PR for the Buildozer repo to add the `buildozer.spec` counterparts.