### PR TITLE
Update python versions matrix on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2.2.1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.x
     - name: Run flake8
       run: |
         python -m pip install --upgrade pip
@@ -26,13 +26,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOs-latest]
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tox tests


### PR DESCRIPTION
This PR updates the python versions matrix used on the CI

`Python 3.6` reached EOL on 23 Dec 2021.