### PR TITLE
Add Recipe for Kivy3 module 

### DIFF
--- a/pythonforandroid/recipes/kivy3/__init__.py
+++ b/pythonforandroid/recipes/kivy3/__init__.py
@@ -12,8 +12,6 @@ class Kivy3Recipe(PythonRecipe):
     '''Due to setuptools.'''
     call_hostpython_via_targetpython = False
 
-    # install_in_hostpython = True
-
     def build_arch(self, arch):
         super().build_arch(arch)
         suffix = '/kivy3/default.glsl'

--- a/pythonforandroid/recipes/kivy3/__init__.py
+++ b/pythonforandroid/recipes/kivy3/__init__.py
@@ -4,7 +4,7 @@ import shutil
 
 class Kivy3Recipe(PythonRecipe):
     version = 'master'
-    url = 'https://github.com/KeyWeeUsr/kivy3/archive/{version}.zip'
+    url = 'https://github.com/kivy/kivy3/archive/{version}.zip'
 
     depends = ['kivy']
     site_packages_name = 'kivy3'

--- a/pythonforandroid/recipes/kivy3/__init__.py
+++ b/pythonforandroid/recipes/kivy3/__init__.py
@@ -1,0 +1,23 @@
+from pythonforandroid.recipe import PythonRecipe
+import shutil
+
+
+class Kivy3Recipe(PythonRecipe):
+    version = 'master'
+    url = 'https://github.com/KeyWeeUsr/kivy3/archive/{version}.zip'
+
+    depends = ['kivy']
+    site_packages_name = 'kivy3'
+
+    '''Due to setuptools.'''
+    call_hostpython_via_targetpython = False
+
+    # install_in_hostpython = True
+
+    def build_arch(self, arch):
+        super().build_arch(arch)
+        suffix = '/kivy3/default.glsl'
+        shutil.copyfile(self.get_build_dir(arch.arch) + suffix, self.ctx.get_python_install_dir() + suffix)
+
+
+recipe = Kivy3Recipe()


### PR DESCRIPTION
Adding the _kivy3_ module in the requirements in  .spec file results to the installation of the module via pip during the debug process. However, the **default.glsl** file is not copied to the python-installs directory along with the rest of the files and, subsequently to the distributions folder. This recipe remedies the issue.

I created this pull-request following @inclement 's advice on discord. Thanks.   