### PR TITLE
Upgrade grunt version re: CVE-2020-7729

### DIFF
--- a/doc/source/ext/sphinx_rtd_theme/package.json
+++ b/doc/source/ext/sphinx_rtd_theme/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": ">=1.3.0",
     "grunt-contrib-sass": "~0.7.2",
     "grunt-contrib-watch": "~0.4.3",
     "grunt-contrib-connect": "0.5.0",


### PR DESCRIPTION
The `python-for-android` repo is currently red-flagged for a security vulnerability. This PR updates grunt according to the dependabot guidelines.

![image](https://user-images.githubusercontent.com/3539755/130355916-6bb31566-cac5-4dee-ba1b-67ef07da60a4.png)

![image](https://user-images.githubusercontent.com/3539755/130355870-846706da-9338-4c0a-a362-e4e5799e372a.png)
