### PR TITLE
Enable androidx

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -196,8 +196,7 @@ options (this list may not be exhaustive):
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--compile-pyo``: Optimise .py files to .pyo.
 - ``--resource``: A key=value pair to add in the string.xml resource file.
-- ``--enable-androidx``: If the argument is included, the AndroidX support 
-library is enabled. 
+- ``--enable-androidx``: If the argument is included, the AndroidX support library is enabled. 
 
 
 Requirements blacklist (APK size optimization)

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -196,7 +196,8 @@ options (this list may not be exhaustive):
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--compile-pyo``: Optimise .py files to .pyo.
 - ``--resource``: A key=value pair to add in the string.xml resource file.
-- ``--enable-androidx``: If the argument is included, build.tmpl.gradle is modified. 
+- ``--enable-androidx``: If the argument is included, the AndroidX support 
+library is enabled. 
 
 
 Requirements blacklist (APK size optimization)

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -196,6 +196,7 @@ options (this list may not be exhaustive):
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--compile-pyo``: Optimise .py files to .pyo.
 - ``--resource``: A key=value pair to add in the string.xml resource file.
+- ``--enable-androidx``: If the argument is included, build.tmpl.gradle is modified. 
 
 
 Requirements blacklist (APK size optimization)

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -677,7 +677,7 @@ tools directory of the Android SDK.
 
     ap.add_argument('--enable-androidx', dest='enable_androidx',
                     action='store_true',
-                    help=('Enable the AndroidX support library, ' 
+                    help=('Enable the AndroidX support library, '
                           'add a library using gradle_dependencies, '
                           'requires api = 28 or greater'))
     ap.add_argument('--android-entrypoint', dest='android_entrypoint',

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -675,6 +675,11 @@ tools directory of the Android SDK.
                               'topics/manifest/'
                               'activity-element.html'))
 
+    ap.add_argument('--enable-androidx', dest='enable_androidx',
+                    action='store_true',
+                    help=('Enable the AndroidX support library, ' 
+                          'add a library using gradle_dependencies, '
+                          'requires api = 28 or greater'))
     ap.add_argument('--android-entrypoint', dest='android_entrypoint',
                     default='org.kivy.android.PythonActivity',
                     help='Defines which java class will be used for startup, usually a subclass of PythonActivity')

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -96,6 +96,13 @@ android {
         }
     }
 
+    {% if args.enable_androidx %}
+    ext {
+        useAndroidX=true
+        enableJetifier=true
+    }
+    {% endif %}
+
 }
 
 dependencies {


### PR DESCRIPTION
Addresses https://github.com/kivy/python-for-android/issues/2020
AndroidX is a support library that replaces the depreciated Android support library.

This PR adds a build option `--enable-androidx` which (when used) adds a block to `build.tmpl.gradle`
When AndroidX is enabled, a specific AndroidX library can be added using the existing  `gradle_dependencies` option.
Some (or all?) of the latest packages in the AndroidX library depend on `api=28`  or greater.

There is an alternative implementation, setting the same two Gradle flags in a new file named `gradle.properties`. Because of the file management uncertainties introduced in the context of `p4a`, this author will not use this approach.

The previous support library is depreciated. There is an argument that AndroidX should be enabled by default. This would impact users who specify an existing support package in `gradle_dependencies`. And there may be some other unforeseen impact. Alternatively AndroidX could be enabled by `api` version, but this would not be transparent to users. I think AndroidX should be enabled by default, but not yet; so it is enabled by build command option. 

As an example user dependency consider https://github.com/kivy/python-for-android/pull/2200 , it depends on the Android support library but is agnostic to which one. However the user code required does depend on the chosen support library, the change is in a Java class name, and in the name of the `gradle_dependencies` package. 

The need for https://github.com/kivy/python-for-android/pull/2200 is wide spread; for example the `plyer` camera https://github.com/kivy/plyer/blob/master/plyer/platforms/android/camera.py uses a 'file url' which can no longer be used between Activities, so is not functional with api =29 or greater. To prevent user rework after https://github.com/kivy/python-for-android/pull/2200 is incorporated, I suggest that this PR be incorporated at the same time.