### PR TITLE
Fix Pymunk crash on older versions of Android

### DIFF
--- a/pythonforandroid/recipes/pymunk/__init__.py
+++ b/pythonforandroid/recipes/pymunk/__init__.py
@@ -10,7 +10,8 @@ class PymunkRecipe(CompiledComponentsPythonRecipe):
 
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)
-        env["LDFLAGS"] += " -llog"
+        env["LDFLAGS"] += " -llog"  # Used by Chipmunk cpMessage
+        env["LDFLAGS"] += " -lm"  # For older versions of Android
         return env
 
 


### PR DESCRIPTION
Seems to be required to link -lm on at least 5.1, but not on 8.0.
Should fix #2388