### PR TITLE
Bump libpq version

### DIFF
--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -4,30 +4,30 @@ import os.path
 
 
 class LibpqRecipe(Recipe):
-    version = "10.12"
-    url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
+    version = '10.12'
+    url = 'http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2'
     depends = []
 
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)
-        env["USE_DEV_URANDOM"] = "1"
+        env['USE_DEV_URANDOM'] = '1'
 
         return env
 
     def should_build(self, arch):
-        return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
+        return not os.path.isfile('{}/libpq.a'.format(self.ctx.get_libs_dir(arch.arch)))
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 
         with current_directory(self.get_build_dir(arch.arch)):
-            configure = sh.Command("./configure")
-            shprint(configure, "--without-readline", "--host=arm-linux", _env=env)
-            shprint(sh.make, "submake-libpq", _env=env)
+            configure = sh.Command('./configure')
+            shprint(configure, '--without-readline', '--host=arm-linux', _env=env)
+            shprint(sh.make, 'submake-libpq', _env=env)
             shprint(
                 sh.cp,
-                "-a",
-                "src/interfaces/libpq/libpq.a",
+                '-a',
+                'src/interfaces/libpq/libpq.a',
                 self.ctx.get_libs_dir(arch.arch),
             )
 

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -8,6 +8,12 @@ class LibpqRecipe(Recipe):
     url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
     depends = []
 
+    def get_recipe_env(self, arch):
+        env = super().get_recipe_env(arch)
+        env["USE_DEV_URANDOM"] = "1"
+
+        return env
+
     def should_build(self, arch):
         return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
 

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -22,14 +22,11 @@ class LibpqRecipe(Recipe):
 
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
-            shprint(configure, '--without-readline', '--host=arm-linux', _env=env)
+            shprint(configure, '--without-readline', '--host=arm-linux',
+                    _env=env)
             shprint(sh.make, 'submake-libpq', _env=env)
-            shprint(
-                sh.cp,
-                '-a',
-                'src/interfaces/libpq/libpq.a',
-                self.ctx.get_libs_dir(arch.arch),
-            )
+            shprint(sh.cp, '-a', 'src/interfaces/libpq/libpq.a',
+                    self.ctx.get_libs_dir(arch.arch))
 
 
 recipe = LibpqRecipe()

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -4,23 +4,26 @@ import os.path
 
 
 class LibpqRecipe(Recipe):
-    version = '9.5.3'
-    url = 'http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2'
+    version = "10.12"
+    url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
     depends = []
 
     def should_build(self, arch):
-        return not os.path.isfile('{}/libpq.a'.format(self.ctx.get_libs_dir(arch.arch)))
+        return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 
         with current_directory(self.get_build_dir(arch.arch)):
-            configure = sh.Command('./configure')
-            shprint(configure, '--without-readline', '--host=arm-linux',
-                    _env=env)
-            shprint(sh.make, 'submake-libpq', _env=env)
-            shprint(sh.cp, '-a', 'src/interfaces/libpq/libpq.a',
-                    self.ctx.get_libs_dir(arch.arch))
+            configure = sh.Command("./configure")
+            shprint(configure, "--without-readline", "--host=arm-linux", _env=env)
+            shprint(sh.make, "submake-libpq", _env=env)
+            shprint(
+                sh.cp,
+                "-a",
+                "src/interfaces/libpq/libpq.a",
+                self.ctx.get_libs_dir(arch.arch),
+            )
 
 
 recipe = LibpqRecipe()


### PR DESCRIPTION
Since buildozer bumped ubuntu versions for their docker image to ubuntu 20.04, the version in the recipe of libpq does not follow the one privided by that distro.

Bumping the version of libpq to follow the one provided by ubuntu 20.04, which is postgresql 10.12, is the easiest way to be able to compile this library on that docker image.

The addition of the environment variable `USE_DEV_URANDOM` prevents the `./configure` stage to look for the file `/dev/urandom` while cross compiling.