### PR TITLE
(host)python3: rm version check for pyconfig patch

### DIFF
--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from os.path import join
 
 from pythonforandroid.logger import shprint
-from pythonforandroid.patching import is_version_lt
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import (
     BuildInterruptingException,
@@ -45,9 +44,7 @@ class HostPython3Recipe(Recipe):
     '''The default url to download our host python recipe. This url will
     change depending on the python version set in attribute :attr:`version`.'''
 
-    patches = (
-        ('patches/pyconfig_detection.patch', is_version_lt("3.8.3")),
-    )
+    patches = ['patches/pyconfig_detection.patch']
 
     @property
     def _exe_name(self):

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from shutil import copy2
 
 from pythonforandroid.logger import info, warning, shprint
-from pythonforandroid.patching import version_starts_with, is_version_lt
+from pythonforandroid.patching import version_starts_with
 from pythonforandroid.recipe import Recipe, TargetPythonRecipe
 from pythonforandroid.util import (
     current_directory,
@@ -61,7 +61,7 @@ class Python3Recipe(TargetPythonRecipe):
     name = 'python3'
 
     patches = [
-        ('patches/pyconfig_detection.patch', is_version_lt("3.8.3")),
+        'patches/pyconfig_detection.patch',
 
         # Python 3.7.1
         ('patches/py3.7.1_fix-ctypes-util-find-library.patch', version_starts_with("3.7")),


### PR DESCRIPTION
Fixes the osx build.

The patch in #2159 was only applied for < 3.8.3, but the problem still exists with 3.8.5.