### PR TITLE
add android:usesCleartextTraffic="true" to sdl2

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -60,7 +60,8 @@
                  android:allowBackup="{{ args.allow_backup }}"
                  {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
-                 android:hardwareAccelerated="true" >
+                 android:hardwareAccelerated="true" 
+                 android:usesCleartextTraffic="true">
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />
         {% endfor %}


### PR DESCRIPTION
add android:usesCleartextTraffic="true" to sdl2 for using webview with kivy


```python3

from kivy.app import App
from jnius import autoclass
from kivy.clock import Clock
from android.runnable import run_on_ui_thread
from kivy.uix.widget import Widget

WebView = autoclass("android.webkit.WebView")
WebSettings = autoclass("android.webkit.WebSettings")
WebViewClient = autoclass("android.webkit.WebViewClient")
activity = autoclass("org.kivy.android.PythonActivity").mActivity


@run_on_ui_thread
def create_webview(*args):
    webview = WebView(activity)
    webview.getSettings().setJavaScriptEnabled(True)
    webview.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW)
    wvc = WebViewClient()
    webview.setWebViewClient(wvc)
    activity.setContentView(webview)
    webview.loadUrl("http://18.15.178.11:9999")


class Wv(Widget):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.__functionstable__ = {}
        Clock.schedule_once(create_webview, 0)


class ServiceApp(App):
    def build(self):
        return Wv()


if __name__ == "__main__":
    ServiceApp().run()

```