### PR TITLE
don't run git pull when not on a branch

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -220,11 +220,13 @@ class Recipe(with_metaclass(RecipeMeta)):
         elif parsed_url.scheme in ('git', 'git+file', 'git+ssh', 'git+http', 'git+https'):
             if isdir(target):
                 with current_directory(target):
-                    shprint(sh.git, 'fetch', '--tags')
+                    shprint(sh.git, 'fetch', '--tags', '--recurse-submodules')
                     if self.version:
                         shprint(sh.git, 'checkout', self.version)
-                    shprint(sh.git, 'pull')
-                    shprint(sh.git, 'pull', '--recurse-submodules')
+                    branch = sh.git('branch', '--show-current')
+                    if branch:
+                        shprint(sh.git, 'pull')
+                        shprint(sh.git, 'pull', '--recurse-submodules')
                     shprint(sh.git, 'submodule', 'update', '--recursive')
             else:
                 if url.startswith('git+'):


### PR DESCRIPTION
When using e.g. a `git+https` url and a `version` that refers to a tag (not a branch), p4a fails when the repo has already been cloned b/c it tries to run `git pull` (which requires a branch and fails with a detached HEAD). This fixes that.