### PR TITLE
Avoids build error for opencv and bumps version to 4.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir ${ANDROID_HOME} && chown --recursive ${USER} ${HOME_DIR} ${ANDROID_HOM
 USER ${USER}
 
 # Download and install android's NDK/SDK
-COPY ci/makefiles/android.mk /tmp/android.mk
+COPY --chown=user:user ci/makefiles/android.mk /tmp/android.mk
 RUN make --file /tmp/android.mk \
     && sudo rm /tmp/android.mk
 

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -13,7 +13,7 @@ class OpenCVRecipe(NDKRecipe):
         build of most of the libraries of the opencv's package, so we can
         process images, videos, objects, photos...
     '''
-    version = '4.0.1'
+    version = '4.5.1'
     url = 'https://github.com/opencv/opencv/archive/{version}.zip'
     depends = ['numpy']
     patches = ['patches/p4a_build.patch']
@@ -75,6 +75,8 @@ class OpenCVRecipe(NDKRecipe):
                     '-DANDROID_STANDALONE_TOOLCHAIN={}'.format(self.ctx.ndk_dir),
                     '-DANDROID_NATIVE_API_LEVEL={}'.format(self.ctx.ndk_api),
                     '-DANDROID_EXECUTABLE={}/tools/android'.format(env['ANDROID_SDK']),
+                    '-DANDROID_SDK_TOOLS_VERSION=6514223',
+                    '-DANDROID_PROJECTS_SUPPORT_GRADLE=ON',
 
                     '-DCMAKE_TOOLCHAIN_FILE={}'.format(
                         join(self.ctx.ndk_dir, 'build', 'cmake',

--- a/pythonforandroid/recipes/opencv_extras/__init__.py
+++ b/pythonforandroid/recipes/opencv_extras/__init__.py
@@ -15,7 +15,7 @@ class OpenCVExtrasRecipe(Recipe):
     .. seealso:: https://github.com/opencv/opencv_contrib
 
     """
-    version = '4.0.1'
+    version = '4.5.1'
     url = 'https://github.com/opencv/opencv_contrib/archive/{version}.zip'
     depends = ['opencv']
 


### PR DESCRIPTION
Allows build with docker container. Without this changes, I could not build opencv with p4a.