### PR TITLE
docs: fix simple typo, pacakged -> packaged

### DIFF
--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -72,7 +72,7 @@ particular.
 Unpacking an APK
 ----------------
 
-It is sometimes useful to unpack a pacakged APK to see what is inside,
+It is sometimes useful to unpack a packaged APK to see what is inside,
 especially when debugging python-for-android itself.
 
 APKs are just zip files, so you can extract the contents easily::


### PR DESCRIPTION
There is a small typo in doc/source/troubleshooting.rst.

Should read `packaged` rather than `pacakged`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md