### PR TITLE
Updated version of pygame from 2.0.1 to 2.1.0

### DIFF
--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -13,7 +13,7 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
         not part of the build. It's usable, but not complete.
     """
 
-    version = '2.0.1'
+    version = '2.1.0'
     url = 'https://github.com/pygame/pygame/archive/{version}.tar.gz'
 
     site_packages_name = 'pygame'


### PR DESCRIPTION
Changed the version of pygame in the recipe from 2.0.1 (released in Dec 2020) to the latest release 2.1.0 (released in Nov 2021).