### PR TITLE
update Python to 3.9.2

### DIFF
--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -33,7 +33,7 @@ class HostPython3Recipe(Recipe):
         :class:`~pythonforandroid.python.HostPythonRecipe`
     '''
 
-    version = '3.8.5'
+    version = '3.9.2'
     name = 'hostpython3'
 
     build_subdir = 'native-build'

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -56,7 +56,7 @@ class Python3Recipe(TargetPythonRecipe):
         :class:`~pythonforandroid.python.GuestPythonRecipe`
     '''
 
-    version = '3.8.5'
+    version = '3.9.2'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 


### PR DESCRIPTION
My webview app seems to work fine w/ 3.9.0.

Since the 3.8.1 patches seem to work fine with 3.9.0 I decided not to rename/duplicate them (for now).