### PR TITLE
GitHub Actions: Fixes wrong actions/checkout@v2 usage

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -108,12 +108,10 @@ jobs:
     needs: [flake8]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout python-for-android (current branch)
-      uses: actions/checkout@v2
-    - name: Checkout python-for-android (develop branch)
+    - name: Checkout python-for-android
       uses: actions/checkout@v2
       with:
-        ref: 'develop'
+        fetch-depth: 0
     # helps with GitHub runner getting out of space
     - name: Free disk space
       run: |


### PR DESCRIPTION
This PR fixes a wrong `actions/checkout@v2` usage, that was preventing `Test updated recipes` test to work as expected.
`fetch-depth: 0` should work for our scope, even if it forces us to fetch history for all tags and branches.

See https://github.com/actions/checkout/pull/155 and https://github.com/actions/checkout/issues/214 for additional info.