### PR TITLE
[WIP] :package: Make our default build  as `release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docker/run/make/%: docker/build
 docker/run/make/with-artifact/%: docker/build
 	$(eval $@_APP_ARCH := $(shell basename $*))
 	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
-	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app__$($@_APP_ARCH)-debug-1.1-.apk ./apks
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app__$($@_APP_ARCH)-release-unsigned-1.1-.apk ./apks
 	docker rm -fv p4a-latest
 
 docker/run/shell: docker/build

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -460,7 +460,7 @@ main.py that loads it.''')
         "service": service,
         "service_names": service_names,
         "android_api": android_api,
-        "debug": "debug" in args.build_mode,
+        "debuggable": args.debuggable,
     }
     if get_bootstrap_name() == "sdl2":
         render_args["url_scheme"] = url_scheme
@@ -484,7 +484,7 @@ main.py that loads it.''')
         jars=jars,
         android_api=android_api,
         build_tools_version=build_tools_version,
-        debug_build="debug" in args.build_mode,
+        debuggable=args.debuggable,
         is_library=(get_bootstrap_name() == 'service_library'),
         )
 
@@ -676,10 +676,10 @@ tools directory of the Android SDK.
                     default=join(curdir, 'whitelist.txt'),
                     help=('Use a whitelist file to prevent blacklisting of '
                           'file in the final APK'))
-    ap.add_argument('--release', dest='build_mode', action='store_const',
-                    const='release', default='debug',
-                    help='Build your app as a non-debug release build. '
-                         '(Disables gdb debugging among other things)')
+    ap.add_argument('--debuggable', dest='debuggable', action='store_const',
+                    const='debuggable', default=False,
+                    help='Build your app as a debug release build. '
+                         '(Enables gdb debugging among other things)')
     ap.add_argument('--add-jar', dest='add_jar', action='append',
                     help=('Add a Java .jar to the libs, so you can access its '
                           'classes with pyjnius. You can specify this '

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -55,7 +55,7 @@
          An example Java class can be found in README-android.txt
     -->
     <application android:label="@string/app_name"
-                 {% if debug %}android:debuggable="true"{% endif %}
+                 {% if debuggable %}android:debuggable="true"{% endif %}
                  android:icon="@drawable/icon"
                  android:allowBackup="{{ args.allow_backup }}"
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"


### PR DESCRIPTION
To make a build in debug mode you must use `--debuggable` (which is actually the word that AndroidManifest.xml uses to perform a debuggable build)

This closes #2207

**Important:** To actually perform a full debuggable build, you must be sure to remove any existant release built, since some libraries (the ones that we use the `ndk_build` command) won't be compiled again, unless we remove the old compilation. Also noting, that this is the same for the other way around (If you performed a debuggable build and you want a release built, then better remove the old compiled files)

**Note**: I labeled this `wip` because I think that our github actions artifacts should be build as `debuggable`, otherwise it would require to sign the apks to be able to install it on our devices...or maybe...should  we [sign them](https://github.com/marketplace/actions/sign-android-release)?