### PR TITLE
:package: Split logic for build modes & debug symbols

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -680,6 +680,9 @@ tools directory of the Android SDK.
                     const='release', default='debug',
                     help='Build your app as a non-debug release build. '
                          '(Disables gdb debugging among other things)')
+    ap.add_argument('--with-debug-symbols', dest='with_debug_symbols',
+                    action='store_const', const=True, default=False,
+                    help='Will keep debug symbols from `.so` files.')
     ap.add_argument('--add-jar', dest='add_jar', action='append',
                     help=('Add a Java .jar to the libs, so you can access its '
                           'classes with pyjnius. You can specify this '

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -47,7 +47,7 @@ class SDL2GradleBootstrap(Bootstrap):
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
-        if not self.ctx.build_as_debuggable:
+        if not self.ctx.with_debug_symbols:
             self.strip_libraries(arch)
         self.fry_eggs(site_packages_dir)
         super().assemble_distribution()

--- a/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
@@ -7,7 +7,7 @@
     <!-- Android 2.3.3 -->
     <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
 
-    <application>
+    <application {% if debug %}android:debuggable="true"{% endif %} >
         {% for name in service_names %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
                  android:process=":service_{{ name }}"

--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -46,7 +46,7 @@ class ServiceOnlyBootstrap(Bootstrap):
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
-        if not self.ctx.build_as_debuggable:
+        if not self.ctx.with_debug_symbols:
             self.strip_libraries(arch)
         self.fry_eggs(site_packages_dir)
         super().assemble_distribution()

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -45,6 +45,7 @@
          An example Java class can be found in README-android.txt
     -->
     <application android:label="@string/app_name"
+                 {% if debug %}android:debuggable="true"{% endif %}
                  android:icon="@drawable/icon"
                  android:allowBackup="true"
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -43,7 +43,7 @@ class WebViewBootstrap(Bootstrap):
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
-        if not self.ctx.build_as_debuggable:
+        if not self.ctx.with_debug_symbols:
             self.strip_libraries(arch)
         self.fry_eggs(site_packages_dir)
         super().assemble_distribution()

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -51,6 +51,7 @@
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true"
                  android:usesCleartextTraffic="true"
+                 {% if debug %}android:debuggable="true"{% endif %}
                  >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -82,8 +82,11 @@ class Context:
     '''A build context. If anything will be built, an instance this class
     will be instantiated and used to hold all the build state.'''
 
-    # Whether to build with debugging symbols
+    # Whether to make a debug or release build
     build_as_debuggable = False
+
+    # Whether to strip debug symbols in `.so` files
+    with_debug_symbols = False
 
     env = environ.copy()
     # the filepath of toolchain.py
@@ -831,7 +834,7 @@ def run_pymodules_install(ctx, modules, project_dir=None,
                 )
 
         # Strip object files after potential Cython or native code builds:
-        if not ctx.build_as_debuggable:
+        if not ctx.with_debug_symbols:
             standard_recipe.strip_object_files(
                 ctx.archs[0], env, build_dir=ctx.build_dir
             )

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1072,7 +1072,7 @@ class CythonRecipe(PythonRecipe):
                 info('First build appeared to complete correctly, skipping manual'
                      'cythonising.')
 
-            if not self.ctx.build_as_debuggable:
+            if not self.ctx.with_debug_symbols:
                 self.strip_object_files(arch, env)
 
     def strip_object_files(self, arch, env, build_dir=None):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -196,6 +196,14 @@ def build_dist_from_args(ctx, dist, args):
         ctx.recipe_build_order))
     info('Dist will also contain modules ({}) installed from pip'.format(
         ', '.join(ctx.python_modules)))
+    info(
+        'Dist will be build in mode {build_mode}{with_debug_symbols}'.format(
+            build_mode='debug' if ctx.build_as_debuggable else 'release',
+            with_debug_symbols=' (with debug symbols)'
+            if ctx.with_debug_symbols
+            else '',
+        )
+    )
 
     ctx.distribution = dist
     ctx.prepare_bootstrap(bs)
@@ -519,6 +527,10 @@ class ToolchainCL:
             help='Build your app as a non-debug release build. '
                  '(Disables gdb debugging among other things)')
         parser_packaging.add_argument(
+            '--with-debug-symbols', dest='with_debug_symbols',
+            action='store_const', const=True, default=False,
+            help='Will keep debug symbols from `.so` files.')
+        parser_packaging.add_argument(
             '--keystore', dest='keystore', action='store', default=None,
             help=('Keystore for JAR signing key, will use jarsigner '
                   'default if not specified (release build only)'))
@@ -593,6 +605,8 @@ class ToolchainCL:
             args.unknown_args += ["--private", args.private]
         if hasattr(args, "build_mode") and args.build_mode == "release":
             args.unknown_args += ["--release"]
+        if hasattr(args, "with_debug_symbols") and args.with_debug_symbols:
+            args.unknown_args += ["--with-debug-symbols"]
         if hasattr(args, "ignore_setup_py") and args.ignore_setup_py:
             args.use_setup_py = False
 
@@ -612,6 +626,9 @@ class ToolchainCL:
         self.ctx.build_as_debuggable = getattr(
             args, "build_mode", "debug"
         ) == "debug"
+        self.ctx.with_debug_symbols = getattr(
+            args, "with_debug_symbols", False
+        )
 
         have_setup_py_or_similar = False
         if getattr(args, "private", None) is not None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -19,7 +19,7 @@ class TestBuildBasic(unittest.TestCase):
         assert m_info.call_args_list[-1] == mock.call(
             'No Python modules and no setup.py to process, skipping')
 
-    def test_strip_if_debuggable(self):
+    def test_strip_if_with_debug_symbols(self):
         ctx = mock.Mock()
         ctx.python_recipe.major_minor_version_string = "python3.6"
         ctx.get_site_packages_dir.return_value = "test-doesntexist"
@@ -38,12 +38,13 @@ class TestBuildBasic(unittest.TestCase):
                 mock.patch('pythonforandroid.build.run_setuppy_install'):
             m_project_has_setup_py.return_value = False
 
-            # Make sure it is NOT called when debug build:
-            ctx.build_as_debuggable = True
+            # Make sure it is NOT called when `with_debug_symbols` is true:
+            ctx.with_debug_symbols = True
             assert run_pymodules_install(ctx, modules, project_dir) is None
             assert m_CythonRecipe().strip_object_files.called is False
 
-            # Make sure strip object files IS called when release build:
-            ctx.build_as_debuggable = False
+            # Make sure strip object files IS called when
+            # `with_debug_symbols` is fasle:
+            ctx.with_debug_symbols = False
             assert run_pymodules_install(ctx, modules, project_dir) is None
             assert m_CythonRecipe().strip_object_files.called is True


### PR DESCRIPTION
If we want to **keep** debug symbols from `.so` files we will use: `--with-debug-symbols`

Also:
  - enable debug builds for all bootstraps (AndroidManifest.tmpl.xml)
  - add log message to make it clear what kind of build we will get

This closes #2207