### PR TITLE
AAB support related changes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,14 +41,10 @@ jobs:
         pip install tox>=2.0
         make test
 
-  build:
+  build_apk:
     name: Unit test apk
     needs: [flake8]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        build-arch: ['arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86']
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
@@ -64,14 +60,42 @@ jobs:
     - name: Pull docker image
       run: |
         make docker/pull
-    - name: Build apk Python 3 ${{ matrix.build-arch }}
+    - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
       run: |
         mkdir -p apks
-        make docker/run/make/with-artifact/testapps-with-numpy/${{ matrix.build-arch }}
+        make docker/run/make/with-artifact/testapps-with-numpy
     - uses: actions/upload-artifact@v1
       with:
-        name: bdist_test_app_unittests__${{ matrix.build-arch }}-debug-1.1.apk
+        name: bdist_unit_tests_app-debug-1.1-.apk
         path: apks
+
+  build_aab:
+    name: Unit test aab
+    needs: [flake8]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout python-for-android
+      uses: actions/checkout@v2
+    # helps with GitHub runner getting out of space
+    - name: Free disk space
+      run: |
+        df -h
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt -y clean
+        docker rmi $(docker image ls -aq)
+        df -h
+    - name: Pull docker image
+      run: |
+        make docker/pull
+    - name: Build Android App Bundle Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
+      run: |
+        mkdir -p aabs
+        make docker/run/make/with-artifact/testapps-with-numpy-aab
+    - uses: actions/upload-artifact@v1
+      with:
+        name: bdist_unit_tests_app-release-1.1-.aab
+        path: aabs
 
   rebuild_updated_recipes:
     name: Test updated recipes

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
       run: |
         mkdir -p apks
-        make docker/run/make/with-artifact/testapps-with-numpy
+        make docker/run/make/with-artifact/apk/testapps-with-numpy
     - uses: actions/upload-artifact@v1
       with:
         name: bdist_unit_tests_app-debug-1.1-.apk
@@ -91,7 +91,7 @@ jobs:
     - name: Build Android App Bundle Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
       run: |
         mkdir -p aabs
-        make docker/run/make/with-artifact/testapps-with-numpy-aab
+        make docker/run/make/with-artifact/aab/testapps-with-numpy-aab
     - uses: actions/upload-artifact@v1
       with:
         name: bdist_unit_tests_app-release-1.1-.aab

--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,18 @@ docker/run/test: docker/build
 docker/run/command: docker/build
 	docker run --rm --env-file=.env $(DOCKER_IMAGE) /bin/sh -c "$(COMMAND)"
 
+docker/run/make/with-artifact/apk/%: docker/build
+	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-debug-1.1-.apk ./apks
+	docker rm -fv p4a-latest
+
+docker/run/make/with-artifact/aab/%: docker/build
+	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1-.aab ./aabs
+	docker rm -fv p4a-latest
+
 docker/run/make/%: docker/build
 	docker run --rm --env-file=.env $(DOCKER_IMAGE) make $*
-
-docker/run/make/with-artifact/%: docker/build
-	$(eval $@_APP_ARCH := $(shell basename $*))
-	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
-	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app__$($@_APP_ARCH)-debug-1.1-.apk ./apks
-	docker rm -fv p4a-latest
 
 docker/run/shell: docker/build
 	docker run --rm --env-file=.env -it $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,17 @@ rebuild_updated_recipes: virtualenv
 	ANDROID_SDK_HOME=$(ANDROID_SDK_HOME) ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
 	$(PYTHON) ci/rebuild_updated_recipes.py
 
-testapps-with-numpy/%: virtualenv
-	$(eval $@_APP_ARCH := $(shell basename $*))
+testapps-with-numpy: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
     --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,urllib3,chardet,idna,sqlite3,setuptools,numpy \
-    --arch=$($@_APP_ARCH)
+    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86
+
+testapps-with-numpy-aab: virtualenv
+	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
+    python setup.py aab --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
+    --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,urllib3,chardet,idna,sqlite3,setuptools,numpy \
+    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86 --release
 
 testapps/%: virtualenv
 	$(eval $@_APP_ARCH := $(shell basename $*))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ python-for-android
 
 python-for-android is a packaging tool for Python apps on Android. You can
 create your own Python distribution including the modules and
-dependencies you want, and bundle it in an APK along with your own code.
+dependencies you want, and bundle it in an APK or AAB along with your own code.
 
 Features include:
 
@@ -19,6 +19,7 @@ Features include:
    sqlalchemy.
 -  Multiple architecture targets, for APKs optimised on any given
    device.
+-  AAB: Android App Bundle support.
 
 For documentation and support, see:
 
@@ -30,7 +31,7 @@ For documentation and support, see:
 
 Follow the [quickstart
 instructions](<https://python-for-android.readthedocs.org/en/latest/quickstart/>)
-to install and begin creating APKs.
+to install and begin creating APKs and AABs.
 
 **Quick instructions**: install python-for-android with:
 
@@ -51,6 +52,8 @@ other API levels may not work.
 With everything installed, build an APK with SDL2 with e.g.:
 
     p4a apk --requirements=kivy --private /home/username/devel/planewave_frozen/ --package=net.inclem.planewavessdl2 --name="planewavessdl2" --version=0.5 --bootstrap=sdl2
+
+**If you need to deploy your app on Google Play, Android App Bundle (aab) is required since 1 August 2021:**
 
 **For full instructions and parameter options,** see [the
 documentation](https://python-for-android.readthedocs.io/en/latest/quickstart/#usage).

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ api level below 21, you should use an older version of python-for-android
 On March of 2020 we dropped support for creating apps that use Python 2. The latest
 python-for-android release that supported building Python 2 was version 2019.10.6.
 
-On August of 2021, We added support for Android App Bundle (aab). As a collateral,
+On August of 2021, we added support for Android App Bundle (aab). As a collateral,
 now We support multi-arch apk.
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ api level below 21, you should use an older version of python-for-android
 On March of 2020 we dropped support for creating apps that use Python 2. The latest
 python-for-android release that supported building Python 2 was version 2019.10.6.
 
+On August of 2021, We added support for Android App Bundle (aab). As a collateral,
+now We support multi-arch apk.
+
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].

--- a/doc/source/commands.rst
+++ b/doc/source/commands.rst
@@ -71,8 +71,9 @@ supply those that you need.
   Whether the distribution must be compiled from scratch.
 
 ``--arch``
-  The architecture to build for. Currently only one architecture can be 
-  targeted at a time, and a given distribution can only include one architecture.
+  The architecture to build for. You can specify multiple architectures to build for
+  at the same time. As an example ``p4a ... --arch arm64-v8a --arch armeabi-v7a ...``
+  will build a distribution for both ``arm64-v8a`` and ``armeabi-v7a``.
   
 ``--bootstrap BOOTSTRAP``
   The Java bootstrap to use for your application. You mostly don't

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -213,6 +213,24 @@ You can also replace flask with another web framework.
 Replace ``--port=5000`` with the port on which your app will serve a
 website. The default for Flask is 5000.
 
+Exporting the Android App Bundle (aab) for distributing it on Google Play
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting from August 2021 for new apps and from November 2021 for updates to existings apps,
+Google Play Console will require the Android App Bundle instead of the long lived apk.
+
+python-for-android handles by itself the needed work to accomplish the new requirements:
+
+    p4a aab --private $HOME/code/myapp --package=org.example.myapp --name="My App" --version 0.1 --bootstrap=sdl2 --requirements=python3,kivy --arch=arm64-v8a --arch=armeabi-v7a --release
+
+This `p4a aab ...` command builds a distribution with `python3`,
+`kivy`, and everything else you specified in the requirements.
+It will be packaged using a SDL2 bootstrap, and produce
+an `.aab` file that contains binaries for both `armeabi-v7a` and `arm64-v8a` ABIs.
+
+The Android App Bundle, is supposed to be used for distributing your app.
+If you need to test it locally, on your device, you can use `bundletool <https://developer.android.com/studio/command-line/bundletool>`
+
 Other options
 ~~~~~~~~~~~~~
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -214,7 +214,7 @@ Replace ``--port=5000`` with the port on which your app will serve a
 website. The default for Flask is 5000.
 
 Exporting the Android App Bundle (aab) for distributing it on Google Play
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting from August 2021 for new apps and from November 2021 for updates to existings apps,
 Google Play Console will require the Android App Bundle instead of the long lived apk.

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -85,31 +85,35 @@ At the top level, this will always contain the same set of files::
   AndroidManifest.xml  classes.dex  META-INF     res
   assets               lib          YourApk.apk  resources.arsc
 
-The Python distribution is in the assets folder::
+The user app data (code, images, fonts ..) is packaged into a single tarball contained in the assets folder::
 
   $ cd assets
   $ ls
-  private.mp3
+  private.tar
 
-``private.mp3`` is actually a tarball containing all your packaged
-data, and the Python distribution. Extract it::
+``private.tar`` is a tarball containing all your packaged
+data. Extract it::
 
-  $ tar xf private.mp3
+  $ tar xf private.tar
 
-This will reveal all the Python-related files::
+This will reveal all the user app data (the files shown below are from the touchtracer demo)::
 
   $ ls
-  android_runnable.pyo  include          interpreter_subprocess  main.kv   pipinterface.kv   settings.pyo
-  assets                __init__.pyo     interpreterwrapper.pyo  main.pyo  pipinterface.pyo  utils.pyo
-  editor.kv             interpreter.kv   _python_bundle          menu.kv   private.mp3       widgets.pyo
-  editor.pyo            interpreter.pyo  libpymodules.so         menu.pyo  settings.kv
+  README.txt		android.txt		icon.png		main.pyc		p4a_env_vars.txt	particle.png
+  private.tar		touchtracer.kv
 
-Most of these files have been included by the user (in this case, they
-come from one of my own apps), the rest relate to the python
-distribution.
+Due to how We're required to ship ABI-specific things in Android App Bundle,
+the Python installation is packaged separately, as (most of it) is ABI-specific.
 
-The python installation, along with all side-packages, is mostly contained
-inside the `_python_bundle` folder.
+For example, the Python installation for ``arm64-v8a`` is available in ``lib/arm64-v8a/libpybundle.so``
+
+``libpybundle.so`` is a tarball (but named like a library for packaging requirements), that contains our ``_python_bundle``::
+
+  $ tar xf libpybundle.so
+  $ cd _python_bundle
+  $ ls
+  modules		site-packages	stdlib.zip
+
 
 
 Common errors

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -133,7 +133,7 @@ class Arch:
             ctx=self.ctx,
             command_prefix=self.command_prefix,
             python_includes=join(
-                self.ctx.get_python_install_dir(),
+                self.ctx.get_python_install_dir(self.arch),
                 'include/python{}'.format(self.ctx.python_recipe.version[0:3]),
             ),
         )

--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -1,9 +1,10 @@
 from distutils.spawn import find_executable
 from os import environ
-from os.path import join, split
+from os.path import join, split, exists
 from multiprocessing import cpu_count
 from glob import glob
 
+from pythonforandroid.logger import warning
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import BuildInterruptingException, build_platform
 
@@ -30,7 +31,7 @@ class Arch:
     common_cppflags = [
         '-DANDROID',
         '-D__ANDROID_API__={ctx.ndk_api}',
-        '-I{ctx.ndk_dir}/sysroot/usr/include/{command_prefix}',
+        '-I{ctx.ndk_sysroot}/usr/include/{command_prefix}',
         '-I{python_includes}',
     ]
 
@@ -56,6 +57,24 @@ class Arch:
 
     def __str__(self):
         return self.arch
+
+    @property
+    def ndk_lib_dir(self):
+        return join(self.ctx.ndk_sysroot, 'usr', 'lib', self.command_prefix, str(self.ctx.ndk_api))
+
+    @property
+    def ndk_platform(self):
+        warning("ndk_platform is deprecated and should be avoided in new recipes")
+        ndk_platform = join(
+            self.ctx.ndk_dir,
+            'platforms',
+            'android-{}'.format(self.ctx.ndk_api),
+            self.platform_dir)
+        if not exists(ndk_platform):
+            BuildInterruptingException(
+                "The requested platform folder doesn't exist. If you're building on ndk >= r22, and seeing this error, one of the required recipe is using a removed feature."
+            )
+        return ndk_platform
 
     @property
     def include_dirs(self):
@@ -213,7 +232,7 @@ class Arch:
         # Android's arch/toolchain
         env['ARCH'] = self.arch
         env['NDK_API'] = 'android-{}'.format(str(self.ctx.ndk_api))
-        env['TOOLCHAIN_PREFIX'] = self.ctx.toolchain_prefix
+        env['TOOLCHAIN_PREFIX'] = self.toolchain_prefix
         env['TOOLCHAIN_VERSION'] = self.ctx.toolchain_version
 
         # Custom linker options

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -143,6 +143,14 @@ class BdistAAR(Bdist):
     package_type = 'aar'
 
 
+class BdistAAB(Bdist):
+    """
+    distutil command handler for 'aab'
+    """
+    description = 'Create an AAB with python-for-android'
+    package_type = 'aab'
+
+
 def _set_user_options():
     # This seems like a silly way to do things, but not sure if there's a
     # better way to pass arbitrary options onwards to p4a

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -164,6 +164,7 @@ def _set_user_options():
                 user_options.append((arg[2:], None, None))
 
     BdistAPK.user_options = user_options
+    BdistAAB.user_options = user_options
 
 
 _set_user_options()

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -128,25 +128,19 @@ class Bdist(Command):
 
 
 class BdistAPK(Bdist):
-    """
-    distutil command handler for 'apk'
-    """
+    """distutil command handler for 'apk'."""
     description = 'Create an APK with python-for-android'
     package_type = 'apk'
 
 
 class BdistAAR(Bdist):
-    """
-    distutil command handler for 'aar'
-    """
+    """distutil command handler for 'aar'."""
     description = 'Create an AAR with python-for-android'
     package_type = 'aar'
 
 
 class BdistAAB(Bdist):
-    """
-    distutil command handler for 'aab'
-    """
+    """distutil command handler for 'aab'."""
     description = 'Create an AAB with python-for-android'
     package_type = 'aab'
 

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -374,7 +374,7 @@ class Bootstrap:
         if len(tokens) > 1:
             strip = strip.bake(tokens[1:])
 
-        libs_dir = join(self.dist_dir, '_python_bundle',
+        libs_dir = join(self.dist_dir, f'_python_bundle__{arch.arch}',
                         '_python_bundle', 'modules')
         filens = shprint(sh.find, libs_dir, join(self.dist_dir, 'libs'),
                          '-iname', '*.so', _env=env).stdout.decode('utf-8')

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -408,14 +408,17 @@ main.py that loads it.''')
 
     version_code = 0
     if not args.numeric_version:
-        # Set version code in format (arch-minsdk-app_version)
-        arch_dict = {"x86_64": "9", "arm64-v8a": "8", "armeabi-v7a": "7", "x86": "6"}
-        arch_code = arch_dict.get(arch, '1')
+        """
+        Set version code in format (10 + minsdk + app_version)
+        Historically versioning was (arch + minsdk + app_version),
+        with arch expressed with a single digit from 6 to 9.
+        Since the multi-arch support, has been changed to 10.
+        """
         min_sdk = args.min_sdk_version
         for i in args.version.split('.'):
             version_code *= 100
             version_code += int(i)
-        args.numeric_version = "{}{}{}".format(arch_code, min_sdk, version_code)
+        args.numeric_version = "{}{}{}".format("10", min_sdk, version_code)
 
     if args.intent_filters:
         with open(args.intent_filters) as fd:

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -267,7 +267,7 @@ main.py that loads it.''')
     # Package up the private data (public not supported).
     use_setup_py = get_dist_info_for("use_setup_py",
                                      error_if_missing=False) is True
-    tar_dirs = [env_vars_tarpath]
+    private_tar_dirs = [env_vars_tarpath]
     _temp_dirs_to_clean = []
     try:
         if args.private:
@@ -277,7 +277,7 @@ main.py that loads it.''')
                     ):
                 print('No setup.py/pyproject.toml used, copying '
                       'full private data into .apk.')
-                tar_dirs.append(args.private)
+                private_tar_dirs.append(args.private)
             else:
                 print("Copying main.py's ONLY, since other app data is "
                       "expected in site-packages.")
@@ -309,10 +309,7 @@ main.py that loads it.''')
                             )
 
                 # Append directory with all main.py's to result apk paths:
-                tar_dirs.append(main_py_only_dir)
-        for python_bundle_dir in ('private', '_python_bundle'):
-            if exists(python_bundle_dir):
-                tar_dirs.append(python_bundle_dir)
+                private_tar_dirs.append(main_py_only_dir)
         if get_bootstrap_name() == "webview":
             for asset in listdir('webview_includes'):
                 shutil.copy(join('webview_includes', asset), join(assets_dir, asset))
@@ -326,8 +323,13 @@ main.py that loads it.''')
                 shutil.copytree(realpath(asset_src), join(assets_dir, asset_dest))
 
         if args.private or args.launcher:
+            for arch in get_dist_info_for("archs"):
+                libs_dir = f"libs/{arch}"
+                make_tar(
+                    join(libs_dir, 'libpybundle.so'), [f'_python_bundle__{arch}'], args.ignore_path,
+                    optimize_python=args.optimize_python)
             make_tar(
-                join(assets_dir, 'private.mp3'), tar_dirs, args.ignore_path,
+                join(assets_dir, 'private.tar'), private_tar_dirs, args.ignore_path,
                 optimize_python=args.optimize_python)
     finally:
         for directory in _temp_dirs_to_clean:
@@ -357,9 +359,6 @@ main.py that loads it.''')
     elif args.icon_fg or args.icon_bg:
         print("WARNING: Received an --icon_fg or an --icon_bg argument, but not both. "
               "Ignoring.")
-
-    if args.enable_androidx:
-        shutil.copy('templates/gradle.properties', 'gradle.properties')
 
     if get_bootstrap_name() != "service_only":
         lottie_splashscreen = join(res_dir, 'raw/splashscreen.json')
@@ -410,7 +409,6 @@ main.py that loads it.''')
     version_code = 0
     if not args.numeric_version:
         # Set version code in format (arch-minsdk-app_version)
-        arch = get_dist_info_for("archs")[0]
         arch_dict = {"x86_64": "9", "arm64-v8a": "8", "armeabi-v7a": "7", "x86": "6"}
         arch_code = arch_dict.get(arch, '1')
         min_sdk = args.min_sdk_version
@@ -548,6 +546,12 @@ main.py that loads it.''')
         debug_build="debug" in args.build_mode,
         is_library=(get_bootstrap_name() == 'service_library'),
         )
+
+    # gradle properties
+    render(
+        'gradle.tmpl.properties',
+        'gradle.properties',
+        args=args)
 
     # ant build templates
     render(

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -127,7 +127,7 @@ public class PythonUtil {
         f.delete();
     }
 
-    public static void unpackData(
+    public static void unpackAsset(
         Context ctx,
         final String resource,
         File target,
@@ -170,7 +170,74 @@ public class PythonUtil {
             target.mkdirs();
 
             AssetExtract ae = new AssetExtract(ctx);
-            if (!ae.extractTar(resource + ".mp3", target.getAbsolutePath())) {
+            if (!ae.extractTar(resource + ".tar", target.getAbsolutePath(), "private")) {
+                String msg = "Could not extract " + resource + " data.";
+                if (ctx instanceof Activity) {
+                    toastError((Activity)ctx, msg);
+                } else {
+                    Log.v(TAG, msg);
+                }
+            }
+
+            try {
+                // Write .nomedia.
+                new File(target, ".nomedia").createNewFile();
+
+                // Write version file.
+                FileOutputStream os = new FileOutputStream(diskVersionFn);
+                os.write(dataVersion.getBytes());
+                os.close();
+            } catch (Exception e) {
+                Log.w("python", e);
+            }
+        }
+    }
+
+    public static void unpackPyBundle(
+        Context ctx,
+        final String resource,
+        File target,
+        boolean cleanup_on_version_update) {
+
+        Log.v(TAG, "Unpacking " + resource + " " + target.getName());
+
+        // The version of data in memory and on disk.
+        String dataVersion = "p4aisawesome"; // FIXME: Assets method is not usable for fake .so files bundled as a library.
+        String diskVersion = null;
+
+        Log.v(TAG, "Data version is " + dataVersion);
+
+        // If no version, no unpacking is necessary.
+        if (dataVersion == null) {
+            return;
+        }
+
+        // Check the current disk version, if any.
+        String filesDir = target.getAbsolutePath();
+        String diskVersionFn = filesDir + "/" + resource + ".version";
+
+        // FIXME: Keeping that for later. Now it is surely failing.
+        try {
+            byte buf[] = new byte[64];
+            InputStream is = new FileInputStream(diskVersionFn);
+            int len = is.read(buf);
+            diskVersion = new String(buf, 0, len);
+            is.close();
+        } catch (Exception e) {
+            diskVersion = "";
+        }
+
+        // If the disk data is out of date, extract it and write the version file.
+        if (! dataVersion.equals(diskVersion)) {
+            Log.v(TAG, "Extracting " + resource + " assets.");
+
+            if (cleanup_on_version_update) {
+                recursiveDelete(target);
+            }
+            target.mkdirs();
+
+            AssetExtract ae = new AssetExtract(ctx);
+            if (!ae.extractTar(resource + ".so", target.getAbsolutePath(), "pybundle")) {
                 String msg = "Could not extract " + resource + " data.";
                 if (ctx instanceof Activity) {
                     toastError((Activity)ctx, msg);

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -201,61 +201,23 @@ public class PythonUtil {
 
         Log.v(TAG, "Unpacking " + resource + " " + target.getName());
 
-        // The version of data in memory and on disk.
-        String dataVersion = "p4aisawesome"; // FIXME: Assets method is not usable for fake .so files bundled as a library.
-        String diskVersion = null;
-
-        Log.v(TAG, "Data version is " + dataVersion);
-
-        // If no version, no unpacking is necessary.
-        if (dataVersion == null) {
-            return;
-        }
-
-        // Check the current disk version, if any.
-        String filesDir = target.getAbsolutePath();
-        String diskVersionFn = filesDir + "/" + resource + ".version";
-
-        // FIXME: Keeping that for later. Now it is surely failing.
-        try {
-            byte buf[] = new byte[64];
-            InputStream is = new FileInputStream(diskVersionFn);
-            int len = is.read(buf);
-            diskVersion = new String(buf, 0, len);
-            is.close();
-        } catch (Exception e) {
-            diskVersion = "";
-        }
+        // FIXME: Implement a versioning logic to speed-up the startup process (maybe hash-based?).
 
         // If the disk data is out of date, extract it and write the version file.
-        if (! dataVersion.equals(diskVersion)) {
-            Log.v(TAG, "Extracting " + resource + " assets.");
+        Log.v(TAG, "Extracting " + resource + " assets.");
 
-            if (cleanup_on_version_update) {
-                recursiveDelete(target);
-            }
-            target.mkdirs();
+        if (cleanup_on_version_update) {
+            recursiveDelete(target);
+        }
+        target.mkdirs();
 
-            AssetExtract ae = new AssetExtract(ctx);
-            if (!ae.extractTar(resource + ".so", target.getAbsolutePath(), "pybundle")) {
-                String msg = "Could not extract " + resource + " data.";
-                if (ctx instanceof Activity) {
-                    toastError((Activity)ctx, msg);
-                } else {
-                    Log.v(TAG, msg);
-                }
-            }
-
-            try {
-                // Write .nomedia.
-                new File(target, ".nomedia").createNewFile();
-
-                // Write version file.
-                FileOutputStream os = new FileOutputStream(diskVersionFn);
-                os.write(dataVersion.getBytes());
-                os.close();
-            } catch (Exception e) {
-                Log.w("python", e);
+        AssetExtract ae = new AssetExtract(ctx);
+        if (!ae.extractTar(resource + ".so", target.getAbsolutePath(), "pybundle")) {
+            String msg = "Could not extract " + resource + " data.";
+            if (ctx instanceof Activity) {
+                toastError((Activity)ctx, msg);
+            } else {
+                Log.v(TAG, msg);
             }
         }
     }

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/AssetExtract.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/renpy/android/AssetExtract.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.io.FileOutputStream;
 import java.io.FileNotFoundException;
 import java.io.File;
+import java.io.FileInputStream;
 
 import java.util.zip.GZIPInputStream;
 
@@ -28,7 +29,7 @@ public class AssetExtract {
         mAssetManager = context.getAssets();
     }
 
-    public boolean extractTar(String asset, String target) {
+    public boolean extractTar(String asset, String target, String method) {
 
         byte buf[] = new byte[1024 * 1024];
 
@@ -36,7 +37,12 @@ public class AssetExtract {
         TarInputStream tis = null;
 
         try {
-            assetStream = mAssetManager.open(asset, AssetManager.ACCESS_STREAMING);
+            if(method == "private"){
+                assetStream = mAssetManager.open(asset, AssetManager.ACCESS_STREAMING);
+            } else if (method == "pybundle") {
+                assetStream = new FileInputStream(asset);
+            }
+            
             tis = new TarInputStream(new BufferedInputStream(new GZIPInputStream(new BufferedInputStream(assetStream, 8192)), 8192));
         } catch (IOException e) {
             Log.e("python", "opening up extract tar", e);

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -39,11 +39,16 @@ android {
         manifestPlaceholders = {{ args.manifest_placeholders}}
     }
 
-	{% if debug_build -%}
+	
 	packagingOptions {
-		doNotStrip '**/*.so'
+        {% if debug_build -%}
+        doNotStrip '**/*.so'
+        {% else %}
+        exclude 'lib/**/gdbserver'
+        exclude 'lib/**/gdb.setup'
+        {%- endif %}
 	}
-	{%- endif %}
+	
 
 	{% if args.sign -%}
 	signingConfigs {

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -5,7 +5,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 

--- a/pythonforandroid/bootstraps/common/build/templates/gradle.properties
+++ b/pythonforandroid/bootstraps/common/build/templates/gradle.properties
@@ -1,2 +1,0 @@
-android.useAndroidX=true
-android.enableJetifier=true

--- a/pythonforandroid/bootstraps/common/build/templates/gradle.tmpl.properties
+++ b/pythonforandroid/bootstraps/common/build/templates/gradle.tmpl.properties
@@ -1,0 +1,5 @@
+{% if args.enable_androidx %}
+android.useAndroidX=true
+android.enableJetifier=true
+{% endif %}
+android.bundle.enableUncompressedNativeLibs=false

--- a/pythonforandroid/bootstraps/sdl2/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/sdl2/build/blacklist.txt
@@ -1,5 +1,7 @@
 # prevent user to include invalid extensions
 *.apk
+*.aab
+*.apks
 *.pxd
 
 # eggs

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -104,7 +104,8 @@ public class PythonActivity extends SDLActivity {
         protected String doInBackground(String... params) {
             File app_root_file = new File(params[0]);
             Log.v(TAG, "Ready to unpack");
-            PythonUtil.unpackData(mActivity, "private", app_root_file, true);
+            PythonUtil.unpackAsset(mActivity, "private", app_root_file, true);
+            PythonUtil.unpackPyBundle(mActivity, getApplicationInfo().nativeLibraryDir + "/" + "libpybundle", app_root_file, false);
             return null;
         }
 

--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -37,7 +37,7 @@ class ServiceOnlyBootstrap(Bootstrap):
             self.distribute_javaclasses(self.ctx.javaclass_dir,
                                         dest_dir=join("src", "main", "java"))
 
-            python_bundle_dir = join('_python_bundle', '_python_bundle')
+            python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
             ensure_dir(python_bundle_dir)
             site_packages_dir = self.ctx.python_recipe.create_python_bundle(
                 join(self.dist_dir, python_bundle_dir), arch)

--- a/pythonforandroid/bootstraps/service_only/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/service_only/build/blacklist.txt
@@ -1,5 +1,7 @@
 # prevent user to include invalid extensions
 *.apk
+*.aab
+*.apks
 *.pxd
 
 # eggs

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -74,7 +74,8 @@ public class PythonActivity extends Activity {
 
         Log.v(TAG, "Ready to unpack");
         File app_root_file = new File(getAppRoot());
-        PythonUtil.unpackData(mActivity, "private", app_root_file, true);
+        PythonUtil.unpackAsset(mActivity, "private", app_root_file, true);
+        PythonUtil.unpackPyBundle(mActivity, getApplicationInfo().nativeLibraryDir + "/" + "libpybundle", app_root_file, false);
 
         Log.v(TAG, "About to do super onCreate");
         super.onCreate(savedInstanceState);

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -34,7 +34,7 @@ class WebViewBootstrap(Bootstrap):
             self.distribute_javaclasses(self.ctx.javaclass_dir,
                                         dest_dir=join("src", "main", "java"))
 
-            python_bundle_dir = join('_python_bundle', '_python_bundle')
+            python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
             ensure_dir(python_bundle_dir)
             site_packages_dir = self.ctx.python_recipe.create_python_bundle(
                 join(self.dist_dir, python_bundle_dir), arch)

--- a/pythonforandroid/bootstraps/webview/build/blacklist.txt
+++ b/pythonforandroid/bootstraps/webview/build/blacklist.txt
@@ -1,5 +1,7 @@
 # prevent user to include invalid extensions
 *.apk
+*.aab
+*.apks
 *.pxd
 
 # eggs

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -106,7 +106,8 @@ public class PythonActivity extends Activity {
         protected String doInBackground(String... params) {
             File app_root_file = new File(params[0]);
             Log.v(TAG, "Ready to unpack");
-            PythonUtil.unpackData(mActivity, "private", app_root_file, true);
+            PythonUtil.unpackAsset(mActivity, "private", app_root_file, true);
+            PythonUtil.unpackPyBundle(mActivity, getApplicationInfo().nativeLibraryDir + "/" + "libpybundle", app_root_file, false);
             return null;
         }
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -33,9 +33,11 @@ def get_ndk_standalone(ndk_dir):
 
 def get_ndk_sysroot(ndk_dir):
     sysroot = join(get_ndk_standalone(ndk_dir), 'sysroot')
+    sysroot_exists = True
     if not exists(sysroot):
         warning("sysroot doesn't exist: {}".format(sysroot))
-    return sysroot
+        sysroot_exists = False
+    return sysroot, sysroot_exists
 
 
 def get_toolchain_versions(ndk_dir, arch):
@@ -382,8 +384,8 @@ class Context:
             py_platform = 'linux'
 
         self.ndk_standalone = get_ndk_standalone(self.ndk_dir)
-        self.ndk_sysroot = get_ndk_sysroot(self.ndk_dir)
-        ok = ok and exists(self.ndk_sysroot)
+        self.ndk_sysroot, ndk_sysroot_exists = get_ndk_sysroot(self.ndk_dir)
+        ok = ok and ndk_sysroot_exists
         self.ndk_include_dir = join(self.ndk_sysroot, 'usr', 'include')
 
         for arch in self.archs:

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -46,7 +46,7 @@ class Distribution:
             cls,
             ctx,
             *,
-            arch_name,  # required keyword argument: there is no sensible default
+            archs,  # required keyword argument: there is no sensible default
             name=None,
             recipes=[],
             ndk_api=None,
@@ -70,8 +70,8 @@ class Distribution:
         ndk_api : int
             The NDK API to compile against, included in the dist because it cannot
             be changed later during APK packaging.
-        arch_name : str
-            The target architecture name to compile against, included in the dist because
+        archs : list
+            The target architectures list to compile against, included in the dist because
             it cannot be changed later during APK packaging.
         recipes : list
             The recipes that the distribution must contain.
@@ -99,7 +99,7 @@ class Distribution:
         if name is not None and name:
             possible_dists = [
                 d for d in possible_dists if
-                (d.name == name) and (arch_name in d.archs)]
+                (d.name == name) and all(arch_name in d.archs for arch_name in archs)]
 
             if possible_dists:
                 # There should only be one folder with a given dist name *and* arch.
@@ -136,7 +136,7 @@ class Distribution:
                 continue
             if ndk_api is not None and dist.ndk_api != ndk_api:
                 continue
-            if arch_name is not None and arch_name not in dist.archs:
+            if not all(arch_name in dist.archs for arch_name in archs):
                 continue
             if (set(dist.recipes) == set(recipes) or
                 (set(recipes).issubset(set(dist.recipes)) and
@@ -179,7 +179,7 @@ class Distribution:
             name)
         dist.recipes = recipes
         dist.ndk_api = ctx.ndk_api
-        dist.archs = [arch_name]
+        dist.archs = archs
 
         return dist
 

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -176,11 +176,7 @@ class Distribution:
         dist.name = name
         dist.dist_dir = join(
             ctx.dist_dir,
-            generate_dist_folder_name(
-                name,
-                [arch_name] if arch_name is not None else None,
-            )
-        )
+            name)
         dist.recipes = recipes
         dist.ndk_api = ctx.ndk_api
         dist.archs = [arch_name]
@@ -265,23 +261,3 @@ def pretty_log_dists(dists, log_func=info):
 
     for line in infos:
         log_func('\t' + line)
-
-
-def generate_dist_folder_name(base_dist_name, arch_names=None):
-    """Generate the distribution folder name to use, based on a
-    combination of the input arguments.
-
-    Parameters
-    ----------
-    base_dist_name : str
-        The core distribution identifier string
-    arch_names : list of str
-        The architecture compile targets
-    """
-    if arch_names is None:
-        arch_names = ["no_arch_specified"]
-
-    return '{}__{}'.format(
-        base_dist_name,
-        '_'.join(arch_names)
-    )

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -949,7 +949,7 @@ class PythonRecipe(Recipe):
 
     def should_build(self, arch):
         name = self.folder_name
-        if self.ctx.has_package(name):
+        if self.ctx.has_package(name, arch):
             info('Python package already exists in site-packages')
             return False
         info('{} apparently isn\'t already in site-packages'.format(name))
@@ -976,7 +976,7 @@ class PythonRecipe(Recipe):
         hpenv = env.copy()
         with current_directory(self.get_build_dir(arch.arch)):
             shprint(hostpython, 'setup.py', 'install', '-O2',
-                    '--root={}'.format(self.ctx.get_python_install_dir()),
+                    '--root={}'.format(self.ctx.get_python_install_dir(arch.arch)),
                     '--install-lib=.',
                     _env=hpenv, *self.setup_extra_args)
 

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1142,7 +1142,7 @@ class CythonRecipe(PythonRecipe):
         env['LDSHARED'] = env['CC'] + ' -shared'
         # shprint(sh.whereis, env['LDSHARED'], _env=env)
         env['LIBLINK'] = 'NOTNONE'
-        env['NDKPLATFORM'] = self.ctx.ndk_platform
+        env['NDKPLATFORM'] = self.ctx.ndk_sysroot  # FIXME?
         if self.ctx.copy_libs:
             env['COPYLIBS'] = '1'
 

--- a/pythonforandroid/recipes/Pillow/__init__.py
+++ b/pythonforandroid/recipes/Pillow/__init__.py
@@ -35,9 +35,9 @@ class PillowRecipe(CompiledComponentsPythonRecipe):
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super().get_recipe_env(arch, with_flags_in_cc)
 
-        env['ANDROID_ROOT'] = join(self.ctx.ndk_platform, 'usr')
-        ndk_lib_dir = join(self.ctx.ndk_platform, 'usr', 'lib')
-        ndk_include_dir = join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+        env['ANDROID_ROOT'] = join(arch.ndk_platform, 'usr')
+        ndk_lib_dir = arch.ndk_lib_dir
+        ndk_include_dir = self.ctx.ndk_include_dir
 
         png = self.get_recipe('png', self.ctx)
         png_lib_dir = join(png.get_build_dir(arch.arch), '.libs')

--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -25,7 +25,7 @@ class AudiostreamRecipe(CythonRecipe):
                               jni_path=join(self.ctx.bootstrap.build_dir, 'jni'),
                               sdl_include=sdl_include,
                               sdl_mixer_include=sdl_mixer_include)
-        env['NDKPLATFORM'] = self.ctx.ndk_platform
+        env['NDKPLATFORM'] = arch.ndk_platform
         env['LIBLINK'] = 'NOTNONE'  # Hacky fix. Needed by audiostream setup.py
         return env
 

--- a/pythonforandroid/recipes/cffi/__init__.py
+++ b/pythonforandroid/recipes/cffi/__init__.py
@@ -35,9 +35,7 @@ class CffiRecipe(CompiledComponentsPythonRecipe):
                           self.ctx.get_libs_dir(arch.arch))
         env['LDFLAGS'] += ' -L{}'.format(os.path.join(self.ctx.bootstrap.build_dir, 'libs', arch.arch))
         # required for libc and libdl
-        ndk_dir = self.ctx.ndk_platform
-        ndk_lib_dir = os.path.join(ndk_dir, 'usr', 'lib')
-        env['LDFLAGS'] += ' -L{}'.format(ndk_lib_dir)
+        env['LDFLAGS'] += ' -L{}'.format(arch.ndk_lib_dir)
         env['PYTHONPATH'] = ':'.join([
             self.ctx.get_site_packages_dir(),
             env['BUILDLIB_PATH'],

--- a/pythonforandroid/recipes/evdev/__init__.py
+++ b/pythonforandroid/recipes/evdev/__init__.py
@@ -18,7 +18,7 @@ class EvdevRecipe(CompiledComponentsPythonRecipe):
 
     def get_recipe_env(self, arch=None):
         env = super().get_recipe_env(arch)
-        env['NDKPLATFORM'] = self.ctx.ndk_platform
+        env['NDKPLATFORM'] = arch.ndk_platform
         return env
 
 

--- a/pythonforandroid/recipes/freetype/__init__.py
+++ b/pythonforandroid/recipes/freetype/__init__.py
@@ -47,8 +47,8 @@ class FreetypeRecipe(Recipe):
             )
 
         # android's zlib support
-        zlib_lib_path = join(self.ctx.ndk_platform, 'usr', 'lib')
-        zlib_includes = join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+        zlib_lib_path = arch.ndk_lib_dir
+        zlib_includes = self.ctx.ndk_include_dir
 
         def add_flag_if_not_added(flag, env_key):
             if flag not in env[env_key]:

--- a/pythonforandroid/recipes/icu/__init__.py
+++ b/pythonforandroid/recipes/icu/__init__.py
@@ -114,7 +114,7 @@ class ICURecipe(Recipe):
         src_include = join(
             self.get_build_dir(arch.arch), "icu_build", "include")
         dst_include = join(
-            self.ctx.get_python_install_dir(), "include", "icu")
+            self.ctx.get_python_install_dir(arch.arch), "include", "icu")
         ensure_dir(dst_include)
         shprint(sh.cp, "-r", join(src_include, "layout"), dst_include)
         shprint(sh.cp, "-r", join(src_include, "unicode"), dst_include)

--- a/pythonforandroid/recipes/kivy3/__init__.py
+++ b/pythonforandroid/recipes/kivy3/__init__.py
@@ -15,7 +15,7 @@ class Kivy3Recipe(PythonRecipe):
     def build_arch(self, arch):
         super().build_arch(arch)
         suffix = '/kivy3/default.glsl'
-        shutil.copyfile(self.get_build_dir(arch.arch) + suffix, self.ctx.get_python_install_dir() + suffix)
+        shutil.copyfile(self.get_build_dir(arch.arch) + suffix, self.ctx.get_python_install_dir(arch.arch) + suffix)
 
 
 recipe = Kivy3Recipe()

--- a/pythonforandroid/recipes/libiconv/__init__.py
+++ b/pythonforandroid/recipes/libiconv/__init__.py
@@ -21,7 +21,7 @@ class LibIconvRecipe(Recipe):
             shprint(
                 sh.Command('./configure'),
                 '--host=' + arch.command_prefix,
-                '--prefix=' + self.ctx.get_python_install_dir(),
+                '--prefix=' + self.ctx.get_python_install_dir(arch.arch),
                 _env=env)
             shprint(sh.make, '-j' + str(cpu_count()), _env=env)
 

--- a/pythonforandroid/recipes/libogg/__init__.py
+++ b/pythonforandroid/recipes/libogg/__init__.py
@@ -12,7 +12,7 @@ class OggRecipe(Recipe):
         with current_directory(self.get_build_dir(arch.arch)):
             env = self.get_recipe_env(arch)
             flags = [
-                '--with-sysroot=' + self.ctx.ndk_platform,
+                '--with-sysroot=' + arch.ndk_platform,
                 '--host=' + arch.toolchain_prefix,
             ]
             configure = sh.Command('./configure')

--- a/pythonforandroid/recipes/librt/__init__.py
+++ b/pythonforandroid/recipes/librt/__init__.py
@@ -18,11 +18,8 @@ class LibRt(Recipe):
         libc, so we create a symbolic link which we will remove when our build
         finishes'''
 
-    @property
-    def libc_path(self):
-        return join(self.ctx.ndk_platform, 'usr', 'lib', 'libc')
-
     def build_arch(self, arch):
+        libc_path = join(arch.ndk_platform, 'usr', 'lib', 'libc')
         # Create a temporary folder to add to link path with a fake librt.so:
         fake_librt_temp_folder = join(
             self.get_build_dir(arch.arch),
@@ -35,13 +32,13 @@ class LibRt(Recipe):
         if exists(join(fake_librt_temp_folder, "librt.so")):
             remove(join(fake_librt_temp_folder, "librt.so"))
         shprint(sh.ln, '-sf',
-                self.libc_path + '.so',
+                libc_path + '.so',
                 join(fake_librt_temp_folder, "librt.so"),
                 )
         if exists(join(fake_librt_temp_folder, "librt.a")):
             remove(join(fake_librt_temp_folder, "librt.a"))
         shprint(sh.ln, '-sf',
-                self.libc_path + '.a',
+                libc_path + '.a',
                 join(fake_librt_temp_folder, "librt.a"),
                )
 

--- a/pythonforandroid/recipes/libsecp256k1/__init__.py
+++ b/pythonforandroid/recipes/libsecp256k1/__init__.py
@@ -20,7 +20,7 @@ class LibSecp256k1Recipe(Recipe):
             shprint(
                 sh.Command('./configure'),
                 '--host=' + arch.toolchain_prefix,
-                '--prefix=' + self.ctx.get_python_install_dir(),
+                '--prefix=' + self.ctx.get_python_install_dir(arch.arch),
                 '--enable-shared',
                 '--enable-module-recovery',
                 '--enable-experimental',

--- a/pythonforandroid/recipes/libvorbis/__init__.py
+++ b/pythonforandroid/recipes/libvorbis/__init__.py
@@ -21,7 +21,7 @@ class VorbisRecipe(NDKRecipe):
         with current_directory(self.get_build_dir(arch.arch)):
             env = self.get_recipe_env(arch)
             flags = [
-                '--with-sysroot=' + self.ctx.ndk_platform,
+                '--with-sysroot=' + arch.ndk_platform,
                 '--host=' + arch.toolchain_prefix,
             ]
             configure = sh.Command('./configure')

--- a/pythonforandroid/recipes/libzbar/__init__.py
+++ b/pythonforandroid/recipes/libzbar/__init__.py
@@ -34,7 +34,7 @@ class LibZBarRecipe(Recipe):
                 sh.Command('./configure'),
                 '--host=' + arch.command_prefix,
                 '--target=' + arch.toolchain_prefix,
-                '--prefix=' + self.ctx.get_python_install_dir(),
+                '--prefix=' + self.ctx.get_python_install_dir(arch.arch),
                 # Python bindings are compiled in a separated recipe
                 '--with-python=no',
                 '--with-gtk=no',

--- a/pythonforandroid/recipes/lxml/__init__.py
+++ b/pythonforandroid/recipes/lxml/__init__.py
@@ -51,8 +51,8 @@ class LXMLRecipe(CompiledComponentsPythonRecipe):
         env['LIBS'] += ' -lxml2'
 
         # android's ndk flags
-        ndk_lib_dir = join(self.ctx.ndk_platform, 'usr', 'lib')
-        ndk_include_dir = join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+        ndk_lib_dir = arch.ndk_lib_dir
+        ndk_include_dir = self.ndk_include_dir
         cflags += ' -I' + ndk_include_dir
         env['LDFLAGS'] += ' -L' + ndk_lib_dir
         env['LIBS'] += ' -lz -lm -lc'

--- a/pythonforandroid/recipes/openal/__init__.py
+++ b/pythonforandroid/recipes/openal/__init__.py
@@ -22,7 +22,7 @@ class OpenALRecipe(NDKRecipe):
             env = self.get_recipe_env(arch)
             cmake_args = [
                 '-DCMAKE_TOOLCHAIN_FILE={}'.format('XCompile-Android.txt'),
-                '-DHOST={}'.format(self.ctx.toolchain_prefix)
+                '-DHOST={}'.format(arch.toolchain_prefix)
             ]
             shprint(
                 sh.cmake, '.',

--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -96,7 +96,8 @@ class OpenSSLRecipe(Recipe):
         env = super().get_recipe_env(arch)
         env['OPENSSL_VERSION'] = self.version
         env['MAKE'] = 'make'  # This removes the '-j5', which isn't safe
-        env['ANDROID_NDK'] = self.ctx.ndk_dir
+        env['CC'] = 'clang'
+        env['ANDROID_NDK_HOME'] = self.ctx.ndk_dir
         return env
 
     def select_build_arch(self, arch):

--- a/pythonforandroid/recipes/pandas/__init__.py
+++ b/pythonforandroid/recipes/pandas/__init__.py
@@ -20,7 +20,7 @@ class PandasRecipe(CppCompiledComponentsPythonRecipe):
         # we need the includes from our installed numpy at site packages
         # because we need some includes generated at numpy's compile time
         env['NUMPY_INCLUDES'] = join(
-            self.ctx.get_python_install_dir(), "numpy/core/include",
+            self.ctx.get_python_install_dir(arch.arch), "numpy/core/include",
         )
 
         # this flag below is to fix a runtime error:

--- a/pythonforandroid/recipes/protobuf_cpp/__init__.py
+++ b/pythonforandroid/recipes/protobuf_cpp/__init__.py
@@ -115,7 +115,7 @@ class ProtobufCppRecipe(CppCompiledComponentsPythonRecipe):
 
             hpenv = env.copy()
             shprint(hostpython, 'setup.py', 'install', '-O2',
-                    '--root={}'.format(self.ctx.get_python_install_dir()),
+                    '--root={}'.format(self.ctx.get_python_install_dir(arch.arch)),
                     '--install-lib=.',
                     _env=hpenv, *self.setup_extra_args)
 

--- a/pythonforandroid/recipes/psycopg2/__init__.py
+++ b/pythonforandroid/recipes/psycopg2/__init__.py
@@ -43,7 +43,7 @@ class Psycopg2Recipe(PythonRecipe):
             shprint(hostpython, 'setup.py', 'build_ext', '--static-libpq',
                     _env=env)
             shprint(hostpython, 'setup.py', 'install', '-O2',
-                    '--root={}'.format(self.ctx.get_python_install_dir()),
+                    '--root={}'.format(self.ctx.get_python_install_dir(arch.arch)),
                     '--install-lib=.', _env=env)
 
 

--- a/pythonforandroid/recipes/pycrypto/__init__.py
+++ b/pythonforandroid/recipes/pycrypto/__init__.py
@@ -36,7 +36,7 @@ class PyCryptoRecipe(CompiledComponentsPythonRecipe):
         with current_directory(self.get_build_dir(arch.arch)):
             configure = sh.Command('./configure')
             shprint(configure, '--host=arm-eabi',
-                    '--prefix={}'.format(self.ctx.get_python_install_dir()),
+                    '--prefix={}'.format(self.ctx.get_python_install_dir(arch.arch)),
                     '--enable-shared', _env=env)
         super().build_compiled_components(arch)
 

--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -28,9 +28,7 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
         with current_directory(self.get_build_dir(arch.arch)):
             setup_template = open(join("buildconfig", "Setup.Android.SDL2.in")).read()
             env = self.get_recipe_env(arch)
-            env['ANDROID_ROOT'] = join(self.ctx.ndk_platform, 'usr')
-
-            ndk_lib_dir = join(self.ctx.ndk_platform, 'usr', 'lib')
+            env['ANDROID_ROOT'] = join(arch.ndk_platform, 'usr')
 
             png = self.get_recipe('png', self.ctx)
             png_lib_dir = join(png.get_build_dir(arch.arch), '.libs')
@@ -43,7 +41,7 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
                 sdl_includes=(
                     " -I" + join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include') +
                     " -L" + join(self.ctx.bootstrap.build_dir, "libs", str(arch)) +
-                    " -L" + png_lib_dir + " -L" + jpeg_lib_dir + " -L" + ndk_lib_dir),
+                    " -L" + png_lib_dir + " -L" + jpeg_lib_dir + " -L" + arch.ndk_lib_dir),
                 sdl_ttf_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
                 sdl_image_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_image'),
                 sdl_mixer_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer'),

--- a/pythonforandroid/recipes/pyicu/__init__.py
+++ b/pythonforandroid/recipes/pyicu/__init__.py
@@ -13,7 +13,7 @@ class PyICURecipe(CppCompiledComponentsPythonRecipe):
         env = super().get_recipe_env(arch)
 
         icu_include = join(
-            self.ctx.get_python_install_dir(), "include", "icu")
+            self.ctx.get_python_install_dir(arch.arch), "include", "icu")
 
         icu_recipe = self.get_recipe('icu', self.ctx)
         icu_link_libs = icu_recipe.built_libraries.keys()

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -265,8 +265,8 @@ class Python3Recipe(TargetPythonRecipe):
         # the build of zlib module, here we search for android's zlib version
         # and sets the right flags, so python can be build with android's zlib
         info("Activating flags for android's zlib")
-        zlib_lib_path = join(self.ctx.ndk_platform, 'usr', 'lib')
-        zlib_includes = join(self.ctx.ndk_dir, 'sysroot', 'usr', 'include')
+        zlib_lib_path = arch.ndk_lib_dir
+        zlib_includes = self.ctx.ndk_include_dir
         zlib_h = join(zlib_includes, 'zlib.h')
         try:
             with open(zlib_h) as fileh:

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -370,7 +370,7 @@ class Python3Recipe(TargetPythonRecipe):
         # Compile to *.pyc/*.pyo the standard python library
         self.compile_python_files(join(self.get_build_dir(arch.arch), 'Lib'))
         # Compile to *.pyc/*.pyo the other python packages (site-packages)
-        self.compile_python_files(self.ctx.get_python_install_dir())
+        self.compile_python_files(self.ctx.get_python_install_dir(arch.arch))
 
         # Bundle compiled python modules to a folder
         modules_dir = join(dirn, 'modules')
@@ -399,9 +399,9 @@ class Python3Recipe(TargetPythonRecipe):
 
         # copy the site-packages into place
         ensure_dir(join(dirn, 'site-packages'))
-        ensure_dir(self.ctx.get_python_install_dir())
+        ensure_dir(self.ctx.get_python_install_dir(arch.arch))
         # TODO: Improve the API around walking and copying the files
-        with current_directory(self.ctx.get_python_install_dir()):
+        with current_directory(self.ctx.get_python_install_dir(arch.arch)):
             filens = list(walk_valid_filens(
                 '.', self.site_packages_dir_blacklist,
                 self.site_packages_filen_blacklist))

--- a/pythonforandroid/recipes/pyzbar/__init__.py
+++ b/pythonforandroid/recipes/pyzbar/__init__.py
@@ -16,7 +16,7 @@ class PyZBarRecipe(PythonRecipe):
         env = super().get_recipe_env(arch, with_flags_in_cc)
         libzbar = self.get_recipe('libzbar', self.ctx)
         libzbar_dir = libzbar.get_build_dir(arch.arch)
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir(arch.arch)
         env['CFLAGS'] += ' -I' + join(libzbar_dir, 'include')
         env['LDFLAGS'] += ' -L' + join(libzbar_dir, 'zbar', '.libs')
         env['LIBS'] = env.get('LIBS', '') + ' -landroid -lzbar'

--- a/pythonforandroid/recipes/scipy/__init__.py
+++ b/pythonforandroid/recipes/scipy/__init__.py
@@ -33,7 +33,7 @@ class ScipyRecipe(CompiledComponentsPythonRecipe):
         sysroot = f"{self.ctx.ndk_dir}/platforms/{env['NDK_API']}/{arch.platform_dir}"
         sysroot_include = f'{self.ctx.ndk_dir}/toolchains/llvm/prebuilt/{HOST}/sysroot/usr/include'
         libgfortran = f'{self.ctx.ndk_dir}/toolchains/{prefix}-{GCC_VER}/prebuilt/{HOST}/{prefix}/{LIB}'
-        numpylib = self.ctx.get_python_install_dir() + '/numpy/core/lib'
+        numpylib = self.ctx.get_python_install_dir(arch.arch) + '/numpy/core/lib'
         LDSHARED_opts = env['LDSHARED'].split('clang')[1]
 
         env['LAPACK'] = f'{lapack_dir}/lib'

--- a/pythonforandroid/recipes/zbar/__init__.py
+++ b/pythonforandroid/recipes/zbar/__init__.py
@@ -23,7 +23,7 @@ class ZBarRecipe(PythonRecipe):
         env = super().get_recipe_env(arch, with_flags_in_cc)
         libzbar = self.get_recipe('libzbar', self.ctx)
         libzbar_dir = libzbar.get_build_dir(arch.arch)
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir(arch.arch)
         env['CFLAGS'] += ' -I' + join(libzbar_dir, 'include')
         env['LDFLAGS'] += ' -L' + join(libzbar_dir, 'zbar', '.libs')
         env['LIBS'] = env.get('LIBS', '') + ' -landroid -lzbar'

--- a/pythonforandroid/recipes/zbarlight/__init__.py
+++ b/pythonforandroid/recipes/zbarlight/__init__.py
@@ -16,7 +16,7 @@ class ZBarLightRecipe(PythonRecipe):
         env = super().get_recipe_env(arch, with_flags_in_cc)
         libzbar = self.get_recipe('libzbar', self.ctx)
         libzbar_dir = libzbar.get_build_dir(arch.arch)
-        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir()
+        env['PYTHON_ROOT'] = self.ctx.get_python_install_dir(arch.arch)
         env['CFLAGS'] += ' -I' + join(libzbar_dir, 'include')
         env['LDFLAGS'] += ' -L' + join(libzbar_dir, 'zbar', '.libs')
         env['LIBS'] = env.get('LIBS', '') + ' -landroid -lzbar'

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -153,6 +153,7 @@ def check_target_api(api, arch):
     recommendation
     """
 
+    # FIXME: Should We remove support for armeabi (ARMv5)?
     if api >= ARMEABI_MAX_TARGET_API and arch == 'armeabi':
         raise BuildInterruptingException(
             UNSUPPORTED_NDK_API_FOR_ARMEABI_MESSAGE.format(

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -99,8 +99,6 @@ user_dir = dirname(realpath(os.path.curdir))
 toolchain_dir = dirname(__file__)
 sys.path.insert(0, join(toolchain_dir, "tools", "external"))
 
-APK_SUFFIX = '.apk'
-
 
 def add_boolean_option(parser, names, no_names=None,
                        default=True, dest=None, description=None):
@@ -313,8 +311,8 @@ class ToolchainCL:
                   '(default: {})'.format(default_storage_dir)))
 
         generic_parser.add_argument(
-            '--arch', help='The arch to build for.',
-            default='armeabi-v7a')
+            '--arch', help='The archs to build for.',
+            action='append', default=[])
 
         # Options for specifying the Distribution
         generic_parser.add_argument(
@@ -565,6 +563,11 @@ class ToolchainCL:
 
         add_parser(
             subparsers,
+            'aab', help='Build an AAB',
+            parents=[parser_packaging])
+
+        add_parser(
+            subparsers,
             'create', help='Compile a set of requirements into a dist',
             parents=[generic_parser])
         add_parser(
@@ -712,7 +715,7 @@ class ToolchainCL:
         self.ctx.symlink_bootstrap_files = args.symlink_bootstrap_files
         self.ctx.java_build_tool = args.java_build_tool
 
-        self._archs = split_argument_list(args.arch)
+        self._archs = args.arch
 
         self.ctx.local_recipes = args.local_recipes
         self.ctx.copy_libs = args.copy_libs
@@ -1028,7 +1031,7 @@ class ToolchainCL:
         """
         Creates an android package using gradle
         :param args: parser args
-        :param package_type: one of 'apk', 'aar'
+        :param package_type: one of 'apk', 'aar', 'aab'
         :return (gradle output, build_args)
         """
         ctx = self.ctx
@@ -1078,7 +1081,10 @@ class ToolchainCL:
             if args.build_mode == "debug":
                 gradle_task = "assembleDebug"
             elif args.build_mode == "release":
-                gradle_task = "assembleRelease"
+                if package_type == "apk":
+                    gradle_task = "assembleRelease"
+                elif package_type == "aab":
+                    gradle_task = "bundleRelease"
             else:
                 raise BuildInterruptingException(
                     "Unknown build mode {} for apk()".format(args.build_mode))
@@ -1092,7 +1098,7 @@ class ToolchainCL:
         :param args: the parser args
         :param output: RunningCommand output
         :param build_args: build args as returned by build.parse_args
-        :param package_type: one of 'apk', 'aar'
+        :param package_type: one of 'apk', 'aar', 'aab'
         :param output_dir: where to put the package file
         """
 
@@ -1129,11 +1135,12 @@ class ToolchainCL:
                 raise BuildInterruptingException('Couldn\'t find the built APK')
 
         info_main('# Found android package file: {}'.format(package_file))
+        package_extension = f".{package_type}"
         if package_add_version:
             info('# Add version number to android package')
-            package_name = basename(package_file)[:-len(APK_SUFFIX)]
+            package_name = basename(package_file)[:-len(package_extension)]
             package_file_dest = "{}-{}-{}".format(
-                package_name, build_args.version, APK_SUFFIX)
+                package_name, build_args.version, package_extension)
             info('# Android package renamed to {}'.format(package_file_dest))
             shprint(sh.cp, package_file, package_file_dest)
         else:
@@ -1150,6 +1157,12 @@ class ToolchainCL:
         output, build_args = self._build_package(args, package_type='aar')
         output_dir = join(self._dist.dist_dir, "build", "outputs", 'aar')
         self._finish_package(args, output, build_args, 'aar', output_dir)
+
+    @require_prebuilt_dist
+    def aab(self, args):
+        output, build_args = self._build_package(args, package_type='aab')
+        output_dir = join(self._dist.dist_dir, "build", "outputs", 'bundle', args.build_mode)
+        self._finish_package(args, output, build_args, 'aab', output_dir)
 
     @require_prebuilt_dist
     def create(self, args):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -161,7 +161,7 @@ def dist_from_args(ctx, args):
         ctx,
         name=args.dist_name,
         recipes=split_argument_list(args.requirements),
-        arch_name=args.arch,
+        archs=args.arch,
         ndk_api=args.ndk_api,
         force_build=args.force_build,
         require_perfect_match=args.require_perfect_match,

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1079,6 +1079,11 @@ class ToolchainCL:
                     _tail=20, _critical=True, _env=env
                 )
             if args.build_mode == "debug":
+                if package_type == "aab":
+                    raise BuildInterruptingException(
+                        "aab is meant only for distribution and is not available in debug mode. "
+                        "Instead, you can use apk while building for debugging purposes."
+                    )
                 gradle_task = "assembleDebug"
             elif args.build_mode == "release":
                 if package_type == "apk":

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(name='python-for-android',
           'distutils.commands': [
               'apk = pythonforandroid.bdistapk:BdistAPK',
               'aar = pythonforandroid.bdistapk:BdistAAR',
+              'aab = pythonforandroid.bdistapk:BdistAAB',
               ],
           },
       classifiers=[

--- a/testapps/on_device_unit_tests/setup.py
+++ b/testapps/on_device_unit_tests/setup.py
@@ -50,6 +50,20 @@ options = {
             'permissions': ['INTERNET', 'VIBRATE'],
             'orientation': 'sensor',
             'service': 'P4a_test_service:app_service.py',
+        },
+    'aab':
+        {
+            'requirements':
+                'sqlite3,libffi,openssl,pyjnius,kivy,python3,requests,urllib3,'
+                'chardet,idna',
+            'android-api': 27,
+            'ndk-api': 21,
+            'dist-name': 'bdist_unit_tests_app',
+            'arch': 'armeabi-v7a',
+            'bootstrap' : 'sdl2',
+            'permissions': ['INTERNET', 'VIBRATE'],
+            'orientation': 'sensor',
+            'service': 'P4a_test_service:app_service.py',
         }
 }
 

--- a/tests/recipes/recipe_ctx.py
+++ b/tests/recipes/recipe_ctx.py
@@ -44,10 +44,8 @@ class RecipeCtx:
         self.ctx.recipe_build_order = self.recipe_build_order
         self.ctx.python_recipe = Recipe.get_recipe("python3", self.ctx)
         self.arch = ArchAarch_64(self.ctx)
-        self.ctx.ndk_platform = (
-            f"{self.ctx._ndk_dir}/platforms/"
-            f"android-{self.ctx.ndk_api}/{self.arch.platform_dir}"
-        )
+        self.ctx.ndk_sysroot = f'{self.ctx._ndk_dir}/sysroot'
+        self.ctx.ndk_include_dir = f'{self.ctx.ndk_sysroot}/usr/include'
         self.recipe = Recipe.get_recipe(self.recipe_name, self.ctx)
 
     def tearDown(self):

--- a/tests/recipes/recipe_ctx.py
+++ b/tests/recipes/recipe_ctx.py
@@ -39,7 +39,7 @@ class RecipeCtx:
         self.ctx.setup_dirs(os.getcwd())
         self.ctx.bootstrap = Bootstrap().get_bootstrap("sdl2", self.ctx)
         self.ctx.bootstrap.distribution = Distribution.get_distribution(
-            self.ctx, name="sdl2", recipes=self.recipes, arch_name=self.TEST_ARCH,
+            self.ctx, name="sdl2", recipes=self.recipes, archs=[self.TEST_ARCH],
         )
         self.ctx.recipe_build_order = self.recipe_build_order
         self.ctx.python_recipe = Recipe.get_recipe("python3", self.ctx)

--- a/tests/recipes/test_icu.py
+++ b/tests/recipes/test_icu.py
@@ -53,7 +53,6 @@ class TestIcuRecipe(RecipeCtx, unittest.TestCase):
         mock_archs_glob.return_value = [
             os.path.join(self.ctx._ndk_dir, "toolchains", "llvm")
         ]
-        self.ctx.toolchain_prefix = self.arch.toolchain_prefix
         self.ctx.toolchain_version = "4.9"
         self.recipe.build_arch(self.arch)
 

--- a/tests/recipes/test_pandas.py
+++ b/tests/recipes/test_pandas.py
@@ -38,7 +38,7 @@ class TestPandasRecipe(RecipeCtx, unittest.TestCase):
             self.ctx.recipe_build_order
         )
         numpy_includes = join(
-            self.ctx.get_python_install_dir(), "numpy/core/include",
+            self.ctx.get_python_install_dir(self.arch.arch), "numpy/core/include",
         )
         env = self.recipe.get_recipe_env(self.arch)
         self.assertIn(numpy_includes, env["NUMPY_INCLUDES"])

--- a/tests/recipes/test_python3.py
+++ b/tests/recipes/test_python3.py
@@ -194,7 +194,7 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
         expected_sp_paths = [
             modules_build_dir,
             join(recipe_build_dir, 'Lib'),
-            self.ctx.get_python_install_dir(),
+            self.ctx.get_python_install_dir(self.arch.arch),
         ]
         for n, (sp_call, kw) in enumerate(mock_subprocess.call_args_list):
             self.assertEqual(sp_call[0][-1], expected_sp_paths[n])

--- a/tests/test_archs.py
+++ b/tests/test_archs.py
@@ -64,7 +64,7 @@ class ArchSetUpBaseClass(object):
             self.ctx,
             name="sdl2",
             recipes=["python3", "kivy"],
-            arch_name=self.TEST_ARCH,
+            archs=[self.TEST_ARCH],
         )
         self.ctx.python_recipe = Recipe.get_recipe("python3", self.ctx)
         # Here we define the expected compiler, which, as per ndk >= r19,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -8,7 +8,7 @@ from unittest import mock
 from pythonforandroid.bootstrap import (
     _cmp_bootstraps_by_priority, Bootstrap, expand_dependencies,
 )
-from pythonforandroid.distribution import Distribution, generate_dist_folder_name
+from pythonforandroid.distribution import Distribution
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.archs import ArchARMv7_a
 from pythonforandroid.build import Context
@@ -85,7 +85,7 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
 
         # test dist_dir success
         self.setUp_distribution_with_bootstrap(bs)
-        expected_folder_name = generate_dist_folder_name('test_prj', [self.TEST_ARCH])
+        expected_folder_name = 'test_prj'
         self.assertTrue(
             bs.dist_dir.endswith(f"dists/{expected_folder_name}"))
 
@@ -438,8 +438,8 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
         mock_strip_libraries.assert_called()
         expected__python_bundle = os.path.join(
             self.ctx.dist_dir,
-            f"{self.ctx.bootstrap.distribution.name}__{self.TEST_ARCH}",
-            "_python_bundle",
+            self.ctx.bootstrap.distribution.name,
+            f"_python_bundle__{self.TEST_ARCH}",
             "_python_bundle",
         )
         self.assertIn(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -50,7 +50,7 @@ class BaseClassSetupBootstrap(object):
         self.ctx.bootstrap.distribution = Distribution.get_distribution(
             self.ctx, name="test_prj",
             recipes=["python3", "kivy"],
-            arch_name=self.TEST_ARCH,
+            archs=[self.TEST_ARCH],
         )
 
     def tearDown(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,6 +4,7 @@ from unittest import mock
 import jinja2
 
 from pythonforandroid.build import run_pymodules_install
+from pythonforandroid.archs import ArchARMv7_a, ArchAarch_64
 
 
 class TestBuildBasic(unittest.TestCase):
@@ -14,6 +15,7 @@ class TestBuildBasic(unittest.TestCase):
         `project_dir` optional parameter is None, refs #1898
         """
         ctx = mock.Mock()
+        ctx.archs = [ArchARMv7_a(ctx), ArchAarch_64(ctx)]
         modules = []
         project_dir = None
         with mock.patch('pythonforandroid.build.info') as m_info:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -19,7 +19,7 @@ class TestBuildBasic(unittest.TestCase):
         modules = []
         project_dir = None
         with mock.patch('pythonforandroid.build.info') as m_info:
-            assert run_pymodules_install(ctx, modules, project_dir) is None
+            assert run_pymodules_install(ctx, ctx.archs[0], modules, project_dir) is None
         assert m_info.call_args_list[-1] == mock.call(
             'No Python modules and no setup.py to process, skipping')
 
@@ -44,13 +44,13 @@ class TestBuildBasic(unittest.TestCase):
 
             # Make sure it is NOT called when `with_debug_symbols` is true:
             ctx.with_debug_symbols = True
-            assert run_pymodules_install(ctx, modules, project_dir) is None
+            assert run_pymodules_install(ctx, ctx.archs[0], modules, project_dir) is None
             assert m_CythonRecipe().strip_object_files.called is False
 
             # Make sure strip object files IS called when
             # `with_debug_symbols` is fasle:
             ctx.with_debug_symbols = False
-            assert run_pymodules_install(ctx, modules, project_dir) is None
+            assert run_pymodules_install(ctx, ctx.archs[0], modules, project_dir) is None
             assert m_CythonRecipe().strip_object_files.called is True
 
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -53,7 +53,7 @@ class TestDistribution(unittest.TestCase):
             self.ctx,
             name=kwargs.pop("name", "test_prj"),
             recipes=kwargs.pop("recipes", ["python3", "kivy"]),
-            arch_name=self.TEST_ARCH,
+            archs=[self.TEST_ARCH],
             **kwargs
         )
 
@@ -111,7 +111,7 @@ class TestDistribution(unittest.TestCase):
         returns the proper result which should `unnamed_dist_1`."""
         mock_exists.return_value = False
         self.ctx.bootstrap = Bootstrap().get_bootstrap("sdl2", self.ctx)
-        dist = Distribution.get_distribution(self.ctx, arch_name=self.TEST_ARCH)
+        dist = Distribution.get_distribution(self.ctx, archs=[self.TEST_ARCH])
         self.assertEqual(dist.name, "unnamed_dist_1")
 
     @mock.patch("pythonforandroid.util.chdir")
@@ -213,7 +213,7 @@ class TestDistribution(unittest.TestCase):
             self.ctx,
             name="test_prj",
             recipes=["python3", "kivy"],
-            arch_name=self.TEST_ARCH,
+            archs=[self.TEST_ARCH],
         )
         mock_get_dists.return_value = [expected_dist]
         mock_glob.return_value = ["sdl2-python3"]
@@ -264,7 +264,7 @@ class TestDistribution(unittest.TestCase):
             self.ctx,
             name="test_prj",
             recipes=["python3", "kivy"],
-            arch_name=self.TEST_ARCH,
+            archs=[self.TEST_ARCH],
         )
         mock_get_dists.return_value = [expected_dist]
         self.setUp_distribution_with_bootstrap(

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -62,6 +62,8 @@ class TestToolchainCL:
             '--dist-name=test_toolchain',
             '--activity-class-name=abc.myapp.android.CustomPythonActivity',
             '--service-class-name=xyz.myapp.android.CustomPythonService',
+            '--arch=arm64-v8a',
+            '--arch=armeabi-v7a'
         ]
         with patch_sys_argv(argv), mock.patch(
             'pythonforandroid.build.get_available_apis'
@@ -116,7 +118,7 @@ class TestToolchainCL:
         """
         The `--sdk-dir` is mandatory to `create` a distribution.
         """
-        argv = ['toolchain.py', 'create']
+        argv = ['toolchain.py', 'create', '--arch=arm64-v8a', '--arch=armeabi-v7a']
         with patch_sys_argv(argv), pytest.raises(
             BuildInterruptingException
         ) as ex_info:

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -1,10 +1,12 @@
 import io
 import sys
+from os.path import join
 import pytest
 from unittest import mock
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import ToolchainCL
 from pythonforandroid.util import BuildInterruptingException
+from pythonforandroid.build import get_ndk_standalone
 
 
 def patch_sys_argv(argv):
@@ -70,6 +72,8 @@ class TestToolchainCL:
         ) as m_get_available_apis, mock.patch(
             'pythonforandroid.build.get_toolchain_versions'
         ) as m_get_toolchain_versions, mock.patch(
+            'pythonforandroid.build.get_ndk_sysroot'
+        ) as m_get_ndk_sysroot, mock.patch(
             'pythonforandroid.toolchain.build_recipes'
         ) as m_build_recipes, mock.patch(
             'pythonforandroid.bootstraps.service_only.'
@@ -77,6 +81,10 @@ class TestToolchainCL:
         ) as m_run_distribute:
             m_get_available_apis.return_value = [27]
             m_get_toolchain_versions.return_value = (['4.9'], True)
+            m_get_ndk_sysroot.return_value = (
+                join(get_ndk_standalone("/tmp/android-ndk"), "sysroot"),
+                True,
+            )
             tchain = ToolchainCL()
             assert tchain.ctx.activity_class_name == 'abc.myapp.android.CustomPythonActivity'
             assert tchain.ctx.service_class_name == 'xyz.myapp.android.CustomPythonService'
@@ -84,10 +92,11 @@ class TestToolchainCL:
             [mock.call('/tmp/android-sdk')],  # linux case
             [mock.call('/private/tmp/android-sdk')]  # macos case
         ]
-        assert m_get_toolchain_versions.call_args_list in [
-            [mock.call('/tmp/android-ndk', mock.ANY)],  # linux case
-            [mock.call('/private/tmp/android-ndk', mock.ANY)],  # macos case
-        ]
+        for callargs in m_get_toolchain_versions.call_args_list:
+            assert callargs in [
+                mock.call("/tmp/android-ndk", mock.ANY),  # linux case
+                mock.call("/private/tmp/android-ndk", mock.ANY),  # macos case
+            ]
         build_order = [
             'hostpython3', 'libffi', 'openssl', 'sqlite3', 'python3',
             'genericndkbuild', 'setuptools', 'six', 'pyjnius', 'android',

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -70,8 +70,6 @@ class TestToolchainCL:
         ) as m_get_available_apis, mock.patch(
             'pythonforandroid.build.get_toolchain_versions'
         ) as m_get_toolchain_versions, mock.patch(
-            'pythonforandroid.build.get_ndk_platform_dir'
-        ) as m_get_ndk_platform_dir, mock.patch(
             'pythonforandroid.toolchain.build_recipes'
         ) as m_build_recipes, mock.patch(
             'pythonforandroid.bootstraps.service_only.'
@@ -79,8 +77,6 @@ class TestToolchainCL:
         ) as m_run_distribute:
             m_get_available_apis.return_value = [27]
             m_get_toolchain_versions.return_value = (['4.9'], True)
-            m_get_ndk_platform_dir.return_value = (
-                '/tmp/android-ndk/platforms/android-21/arch-arm', True)
             tchain = ToolchainCL()
             assert tchain.ctx.activity_class_name == 'abc.myapp.android.CustomPythonActivity'
             assert tchain.ctx.service_class_name == 'xyz.myapp.android.CustomPythonService'


### PR DESCRIPTION
Is marked as WIP, cause the main target of this PR is to open a discussion around potential changes, and how to restructure some p4a functions in order to support AAB (See #2084).

Apart from the new (currently useless), `aab` build option, the current changes are basically doing the following:

- The old `private.mp3` tar file, is now been moved from `assets/private.mp3` to `lib/xxx/private.so`, where "xxx" is the targeted ABI. (This is necessary due to https://github.com/google/bundletool/issues/190)

- The new `lib/xxx/private.so` is now unpacked from the `getApplicationInfo().nativeLibraryDir` reported folder to the same target as before.

- Now the version check is skipped for obvious reasons. We should re-implement this feature via (as an example) an md5 hash? (Better if We do that at build time, skipping the md5 hash generation during runtime)


Next steps:

- [ ] Discuss the version management issue
- [x] Optimize the `private.so`by splitting it in two parts (ABI-specific parts(`_python_bundle`)) and NON-ABI-specific (that could be shipped into assets like We're already doing))
- [x] Instead of creating multiple dists for each ABI, create a single dist with multiple `_python_bundle` so it is easier to build the bundle later.
- [x] Add the option to build multiple ABIs at the same time.
- [x] Add the needed code to build the bundle.
- [x] Test the generated bundle on Play Console and generate ABI-specific apks via `bundletool`.
- [ ] Drop current apk generation method.
- [x] Fix issue: If the user builds in debug mode, and later in release mode, it fails due to gdb files in libs/arch folder.

I rarely have some spare time, so help is always appreciated.
