### PR TITLE
Call cython via the setuptools entrypoint, fixes #2311

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1089,10 +1089,7 @@ class CythonRecipe(PythonRecipe):
             del cyenv['PYTHONPATH']
         if 'PYTHONNOUSERSITE' in cyenv:
             cyenv.pop('PYTHONNOUSERSITE')
-        python_command = sh.Command("python{}".format(
-            self.ctx.python_recipe.major_minor_version_string.split(".")[0]
-        ))
-        shprint(python_command, "-m", "Cython.Build.Cythonize",
+        shprint(sh.Command("cython"),
                 filename, *self.cython_args, _env=cyenv)
 
     def cythonize_build(self, env, build_dir="."):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1089,7 +1089,11 @@ class CythonRecipe(PythonRecipe):
             del cyenv['PYTHONPATH']
         if 'PYTHONNOUSERSITE' in cyenv:
             cyenv.pop('PYTHONNOUSERSITE')
-        shprint(sh.Command("cython"),
+        python_command = sh.Command("python{}".format(
+            self.ctx.python_recipe.major_minor_version_string.split(".")[0]
+        ))
+        shprint(python_command, "-c"
+                "import sys; from Cython.Compiler.Main import setuptools_main; sys.exit(setuptools_main());",
                 filename, *self.cython_args, _env=cyenv)
 
     def cythonize_build(self, env, build_dir="."):


### PR DESCRIPTION
As per #2311, the. running `python -m Cython.Build.Cythonize` is **not** the same thing as running `cython`