### PR TITLE
Fix build

### DIFF
--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -46,7 +46,7 @@
     -->
     <application android:label="@string/app_name"
                  {% if debug %}android:debuggable="true"{% endif %}
-                 android:icon="@drawable/icon"
+                 android:icon="@mipmap/icon"
                  android:allowBackup="{{ args.allow_backup }}"
                  {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"


### PR DESCRIPTION
Build fails with AAPT: error: resource drawable/icon not found. Since it moved to mipmap. Update AndroidManifest template with the new path