### PR TITLE
Avoids 'Permission Denied' error during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir ${ANDROID_HOME} && chown --recursive ${USER} ${HOME_DIR} ${ANDROID_HOM
 USER ${USER}
 
 # Download and install android's NDK/SDK
-COPY ci/makefiles/android.mk /tmp/android.mk
+COPY --chown=user:user ci/makefiles/android.mk /tmp/android.mk
 RUN make --file /tmp/android.mk \
     && sudo rm /tmp/android.mk
 


### PR DESCRIPTION
During docker build ```docker build --tag=p4a --file Dockerfile .``` I got a **Permission Denied** error. Changing file permission solved the problem for me.
