### PR TITLE
Updated gradle plugin version

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -5,7 +5,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 
@@ -99,14 +99,15 @@ android {
 
 dependencies {
     {%- for aar in aars %}
-    compile(name: '{{ aar }}', ext: 'aar')
+    implementation(name: '{{ aar }}', ext: 'aar')
     {%- endfor -%}
     {%- for jar in jars %}
-    compile files('src/main/libs/{{ jar }}')
+    implementation files('src/main/libs/{{ jar }}')
     {%- endfor -%}
     {%- if args.depends -%}
     {%- for depend in args.depends %}
-    compile '{{ depend }}'
+    implementation '{{ depend }}'
     {%- endfor %}
     {%- endif %}
 }
+


### PR DESCRIPTION
Description of changes:

* 3.1.4 seems to be pretty outdated and also has some issues with Firebase, 3.5.2 works quite well.
* Got rid of deprecated `compile` method. Replaced them with `implementation`.
<del>* Added extra `classpath` and `apply plugin` as they're required to use firebase(Instead of hardcoding these in the build.gradle file, there could be options to add extra `classpath` and `apply plugin` as per one's requirement).</del> (Because Google services plugin requires a google-services.json file so this plugin must only be added if requires)
