### PR TITLE
Update AndroidManifest.tmpl.xml

### DIFF
--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -65,6 +65,7 @@
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
+                  android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"
                   {% endif %}
@@ -91,7 +92,8 @@
         <service android:name="org.kivy.android.billing.BillingReceiver"
                  android:process=":pythonbilling" />
         <receiver android:name="org.kivy.android.billing.BillingReceiver"
-                  android:process=":pythonbillingreceiver">
+                  android:process=":pythonbillingreceiver"
+                  android:exported="false">
             <intent-filter>
                 <action android:name="com.android.vending.billing.IN_APP_NOTIFY" />
                 <action android:name="com.android.vending.billing.RESPONSE_CODE" />


### PR DESCRIPTION
If an activity, service, or broadcast receiver uses intent filters and doesn't have an explicitly-declared value for android:exported, your app can't be installed on a device that runs Android 12 or higher. (https://developer.android.com/about/versions/12/behavior-changes-12). I added three changes accordingly with the requirements.