### PR TITLE
:bug: Fixes service_only and webview symbol errors, closes #2228

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -13,9 +13,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -27,7 +25,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
 import android.widget.ImageView;

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -9,7 +9,10 @@ import java.util.List;
 import java.util.ArrayList;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface
 import android.content.Intent;
+import android.view.KeyEvent;
 import android.util.Log;
 import android.widget.Toast;
 import android.os.Bundle;

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -11,7 +11,10 @@ import java.util.List;
 import java.util.ArrayList;
 
 import android.view.ViewGroup;
+import android.view.KeyEvent;
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.util.Log;
 import android.widget.Toast;


### PR DESCRIPTION
The error was:
```
Listing '/home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/webview_includes'...
[INFO]:    Detected highest available build tools version to be 28.0.2
[DEBUG]:   -> running gradlew assembleDebug
[DEBUG]:        Starting a Gradle Daemon, 2 incompatible and 1 stopped Daemons could not be reused, use --status for details
[DEBUG]:
[DEBUG]:        > Task :compileDebugJavaWithJavac FAILED
[DEBUG]:        /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/src/main/java/org/kivy/android/PythonActivity.java:245: error: cannot find symbol
[DEBUG]:            public boolean onKeyDown(int keyCode, KeyEvent event) {
[DEBUG]:                                                  ^
[DEBUG]:          symbol:   class KeyEvent
[DEBUG]:          location: class PythonActivity
[DEBUG]:        /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/src/main/java/org/kivy/android/PythonActivity.java:130: error: package AlertDialog does not exist
[DEBUG]:                        AlertDialog.Builder dlgAlert  = new AlertDialog.Builder(PythonActivity.mActivity);
[DEBUG]:                                   ^
[DEBUG]:        /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/src/main/java/org/kivy/android/PythonActivity.java:130: error: package AlertDialog does not exist
[DEBUG]:                        AlertDialog.Builder dlgAlert  = new AlertDialog.Builder(PythonActivity.mActivity);
[DEBUG]:                                                                       ^
[DEBUG]:        /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/src/main/java/org/kivy/android/PythonActivity.java:137: error: package DialogInterface does not exist
[DEBUG]:                            new DialogInterface.OnClickListener() {
[DEBUG]:                                               ^
[DEBUG]:        /home/user/.local/share/python-for-android/dists/unnamed_dist_1__armeabi-v7a/src/main/java/org/kivy/android/PythonActivity.java:247: error: cannot find symbol
[DEBUG]:                if ((keyCode == KeyEvent.KEYCODE_BACK) && mWebView.canGoBack()) {
[DEBUG]:                                ^
[DEBUG]:          symbol:   variable KeyEvent
[DEBUG]:          location: class PythonActivity
[DEBUG]:        Note: Some input files use or override a deprecated API.
[DEBUG]:        Note: Recompile with -Xlint:deprecation for details.
[DEBUG]:        5 errors
[DEBUG]:
[DEBUG]:
[DEBUG]:        FAILURE: Build failed with an exception.
[DEBUG]:
[DEBUG]:        * What went wrong:
[DEBUG]:        Execution failed for task ':compileDebugJavaWithJavac'.
[DEBUG]:        > Compilation failed; see the compiler error output for details.
[DEBUG]:
[DEBUG]:        * Try:
[DEBUG]:        Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
[DEBUG]:
[DEBUG]:        * Get more help at https://help.gradle.org
[DEBUG]:
[DEBUG]:        BUILD FAILED in 29s
[DEBUG]:        15 actionable tasks: 3 executed, 12 up-to-date
```