### PR TITLE
:arrow_up: Bumps to Gradle 6.4.1

### DIFF
--- a/pythonforandroid/bootstraps/common/build/gradle/wrapper/gradle-wrapper.properties
+++ b/pythonforandroid/bootstraps/common/build/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip


### PR DESCRIPTION
Gradle 6 supports OpenJDK up to version 13.
Also refs: https://github.com/kivy/buildozer/pull/1135