### PR TITLE
Added a build.py argument to add arbitrary xml to the <application> section of AndroidManifest.xml

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -775,6 +775,9 @@ tools directory of the Android SDK.
     ap.add_argument('--extra-manifest-xml', default='',
                     help=('Extra xml to write directly inside the <manifest> element of'
                           'AndroidManifest.xml'))
+    ap.add_argument('--extra-manifest-application-xml', default='',
+                    help=('Extra xml to write directly inside the <manifest><application> element of'
+                          'AndroidManifest.xml'))
     ap.add_argument('--manifest-placeholders', dest='manifest_placeholders',
                     default='[:]', help=('Inject build variables into the manifest '
                                          'via the manifestPlaceholders property'))

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -133,6 +133,9 @@
     {% for a in args.add_activity  %}
     <activity android:name="{{ a }}"></activity>
     {% endfor %}
+
+    {{ args.extra_manifest_application_xml }}
+
     </application>
 
 </manifest>


### PR DESCRIPTION
This fasciliates BOOT_COMPLETED, as per https://github.com/kivy/kivy/wiki/Starting-Kivy-App-and-Service-on-bootup-on-Android, as well as  fascilitates api29 storage workaround (as mentioned on Discord `android-support` channel. https://discord.com/channels/423249981340778496/712344698559397895/755856361283387522)

Buildozer update will follow once this is merged in.