### PR TITLE
:books: Troubleshoot SSL error

### DIFF
--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -202,3 +202,9 @@ ModuleNotFoundError: No module named '_ctypes'
 You do not have the libffi headers available to python-for-android, so you need to install them. On Ubuntu and derivatives these come from the `libffi-dev` package.
 
 After installing the headers, clean the build (`p4a clean builds`, or with buildozer delete the `.buildozer` directory within your app directory) and run python-for-android again.
+
+SSLError("Can't connect to HTTPS URL because the SSL module is not available.")
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Your `hostpython3` was compiled without SSL support. You need to install the SSL development files before rebuilding the `hostpython3` recipe.
+On Ubuntu and derivatives these come from the `libssl-dev` package (then `p4a clean builds`, or with buildozer `buildozer android clean`).


### PR DESCRIPTION
Documents how to fix the following error:
```
SSLError("Can't connect to HTTPS URL because the SSL module is not available.")
```