### PR TITLE
:bug: Fixes pip command on Travis and bumps actions/setup-python

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: 3.7
     - name: Run flake8
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tox tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ jobs:
         - type -t deactivate && deactivate || true
         - export PATH=/opt/python/3.7.1/bin:$PATH
         # Install tox
-        - pip3.7 install tox>=2.0
+        - python3.7 -m pip install tox>=2.0
         # Install coveralls & dependencies
         #   Note: pyOpenSSL needed to send the coveralls reports
-        - pip3.7 install pyOpenSSL
-        - pip3.7 install coveralls
+        - python3.7 -m pip install pyOpenSSL
+        - python3.7 -m pip install coveralls
       script:
         # ignores test_pythonpackage.py since it runs for too long
         - tox -- tests/ --ignore tests/test_pythonpackage.py


### PR DESCRIPTION
Travis error was:
```
pyenv: pip3.7: command not found
```
Also bumps `actions/setup-python` to latest tag.
Hopefully fixes recent `set-env` and `add-path` commands depreciation.
The error is:
```
Error: Unable to process command
'##[set-env name=pythonLocation;]/opt/hostedtoolcache/Python/3.7.9/x64' successfully.
Error: The `set-env` command is disabled.
Please upgrade to using Environment Files or opt into unsecure command execution by
setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.
For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```