### PR TITLE
build python3 with loadable-sqlite-extensions

### DIFF
--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -94,7 +94,8 @@ class Python3Recipe(TargetPythonRecipe):
         '--without-ensurepip',
         'ac_cv_little_endian_double=yes',
         '--prefix={prefix}',
-        '--exec-prefix={exec_prefix}')
+        '--exec-prefix={exec_prefix}',
+        '--enable-loadable-sqlite-extensions')
     '''The configure arguments needed to build the python recipe. Those are
     used in method :meth:`build_arch` (if not overwritten like python3's
     recipe does).


### PR DESCRIPTION
I assume most users don't need this (unlike me), but I don't really see any downsides to having it enabled by default.