### PR TITLE
`libpython3.8m.so` should not have `m` suffix

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -43,7 +43,7 @@ public class PythonUtil {
         libsList.add("python3.5m");
         libsList.add("python3.6m");
         libsList.add("python3.7m");
-        libsList.add("python3.8m");
+        libsList.add("python3.8");
         libsList.add("main");
         return libsList;
     }

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -757,9 +757,7 @@ class BootstrapNDKRecipe(Recipe):
         env['PYTHON_INCLUDE_ROOT'] = self.ctx.python_recipe.include_root(arch.arch)
         env['PYTHON_LINK_ROOT'] = self.ctx.python_recipe.link_root(arch.arch)
         env['EXTRA_LDLIBS'] = ' -lpython{}'.format(
-            self.ctx.python_recipe.major_minor_version_string)
-        if 'python3' in self.ctx.python_recipe.name:
-            env['EXTRA_LDLIBS'] += 'm'
+            self.ctx.python_recipe.link_version)
         return env
 
 
@@ -896,16 +894,13 @@ class PythonRecipe(Recipe):
         env['LANG'] = "en_GB.UTF-8"
 
         if not self.call_hostpython_via_targetpython:
-            python_name = self.ctx.python_recipe.name
             env['CFLAGS'] += ' -I{}'.format(
                 self.ctx.python_recipe.include_root(arch.arch)
             )
             env['LDFLAGS'] += ' -L{} -lpython{}'.format(
                 self.ctx.python_recipe.link_root(arch.arch),
-                self.ctx.python_recipe.major_minor_version_string,
+                self.ctx.python_recipe.link_version,
             )
-            if python_name == 'python3':
-                env['LDFLAGS'] += 'm'
 
             hppath = []
             hppath.append(join(dirname(self.hostpython_location), 'Lib'))

--- a/pythonforandroid/recipes/boost/__init__.py
+++ b/pythonforandroid/recipes/boost/__init__.py
@@ -92,11 +92,7 @@ class BoostRecipe(Recipe):
         env['PYTHON_ROOT'] = self.ctx.python_recipe.link_root(arch.arch)
         env['PYTHON_INCLUDE'] = self.ctx.python_recipe.include_root(arch.arch)
         env['PYTHON_MAJOR_MINOR'] = self.ctx.python_recipe.version[:3]
-        env[
-            'PYTHON_LINK_VERSION'
-        ] = self.ctx.python_recipe.major_minor_version_string
-        if 'python3' in self.ctx.python_recipe.name:
-            env['PYTHON_LINK_VERSION'] += 'm'
+        env['PYTHON_LINK_VERSION'] = self.ctx.python_recipe.link_version
 
         env['ARCH'] = arch.arch.replace('-', '')
         env['TARGET_TRIPLET'] = arch.target

--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -43,9 +43,7 @@ class CffiRecipe(CompiledComponentsPythonRecipe):
             env['BUILDLIB_PATH'],
         ])
         env['LDFLAGS'] += ' -L{}'.format(self.ctx.python_recipe.link_root(arch.arch))
-        env['LDFLAGS'] += ' -lpython{}'.format(self.ctx.python_recipe.major_minor_version_string)
-        if 'python3' in self.ctx.python_recipe.name:
-            env['LDFLAGS'] += 'm'
+        env['LDFLAGS'] += ' -lpython{}'.format(self.ctx.python_recipe.link_version)
         return env
 
 

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -63,9 +63,7 @@ class OpenCVRecipe(NDKRecipe):
             python_include_root = self.ctx.python_recipe.include_root(arch.arch)
             python_site_packages = self.ctx.get_site_packages_dir()
             python_link_root = self.ctx.python_recipe.link_root(arch.arch)
-            python_link_version = self.ctx.python_recipe.major_minor_version_string
-            if 'python3' in self.ctx.python_recipe.name:
-                python_link_version += 'm'
+            python_link_version = self.ctx.python_recipe.link_version
             python_library = join(python_link_root,
                                   'libpython{}.so'.format(python_link_version))
             python_include_numpy = join(python_site_packages,

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -155,10 +155,22 @@ class Python3Recipe(TargetPythonRecipe):
     @property
     def _libpython(self):
         '''return the python's library name (with extension)'''
-        py_version = self.major_minor_version_string
-        if self.major_minor_version_string[0] == '3':
-            py_version += 'm'
-        return 'libpython{version}.so'.format(version=py_version)
+        return 'libpython{link_version}.so'.format(
+            link_version=self.link_version
+        )
+
+    @property
+    def link_version(self):
+        '''return the python's library link version e.g. 3.7m, 3.8'''
+        major, minor = self.major_minor_version_string.split('.')
+        flags = ''
+        if major == '3' and int(minor) < 8:
+            flags += 'm'
+        return '{major}.{minor}{flags}'.format(
+            major=major,
+            minor=minor,
+            flags=flags
+        )
 
     def include_root(self, arch_name):
         return join(self.get_build_dir(arch_name), 'Include')
@@ -393,9 +405,7 @@ class Python3Recipe(TargetPythonRecipe):
         # copy the python .so files into place
         python_build_dir = join(self.get_build_dir(arch.arch),
                                 'android-build')
-        python_lib_name = 'libpython' + self.major_minor_version_string
-        if self.major_minor_version_string[0] == '3':
-            python_lib_name += 'm'
+        python_lib_name = 'libpython' + self.link_version
         shprint(
             sh.cp,
             join(python_build_dir, python_lib_name + '.so'),

--- a/tests/recipes/test_python3.py
+++ b/tests/recipes/test_python3.py
@@ -19,7 +19,7 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
     def test_property__libpython(self):
         self.assertEqual(
             self.recipe._libpython,
-            f'libpython{self.recipe.major_minor_version_string}m.so'
+            f'libpython{self.recipe.link_version}.so'
         )
 
     @mock.patch('pythonforandroid.recipes.python3.Path.is_file')


### PR DESCRIPTION
Hi,

I'm helping a user to diagnose a downstream issue https://github.com/PyO3/pyo3/issues/1077 when compiling a Rust application using p4a. In the linked issue is a lot of background and the OP also contains a link to a minimal example.

Their build with p4a targeting Python 3.8 was failing with link errors. Their workaround was to manually link to `libpython3.8m.so`.

However, I understood the `m` suffix was removed with Python 3.8 after pymalloc builds became ABI-compatible with the mainline: https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes

So I think that `libpython3.8m.so` is a non-standard name for libpython, and propose here the `m` suffix is dropped by p4a.

I am very new to the p4a codebase, so please give me a heads-up for any other sections of the code that should be adjusted for this and I'm happy to round off this PR.