### PR TITLE
Add service information for buildozer.spec

### DIFF
--- a/doc/source/services.rst
+++ b/doc/source/services.rst
@@ -53,11 +53,13 @@ options.
 
 To create the service, create a python script with your service code
 and add a :code:`--service=myservice:/path/to/myservice.py` argument
-when calling python-for-android. The ``myservice`` name before the
-colon is the name of the service class, via which you will interact
-with it later. You can add multiple
-:code:`--service` arguments to include multiple services, which you
-will later be able to stop and start from your app.
+when calling python-for-android, or in buildozer.spec, a
+:code:`services = myservice:/path/to/myservice.py` [app] setting.
+The ``myservice`` name before the colon is the name of the service
+class, via which you will interact with it later. You can add multiple
+:code:`--service` arguments to include multiple services, or separate
+them with a comma in buildozer.spec, all of which you will later be
+able to stop and start from your app.
 
 To run the services (i.e. starting them from within your main app
 code), you must use PyJNIus to interact with the java class


### PR DESCRIPTION
Since this seems to be where the background service documentation is, I wanted to add how to set them up in buildozer.