### PR TITLE
SDL2 caching event->DeviceId and event->source

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
+++ b/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
@@ -72,3 +72,53 @@
          SDLActivity.nativeRunMain(library, function, arguments);
  
          Log.v("SDL", "Finished main function");
+@@ -1799,6 +1799,10 @@
+     // Key events
+     @Override
+     public boolean onKey(View  v, int keyCode, KeyEvent event) {
++
++        int deviceId = event.getDeviceId();
++        int source = event.getSource();
++
+         // Dispatch the different events depending on where they come from
+         // Some SOURCE_JOYSTICK, SOURCE_DPAD or SOURCE_GAMEPAD are also SOURCE_KEYBOARD
+         // So, we try to process them as JOYSTICK/DPAD/GAMEPAD events first, if that fails we try them as KEYBOARD
+@@ -1806,20 +1810,25 @@
+         // Furthermore, it's possible a game controller has SOURCE_KEYBOARD and
+         // SOURCE_JOYSTICK, while its key events arrive from the keyboard source
+         // So, retrieve the device itself and check all of its sources
+-        if (SDLControllerManager.isDeviceSDLJoystick(event.getDeviceId())) {
++        if (SDLControllerManager.isDeviceSDLJoystick(deviceId)) {
+             // Note that we process events with specific key codes here
+             if (event.getAction() == KeyEvent.ACTION_DOWN) {
+-                if (SDLControllerManager.onNativePadDown(event.getDeviceId(), keyCode) == 0) {
++                if (SDLControllerManager.onNativePadDown(deviceId, keyCode) == 0) {
+                     return true;
+                 }
+             } else if (event.getAction() == KeyEvent.ACTION_UP) {
+-                if (SDLControllerManager.onNativePadUp(event.getDeviceId(), keyCode) == 0) {
++                if (SDLControllerManager.onNativePadUp(deviceId, keyCode) == 0) {
+                     return true;
+                 }
+             }
+         }
+ 
+-        if ((event.getSource() & InputDevice.SOURCE_KEYBOARD) != 0) {
++        if (source == InputDevice.SOURCE_UNKNOWN) {
++            InputDevice device = InputDevice.getDevice(deviceId);
++            source = device.getSources();
++        }
++
++        if ((source & InputDevice.SOURCE_KEYBOARD) != 0) {
+             if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                 //Log.v("SDL", "key down: " + keyCode);
+                 if (SDLActivity.isTextInputEvent(event)) {
+@@ -1835,7 +1844,7 @@
+             }
+         }
+ 
+-        if ((event.getSource() & InputDevice.SOURCE_MOUSE) != 0) {
++        if ((source & InputDevice.SOURCE_MOUSE) != 0) {
+             // on some devices key events are sent for mouse BUTTON_BACK/FORWARD presses
+             // they are ignored here because sending them as mouse input to SDL is messy
+             if ((keyCode == KeyEvent.KEYCODE_BACK) || (keyCode == KeyEvent.KEYCODE_FORWARD)) {


### PR DESCRIPTION
Credits https://hg.libsdl.org/SDL/rev/b5cd5e1e4440
Fixes https://github.com/kivy/kivy/issues/6686, https://github.com/kivy/python-for-android/issues/1903, https://github.com/spesmilo/electrum/issues/6276


Tested using the app provided in https://github.com/kivy/kivy/issues/6686

```
from kivy.config import Config
Config.set('kivy', 'exit_on_escape', 'False')

from kivy.app import App
from kivy.lang import Builder
from kivy.core.window import Window
from kivy.uix.screenmanager import ScreenManager


Builder.load_string("""

<Main>:
    id: scr_mngr
    Screen:                           
        name: 'main'
        BoxLayout:
            orientation: "vertical"
            size_hint: 1,1
            pos_hint: {'top':1}
            Label:
                text: "Main Screen"
                size_hint: 1,.1
            Button:
                size_hint: 1,.1
                text: "Go Second Screen"
                on_press: root.go_second()
            Widget:
                
    Screen:                           
        name: 'second'
        BoxLayout:
            orientation: "vertical"
            size_hint: 1,1
            pos_hint: {'top':1}
            Label:
                text: "Second Screen"
                size_hint: 1,.1
            TextInput:
                size_hint: 1,.2
                text: "TextInput"
            Widget:
""")

class Main(ScreenManager):
    def __init__(self, **kwargs): 
        super(Main, self).__init__(**kwargs)
        Window.bind(on_keyboard = self.keyboard)
        
    def keyboard(self,window,key,*args):
        print(str(key))
        if key == 27:
            self.transition.direction  = "right"
            self.current = "main"
            
    def go_second(self,*args):
        self.transition.direction  = "left"
        self.current = "second"

class MyApp(App):    
    def build(self):
        return Main()

if __name__ == '__main__':
    MyApp().run()
```