### PR TITLE
Add *.diff to manifest and package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ recursive-include doc *
 prune doc/build
 
 recursive-include pythonforandroid *.py *.tmpl biglink liblink
-recursive-include pythonforandroid/recipes *.py *.patch *.c *.pyx Setup *.h
+recursive-include pythonforandroid/recipes *.py *.patch *.diff *.c *.pyx Setup *.h
     
 recursive-include pythonforandroid/bootstraps *.properties *.xml *.java *.tmpl *.txt *.png *.aidl *.py *.sh *.c *.h *.html *.patch
     

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def recursively_include(results, directory, patterns):
 
 recursively_include(package_data, 'pythonforandroid/recipes',
                     ['*.patch', 'Setup*', '*.pyx', '*.py', '*.c', '*.h',
-                     '*.mk', '*.jam', ])
+                     '*.mk', '*.jam', '*.diff', ])
 recursively_include(package_data, 'pythonforandroid/bootstraps',
                     ['*.properties', '*.xml', '*.java', '*.tmpl', '*.txt', '*.png',
                      '*.mk', '*.c', '*.h', '*.py', '*.sh', '*.jpg', '*.aidl',


### PR DESCRIPTION
In this https://github.com/kivy/python-for-android/pull/2436 diff files where added to the package_data in setup.py. However, that is not enough. This PR adds the *.diff pattern to a couple of more places needed.