### PR TITLE
:sparkles: Add `opencv_extras` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ testapps-with-numpy/%: virtualenv
 	$(eval $@_APP_ARCH := $(shell basename $*))
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy,opencv,opencv_extras \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
     --arch=$($@_APP_ARCH)
 
 testapps/%: virtualenv

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ testapps-with-numpy/%: virtualenv
 	$(eval $@_APP_ARCH := $(shell basename $*))
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy,opencv,opencv_extras \
     --arch=$($@_APP_ARCH)
 
 testapps/%: virtualenv

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -31,8 +31,7 @@ class OpenCVRecipe(NDKRecipe):
         'libopencv_video.so',
         'libopencv_dnn.so',
         'libopencv_imgcodecs.so',
-        'libopencv_photo.so'
-        # todo: add opencv_extras libraries
+        'libopencv_photo.so',
     ]
 
     def get_lib_dir(self, arch):

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -32,6 +32,7 @@ class OpenCVRecipe(NDKRecipe):
         'libopencv_dnn.so',
         'libopencv_imgcodecs.so',
         'libopencv_photo.so'
+        # todo: add opencv_extras libraries
     ]
 
     def get_lib_dir(self, arch):
@@ -46,6 +47,16 @@ class OpenCVRecipe(NDKRecipe):
     def build_arch(self, arch):
         build_dir = join(self.get_build_dir(arch.arch), 'build')
         shprint(sh.mkdir, '-p', build_dir)
+
+        opencv_extras = []
+        if 'opencv_extras' in self.ctx.recipe_build_order:
+            opencv_extras_dir = self.get_recipe(
+                'opencv_extras', self.ctx).get_build_dir(arch.arch)
+            opencv_extras = [
+                f'-DOPENCV_EXTRA_MODULES_PATH={opencv_extras_dir}/modules',
+                '-DBUILD_opencv_legacy=OFF',
+            ]
+
         with current_directory(build_dir):
             env = self.get_recipe_env(arch)
 
@@ -119,6 +130,8 @@ class OpenCVRecipe(NDKRecipe):
                         major=python_major, numpy_include=python_include_numpy),
                     '-DPYTHON{major}_PACKAGES_PATH={site_packages}'.format(
                         major=python_major, site_packages=python_site_packages),
+
+                    *opencv_extras,
 
                     self.get_build_dir(arch.arch),
                     _env=env)

--- a/pythonforandroid/recipes/opencv_extras/__init__.py
+++ b/pythonforandroid/recipes/opencv_extras/__init__.py
@@ -1,0 +1,23 @@
+from pythonforandroid.recipe import Recipe
+
+
+class OpenCVExtrasRecipe(Recipe):
+    """
+    OpenCV extras recipe allows us to build extra modules from the
+    `opencv_contrib` repository. It depends on opencv recipe and all the build
+    of the modules will be performed inside opencv recipe build directory.
+
+    .. note:: the version of this recipe should be the same than opencv recipe.
+
+    .. warning:: Be aware that these modules are experimental, some of them
+        maybe included in opencv future releases and removed from extras.
+
+    .. seealso:: https://github.com/opencv/opencv_contrib
+
+    """
+    version = '4.0.1'
+    url = 'https://github.com/opencv/opencv_contrib/archive/{version}.zip'
+    depends = ['opencv']
+
+
+recipe = OpenCVExtrasRecipe()


### PR DESCRIPTION
This recipe allows us to build extra modules from the `opencv_contrib` repository. It depends on `opencv` recipe and all the build of the modules will be performed inside opencv build directory.

This closes #2206

**Note:** I've not tested this recipe at runtime but it builds fine for `arm64-v8a` in my local tests, plus generates the extra opencv libraries (which are a lot so probably will increase the size of the apk considerably).

**See also:** https://github.com/opencv/opencv_contrib