### PR TITLE
Adds libm to Pillow recipe

### DIFF
--- a/pythonforandroid/recipes/Pillow/__init__.py
+++ b/pythonforandroid/recipes/Pillow/__init__.py
@@ -91,7 +91,6 @@ class PillowRecipe(CompiledComponentsPythonRecipe):
             env['LDFLAGS'] += f' -L{join(webp_install, "lib")}'
         env['LDFLAGS'] += f' -L{ndk_lib_dir}'
         if cflags not in env['CFLAGS']:
-            #env['CFLAGS'] += cflags
             env['CFLAGS'] += cflags + " -lm"
         return env
 

--- a/pythonforandroid/recipes/Pillow/__init__.py
+++ b/pythonforandroid/recipes/Pillow/__init__.py
@@ -91,7 +91,8 @@ class PillowRecipe(CompiledComponentsPythonRecipe):
             env['LDFLAGS'] += f' -L{join(webp_install, "lib")}'
         env['LDFLAGS'] += f' -L{ndk_lib_dir}'
         if cflags not in env['CFLAGS']:
-            env['CFLAGS'] += cflags
+            #env['CFLAGS'] += cflags
+            env['CFLAGS'] += cflags + " -lm"
         return env
 
 


### PR DESCRIPTION
https://github.com/kivy/buildozer/issues/1020
I have put requirements=pillow directly without any modification
.buildozer/android/platform/python-for-android/pythonforandroid/recipes/Pillow/init.py
Results
In Android 8 running well without any problem

In Android 5 crashing
ImportError: dlopen failed: cannot locate symbol "log" referenced by "_imaging.so"...

and after the change ,In both device running well.
env['CFLAGS'] += cflags + " -lm"