### PR TITLE
recipes: print recipe ENV on failure

### DIFF
--- a/pythonforandroid/logger.py
+++ b/pythonforandroid/logger.py
@@ -214,17 +214,18 @@ def shprint(command, *args, **kwargs):
                       re.compile(filter_in) if filter_in else None,
                       re.compile(filter_out) if filter_out else None)
             printtail(err.stderr.decode('utf-8'), 'STDERR', Err_Fore.RED)
-        if is_critical:
-            env = kwargs.get("env")
+        if is_critical or full_debug:
+            env = kwargs.get("_env")
             if env is not None:
                 info("{}ENV:{}\n{}\n".format(
                     Err_Fore.YELLOW, Err_Fore.RESET, "\n".join(
-                        "set {}={}".format(n, v) for n, v in env.items())))
+                        "export {}='{}'".format(n, v) for n, v in env.items())))
             info("{}COMMAND:{}\ncd {} && {} {}\n".format(
                 Err_Fore.YELLOW, Err_Fore.RESET, os.getcwd(), command,
                 ' '.join(args)))
             warning("{}ERROR: {} failed!{}".format(
                 Err_Fore.RED, command, Err_Fore.RESET))
+        if is_critical:
             exit(1)
         else:
             raise


### PR DESCRIPTION
Print  contents of `_env` when recipe fails and `P4A_FULL_DEBUG` is set.  Printed `export` commands allow for recreation of recipe's build enviroment and faster iteration when developing complex recipes. This acts as a poor man's substitute for the analogous [devshell](https://embeddeduse.com/2018/10/13/building-yocto-packages-manually-with-devshell/) feature in OpenEmbedded.