### PR TITLE
allow specify --numeric-version with APK_NUMERIC_VERSION env

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -58,6 +58,9 @@ options (this list may not be exhaustive):
 - ``--private``: The directory containing your project files.
 - ``--package``: The Java package name for your project. e.g. ``org.example.yourapp``.
 - ``--name``: The app name.
+- ``--numeric-version``: The numeric version number of the project.
+  If not given and no ``APK_NUMERIC_VERSION`` env is set, this is
+  automatically computed from the version.
 - ``--version``: The version number.
 - ``--orientation``: Usually one of ``portait``, ``landscape``,
   ``sensor`` to automatically rotate according to the device

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -590,9 +590,10 @@ tools directory of the Android SDK.
                     help=('The human-readable name of the project.'),
                     required=True)
     ap.add_argument('--numeric-version', dest='numeric_version',
+                    default=os.environ.get('APK_NUMERIC_VERSION', None),
                     help=('The numeric version number of the project. If not '
-                          'given, this is automatically computed from the '
-                          'version.'))
+                          'given and no APK_NUMERIC_VERSION env is set, this '
+                          'is automatically computed from the version.'))
     ap.add_argument('--version', dest='version',
                     help=('The version number of the project. This should '
                           'consist of numbers and dots, and should have the '


### PR DESCRIPTION
- add `default=os.environ.get('APK_NUMERIC_VERSION', None)` to `--numeric-version` argument