### PR TITLE
Fix runtime psycopg2 error

### DIFF
--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -4,30 +4,30 @@ import os.path
 
 
 class LibpqRecipe(Recipe):
-    version = "10.12"
-    url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
+    version = '10.12'
+    url = 'http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2'
     depends = []
 
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)
-        env["USE_DEV_URANDOM"] = "1"
+        env['USE_DEV_URANDOM'] = '1'
 
         return env
 
     def should_build(self, arch):
-        return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
+        return not os.path.isfile('{}/libpq.a'.format(self.ctx.get_libs_dir(arch.arch)))
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 
         with current_directory(self.get_build_dir(arch.arch)):
-            configure = sh.Command("./configure")
-            shprint(configure, "--without-readline", "--host=arm-linux", _env=env)
-            shprint(sh.make, "submake-libpq", _env=env)
+            configure = sh.Command('./configure')
+            shprint(configure, '--without-readline', '--host=arm-linux', _env=env)
+            shprint(sh.make, 'submake-libpq', _env=env)
             shprint(
                 sh.cp,
-                "-a",
-                "src/interfaces/libpq/libpq.a",
+                '-a',
+                'src/interfaces/libpq/libpq.a',
                 self.ctx.get_libs_dir(arch.arch),
             )
 

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -8,6 +8,12 @@ class LibpqRecipe(Recipe):
     url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
     depends = []
 
+    def get_recipe_env(self, arch):
+        env = super().get_recipe_env(arch)
+        env["USE_DEV_URANDOM"] = "1"
+
+        return env
+
     def should_build(self, arch):
         return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
 

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -22,14 +22,11 @@ class LibpqRecipe(Recipe):
 
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
-            shprint(configure, '--without-readline', '--host=arm-linux', _env=env)
+            shprint(configure, '--without-readline', '--host=arm-linux',
+                    _env=env)
             shprint(sh.make, 'submake-libpq', _env=env)
-            shprint(
-                sh.cp,
-                '-a',
-                'src/interfaces/libpq/libpq.a',
-                self.ctx.get_libs_dir(arch.arch),
-            )
+            shprint(sh.cp, '-a', 'src/interfaces/libpq/libpq.a',
+                    self.ctx.get_libs_dir(arch.arch))
 
 
 recipe = LibpqRecipe()

--- a/pythonforandroid/recipes/libpq/__init__.py
+++ b/pythonforandroid/recipes/libpq/__init__.py
@@ -4,23 +4,26 @@ import os.path
 
 
 class LibpqRecipe(Recipe):
-    version = '9.5.3'
-    url = 'http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2'
+    version = "10.12"
+    url = "http://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.bz2"
     depends = []
 
     def should_build(self, arch):
-        return not os.path.isfile('{}/libpq.a'.format(self.ctx.get_libs_dir(arch.arch)))
+        return not os.path.isfile("{}/libpq.a".format(self.ctx.get_libs_dir(arch.arch)))
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)
 
         with current_directory(self.get_build_dir(arch.arch)):
-            configure = sh.Command('./configure')
-            shprint(configure, '--without-readline', '--host=arm-linux',
-                    _env=env)
-            shprint(sh.make, 'submake-libpq', _env=env)
-            shprint(sh.cp, '-a', 'src/interfaces/libpq/libpq.a',
-                    self.ctx.get_libs_dir(arch.arch))
+            configure = sh.Command("./configure")
+            shprint(configure, "--without-readline", "--host=arm-linux", _env=env)
+            shprint(sh.make, "submake-libpq", _env=env)
+            shprint(
+                sh.cp,
+                "-a",
+                "src/interfaces/libpq/libpq.a",
+                self.ctx.get_libs_dir(arch.arch),
+            )
 
 
 recipe = LibpqRecipe()

--- a/pythonforandroid/recipes/psycopg2/__init__.py
+++ b/pythonforandroid/recipes/psycopg2/__init__.py
@@ -10,7 +10,7 @@ class Psycopg2Recipe(PythonRecipe):
     `ANDROID_API` (`ndk-api`) >= 26, see:
     https://github.com/kivy/python-for-android/issues/1711#issuecomment-465747557
     """
-    version = '2.8.4'
+    version = '2.8.5'
     url = 'https://pypi.python.org/packages/source/p/psycopg2/psycopg2-{version}.tar.gz'
     depends = ['libpq', 'setuptools']
     site_packages_name = 'psycopg2'


### PR DESCRIPTION
I inadvertently introduced a runtime error in #2245.

For some reason psycopg2 2.8.4 has a linking issue to PQencryptPasswordConn. This seems to have been fixed with 2.8.5 on my machine. So a simple revision bump should be fine.