### PR TITLE
Add possibility to add a backup rules xml file

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -474,7 +474,7 @@ main.py that loads it.''')
     if args.backup_rules:
         res_xml_dir = join(res_dir, 'xml')
         ensure_dir(res_xml_dir)
-        shutil.copy(args.backup_rules, res_xml_dir)
+        shutil.copy(join(args.private, args.backup_rules), res_xml_dir)
         args.backup_rules = split(args.backup_rules)[1][:-4]
 
     # Render out android manifest:
@@ -764,10 +764,10 @@ tools directory of the Android SDK.
     ap.add_argument('--backup-rules', dest='backup_rules', default='',
                     help=('Backup rules for Android Auto Backup. Argument is a '
                           'filename containing xml. The filename should be '
-                          'located relative to the python-for-android'
-                          'directory. See https://developer.android.com/'
-                          'guide/topics/data/autobackup#IncludingFiles for '
-                          'more information'))
+                          'located relative to the private directory containing your source code '
+                          'files (containing your main.py entrypoint). '
+                          'See https://developer.android.com/guide/topics/data/'
+                          'autobackup#IncludingFiles for more information'))
     ap.add_argument('--no-optimize-python', dest='optimize_python',
                     action='store_false', default=True,
                     help=('Whether to compile to optimised .pyo files, using -OO '

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -470,6 +470,13 @@ main.py that loads it.''')
     # Folder name for launcher (used by SDL2 bootstrap)
     url_scheme = 'kivy'
 
+    # Copy backup rules file if specified and update the argument
+    if args.backup_rules:
+        res_xml_dir = join(res_dir, 'xml')
+        ensure_dir(res_xml_dir)
+        shutil.copy(args.backup_rules, res_xml_dir)
+        args.backup_rules = split(args.backup_rules)[1][:-4]
+
     # Render out android manifest:
     manifest_path = "src/main/AndroidManifest.xml"
     render_args = {
@@ -754,6 +761,13 @@ tools directory of the Android SDK.
                     help='Set the launch mode of the main activity in the manifest.')
     ap.add_argument('--allow-backup', dest='allow_backup', default='true',
                     help="if set to 'false', then android won't backup the application.")
+    ap.add_argument('--backup-rules', dest='backup_rules', default='',
+                    help=('Backup rules for Android Auto Backup. Argument is a '
+                          'filename containing xml. The filename should be '
+                          'located relative to the python-for-android'
+                          'directory. See https://developer.android.com/'
+                          'guide/topics/data/autobackup#IncludingFiles for '
+                          'more information'))
     ap.add_argument('--no-optimize-python', dest='optimize_python',
                     action='store_false', default=True,
                     help=('Whether to compile to optimised .pyo files, using -OO '

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -58,6 +58,7 @@
                  {% if debug %}android:debuggable="true"{% endif %}
                  android:icon="@drawable/icon"
                  android:allowBackup="{{ args.allow_backup }}"
+                 {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true" >
         {% for l in args.android_used_libs %}

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -47,7 +47,8 @@
     <application android:label="@string/app_name"
                  {% if debug %}android:debuggable="true"{% endif %}
                  android:icon="@drawable/icon"
-                 android:allowBackup="true"
+                 android:allowBackup="{{ args.allow_backup }}"
+                 {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true" >
         {% for l in args.android_used_libs %}
@@ -72,7 +73,7 @@
 
         {% if service %}
         <service android:name="org.kivy.android.PythonService"
-                 android:process=":pythonservice" 
+                 android:process=":pythonservice"
                  android:exported="true"/>
         {% endif %}
         {% for name in service_names %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -47,7 +47,8 @@
     -->
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon"
-                 android:allowBackup="true"
+                 android:allowBackup="{{ args.allow_backup }}"
+                 {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true"
                  android:usesCleartextTraffic="true"


### PR DESCRIPTION
This PR enables users to pass a new argument to p4a to enable
custom backup rules through the means of an XML file as documented
in the official [Android docs](https://developer.android.com/guide/topics/data/autobackup#IncludingFiles).

I also noticed that the "allowBackup" flag would do nothing when userd
with either `webview` or `service_only` bootstraps, where the 
`AndroidManifest.tmpl.xml` would set it to a hardcoded "true" instead of 
the user-defined value.