### PR TITLE
:arrow_up: Bumps to OpenJDK 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/app" \
     PATH="${HOME_DIR}/.local/bin:${PATH}" \
     ANDROID_HOME="${HOME_DIR}/.android" \
-    JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+    JAVA_HOME="/usr/lib/jvm/java-13-openjdk-amd64"
 
 
 # install system dependencies
@@ -69,7 +69,7 @@ RUN dpkg --add-architecture i386 \
     libssl-dev \
     libstdc++6:i386 \
     libtool \
-    openjdk-8-jdk \
+    openjdk-13-jdk \
     patch \
     pkg-config \
     python3 \
@@ -99,7 +99,7 @@ USER ${USER}
 
 # Download and install android's NDK/SDK
 COPY ci/makefiles/android.mk /tmp/android.mk
-RUN make --file /tmp/android.mk target_os=linux \
+RUN make --file /tmp/android.mk \
     && sudo rm /tmp/android.mk
 
 # install python-for-android from current branch

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: virtualenv
 
 $(VIRTUAL_ENV):
 	python3 -m venv $(VIRTUAL_ENV)
-	$(PIP) install Cython==0.29.19
+	$(PIP) install Cython
 	$(PIP) install -e .
 
 virtualenv: $(VIRTUAL_ENV)

--- a/ci/makefiles/android.mk
+++ b/ci/makefiles/android.mk
@@ -1,24 +1,28 @@
 # Downloads and installs the Android SDK depending on supplied platform: darwin or linux
 
-# We must provide a platform (darwin or linux) and we need JAVA_HOME defined
-ifndef target_os
-    $(error target_os is not set...aborted!)
-endif
-
 # Those android NDK/SDK variables can be override when running the file
 ANDROID_NDK_VERSION ?= 19b
-ANDROID_SDK_TOOLS_VERSION ?= 4333796
-ANDROID_SDK_BUILD_TOOLS_VERSION ?= 28.0.2
+ANDROID_SDK_TOOLS_VERSION ?= 6514223
+ANDROID_SDK_BUILD_TOOLS_VERSION ?= 29.0.3
 ANDROID_HOME ?= $(HOME)/.android
 ANDROID_API_LEVEL ?= 27
 
+# per OS dictionary-like
+UNAME_S := $(shell uname -s)
+TARGET_OS_Linux = linux
+TARGET_OS_ALIAS_Linux = $(TARGET_OS_Linux)
+TARGET_OS_Darwin = darwin
+TARGET_OS_ALIAS_Darwin = mac
+TARGET_OS = $(TARGET_OS_$(UNAME_S))
+TARGET_OS_ALIAS = $(TARGET_OS_ALIAS_$(UNAME_S))
+
 ANDROID_SDK_HOME=$(ANDROID_HOME)/android-sdk
-ANDROID_SDK_TOOLS_ARCHIVE=sdk-tools-$(target_os)-$(ANDROID_SDK_TOOLS_VERSION).zip
+ANDROID_SDK_TOOLS_ARCHIVE=commandlinetools-$(TARGET_OS_ALIAS)-$(ANDROID_SDK_TOOLS_VERSION)_latest.zip
 ANDROID_SDK_TOOLS_DL_URL=https://dl.google.com/android/repository/$(ANDROID_SDK_TOOLS_ARCHIVE)
 
 ANDROID_NDK_HOME=$(ANDROID_HOME)/android-ndk
 ANDROID_NDK_FOLDER=$(ANDROID_HOME)/android-ndk-r$(ANDROID_NDK_VERSION)
-ANDROID_NDK_ARCHIVE=android-ndk-r$(ANDROID_NDK_VERSION)-$(target_os)-x86_64.zip
+ANDROID_NDK_ARCHIVE=android-ndk-r$(ANDROID_NDK_VERSION)-$(TARGET_OS)-x86_64.zip
 ANDROID_NDK_DL_URL=https://dl.google.com/android/repository/$(ANDROID_NDK_ARCHIVE)
 
 $(info Target install OS is          : $(target_os))
@@ -61,8 +65,8 @@ extract_android_ndk:
 # updates Android SDK, install Android API, Build Tools and accept licenses
 update_android_sdk:
 	touch $(ANDROID_HOME)/repositories.cfg
-	yes | $(ANDROID_SDK_HOME)/tools/bin/sdkmanager --licenses > /dev/null
-	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager "build-tools;$(ANDROID_SDK_BUILD_TOOLS_VERSION)" > /dev/null
-	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager "platforms;android-$(ANDROID_API_LEVEL)" > /dev/null
+	yes | $(ANDROID_SDK_HOME)/tools/bin/sdkmanager --sdk_root=$(ANDROID_SDK_HOME) --licenses > /dev/null
+	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager --sdk_root=$(ANDROID_SDK_HOME) "build-tools;$(ANDROID_SDK_BUILD_TOOLS_VERSION)" > /dev/null
+	$(ANDROID_SDK_HOME)/tools/bin/sdkmanager --sdk_root=$(ANDROID_SDK_HOME) "platforms;android-$(ANDROID_API_LEVEL)" > /dev/null
 	# Set avdmanager permissions (executable)
 	chmod +x $(ANDROID_SDK_HOME)/tools/bin/avdmanager

--- a/ci/makefiles/osx.mk
+++ b/ci/makefiles/osx.mk
@@ -7,15 +7,15 @@ all: install_java upgrade_cython install_android_ndk_sdk install_p4a
 
 install_java:
 	brew tap adoptopenjdk/openjdk
-	brew cask install adoptopenjdk8
+	brew cask install adoptopenjdk13
 	/usr/libexec/java_home -V
 
 upgrade_cython:
-	pip3 install --upgrade Cython==0.29.19
+	pip3 install --upgrade Cython
 
 install_android_ndk_sdk:
 	mkdir -p $(ANDROID_HOME)
-	make -f ci/makefiles/android.mk target_os=darwin JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+	make -f ci/makefiles/android.mk JAVA_HOME=`/usr/libexec/java_home -v 13`
 
 install_p4a:
 	# check python version and install p4a

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -145,45 +145,6 @@ the build (e.g. if buildozer was previously used). Removing this
 directory should fix the problem, and is desirable anyway since you
 don't want it in the APK.
 
-Errors related to Java version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The errors listed below are related to Java version mismatch, it should be
-fixed by installing Java 8.
-
-- :code:`java.lang.UnsupportedClassVersionError: com/android/dx/command/Main`
-- :code:`java.lang.NoClassDefFoundError: sun/misc/BASE64Encoder`
-- :code:`java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema`
-
-On Ubuntu fix it my making sure only the :code:`openjdk-8-jdk` package is installed::
-
-    apt remove --purge openjdk-*-jdk
-    apt install openjdk-8-jdk
-
-In the similar fashion for macOS you need to install the :code:`java8` package::
-
-    brew cask install java8
-    export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-
-
-Error: Cask 'java8' is unavailable: No Cask with this name exists
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to install Java 8 on macOS you may need extra steps::
-
-    brew tap homebrew/cask-versions
-    brew cask install homebrew/cask-versions/adoptopenjdk8
-    export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-
-
-JNI DETECTED ERROR IN APPLICATION: static jfieldID 0x0000000 not valid for class java.lang.Class<org.renpy.android.PythonActivity>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This error appears in the logcat log if you try to access
-``org.renpy.android.PythonActivity`` from within the new toolchain. To
-fix it, change your code to reference
-``org.kivy.android.PythonActivity`` instead.
-
 Requested API target 19 is not available, install it with the SDK android tool
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- bumps CI build to OpenJDK 13
- bumps Android SDK Build-Tools to 29.0.3
- unpins Cython as it currently works with latest versions
- cleans troubleshooting documentation