### PR TITLE
Updated version of pygame from 2.0.0-dev7 to 2.0.1

### DIFF
--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -13,8 +13,8 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
         not part of the build. It's usable, but not complete.
     """
 
-    version = '2.0.0-dev7'
-    url = 'https://github.com/pygame/pygame/archive/android-{version}.tar.gz'
+    version = '2.0.1'
+    url = 'https://github.com/pygame/pygame/archive/{version}.tar.gz'
 
     site_packages_name = 'pygame'
     name = 'pygame'


### PR DESCRIPTION
Changed the version of pygame in the recipe from 2.0.0-dev (released in Feb 2020) to the latest release 2.0.1 (released in Dec 2021).

Version 2.0.0-dev had the tag name as `android` ; due to which changing the version number via setup.py/cli fails.
This issue is also resolved by this PR.