### PR TITLE
:bug: Adds missing requests sub dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ testapps-with-numpy/%: virtualenv
 	$(eval $@_APP_ARCH := $(shell basename $*))
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
-    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,sqlite3,setuptools,numpy \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,urllib3,chardet,idna,sqlite3,setuptools,numpy \
     --arch=$($@_APP_ARCH)
 
 testapps/%: virtualenv

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -211,7 +211,7 @@ Remember to always clean the build before rebuilding (`p4a clean builds`, or wit
 
 On Ubuntu and derivatives::
 
-    apt install openssl
+    apt install libssl-dev
     p4a clean builds # or with: buildozer `buildozer android clean
 
 On macOS::

--- a/testapps/on_device_unit_tests/setup.py
+++ b/testapps/on_device_unit_tests/setup.py
@@ -12,7 +12,8 @@ and, of course, we should have the proper test for the given recipe at
 app requirements via the dictionary `options`. Here you have some examples
 to build the supported app modes::
 
-  - kivy *basic*: `sqlite3,libffi,openssl,pyjnius,kivy,python3,requests`
+  - kivy *basic*: `sqlite3,libffi,openssl,pyjnius,kivy,python3,requests,
+    urllib3,chardet,idna`
   - kivy *images/graphs*: `kivy,python3,numpy,matplotlib,Pillow`
   - kivy *encryption*: `kivy,python3,cryptography,pycryptodome,scrypt,
     m2crypto,pysha3`
@@ -39,7 +40,8 @@ options = {
     'apk':
         {
             'requirements':
-                'sqlite3,libffi,openssl,pyjnius,kivy,python3,requests',
+                'sqlite3,libffi,openssl,pyjnius,kivy,python3,requests,urllib3,'
+                'chardet,idna',
             'android-api': 27,
             'ndk-api': 21,
             'dist-name': 'bdist_unit_tests_app',


### PR DESCRIPTION
The `requests` module has `urllib3`, `chardet` and `idna` as dependencies.
This used to be handled dynamically thanks to the `requests` recipe.
This is a drawback and side effect of #2202.
The on device error was:
```
Imported unittest
loading tests...
running unittest...
unittest result is:
....EE........
======================================================================
ERROR: test_import_module (tests.test_requirements.RequestsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/user/app/testapps/on_device_unit_tests/build/bdist.android-armeabi-v7a/test_app/tests/mixin.py", line 17, in test_import_module
  File "/home/user/.local/share/python-for-android/build/other_builds/python3/armeabi-v7a__ndk_target_21/python3/Lib/importlib/__init__.py", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/user/.local/share/python-for-android/build/python-installs/bdist_unit_tests_app/requests/__init__.py", line 43, in <module>
ModuleNotFoundError: No module named 'urllib3'

======================================================================
ERROR: test_run_module (tests.test_requirements.RequestsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/user/app/testapps/on_device_unit_tests/build/bdist.android-armeabi-v7a/test_app/tests/test_requirements.py", line 74, in test_run_module
  File "/home/user/.local/share/python-for-android/build/python-installs/bdist_unit_tests_app/requests/__init__.py", line 43, in <module>
ModuleNotFoundError: No module named 'urllib3'

----------------------------------------------------------------------
Ran 14 tests in 0.591s

FAILED (errors=2)

Ran tests
```