### PR TITLE
:rotating_light: Depreciation warning fixes

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -9,6 +9,7 @@ from re import match
 import sh
 import shutil
 import fnmatch
+from urllib.request import urlretrieve
 from os import listdir, unlink, environ, mkdir, curdir, walk
 from sys import stdout
 import time
@@ -17,22 +18,9 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 from pythonforandroid.logger import (logger, info, warning, debug, shprint, info_main)
-from pythonforandroid.util import (urlretrieve, current_directory, ensure_dir,
+from pythonforandroid.util import (current_directory, ensure_dir,
                                    BuildInterruptingException)
-
-
-def import_recipe(module, filename):
-    # Python 3.5+
-    import importlib.util
-    if hasattr(importlib.util, 'module_from_spec'):
-        spec = importlib.util.spec_from_file_location(module, filename)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-    else:
-        # Python 3.3 and 3.4:
-        from importlib.machinery import SourceFileLoader
-        return SourceFileLoader(module, filename).load_module()
+from pythonforandroid.util import load_source as import_recipe
 
 
 class RecipeMeta(type):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -11,7 +11,7 @@ from pythonforandroid import __version__
 from pythonforandroid.pythonpackage import get_dep_names_of_package
 from pythonforandroid.recommendations import (
     RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API, print_recommendations)
-from pythonforandroid.util import BuildInterruptingException
+from pythonforandroid.util import BuildInterruptingException, load_source
 from pythonforandroid.entrypoints import main
 
 
@@ -81,7 +81,6 @@ from functools import wraps
 
 import argparse
 import sh
-import imp
 from appdirs import user_data_dir
 import logging
 from distutils.version import LooseVersion
@@ -752,8 +751,8 @@ class ToolchainCL:
             return
         if not hasattr(self, "hook_module"):
             # first time, try to load the hook module
-            self.hook_module = imp.load_source("pythonforandroid.hook",
-                                               self.args.hook)
+            self.hook_module = load_source(
+                "pythonforandroid.hook", self.args.hook)
         if hasattr(self.hook_module, name):
             info("Hook: execute {}".format(name))
             getattr(self.hook_module, name)(self)
@@ -1025,7 +1024,7 @@ class ToolchainCL:
         with current_directory(dist.dist_dir):
             self.hook("before_apk_build")
             os.environ["ANDROID_API"] = str(self.ctx.android_api)
-            build = imp.load_source('build', join(dist.dist_dir, 'build.py'))
+            build = load_source('build', join(dist.dist_dir, 'build.py'))
             build_args = build.parse_args_and_make_package(
                 args.unknown_args
             )

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -4,17 +4,7 @@ from os import getcwd, chdir, makedirs, walk, uname
 import shutil
 from fnmatch import fnmatch
 from tempfile import mkdtemp
-
-from urllib.request import FancyURLopener
-
 from pythonforandroid.logger import (logger, Err_Fore, error, info)
-
-
-class WgetDownloader(FancyURLopener):
-    version = ('Wget/1.17.1')
-
-
-urlretrieve = WgetDownloader().retrieve
 
 
 build_platform = '{system}-{machine}'.format(
@@ -82,6 +72,20 @@ def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
                     break
             else:
                 yield join(dirn, filen)
+
+
+def load_source(module, filename):
+    # Python 3.5+
+    import importlib.util
+    if hasattr(importlib.util, 'module_from_spec'):
+        spec = importlib.util.spec_from_file_location(module, filename)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    else:
+        # Python 3.3 and 3.4:
+        from importlib.machinery import SourceFileLoader
+        return SourceFileLoader(module, filename).load_module()
 
 
 class BuildInterruptingException(Exception):


### PR DESCRIPTION
Fixes running `tox` outputs warnings:
- replaces the `imp` module by the `importlib` one
- simplifies downloader dropping `FancyURLopener`

The warnings were:
```
pythonforandroid/util.py:17
  /home/andre/workspace/python-for-android/pythonforandroid/util.py:17:
DeprecationWarning: WgetDownloader style of invoking requests is deprecated. Use newer urlopen functions/methods
    urlretrieve = WgetDownloader().retrieve

pythonforandroid/toolchain.py:84
  /home/andre/workspace/python-for-android/pythonforandroid/toolchain.py:84:
DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp
```