### PR TITLE
Update AndroidManifest.tmpl.xml

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -75,7 +75,7 @@
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
-                     android:exported="true"
+                  android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"
                   {% endif %}
@@ -103,7 +103,7 @@
         <activity android:name="org.kivy.android.launcher.ProjectChooser"
                   android:icon="@mipmap/icon"
                   android:label="@string/app_name"
-                     android:exported="true">
+                  android:exported="true">
 
           <intent-filter>
             <action android:name="android.intent.action.MAIN" />
@@ -130,7 +130,7 @@
                  android:process=":pythonbilling" />
         <receiver android:name="org.kivy.android.billing.BillingReceiver"
                   android:process=":pythonbillingreceiver"
-                     android:exported="false">
+                  android:exported="false">
             <intent-filter>
                 <action android:name="com.android.vending.billing.IN_APP_NOTIFY" />
                 <action android:name="com.android.vending.billing.RESPONSE_CODE" />

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -75,6 +75,7 @@
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
+                     android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"
                   {% endif %}
@@ -101,7 +102,8 @@
         {% if args.launcher %}
         <activity android:name="org.kivy.android.launcher.ProjectChooser"
                   android:icon="@mipmap/icon"
-                  android:label="@string/app_name">
+                  android:label="@string/app_name"
+                     android:exported="true">
 
           <intent-filter>
             <action android:name="android.intent.action.MAIN" />
@@ -127,7 +129,8 @@
         <service android:name="org.kivy.android.billing.BillingReceiver"
                  android:process=":pythonbilling" />
         <receiver android:name="org.kivy.android.billing.BillingReceiver"
-                  android:process=":pythonbillingreceiver">
+                  android:process=":pythonbillingreceiver"
+                     android:exported="false">
             <intent-filter>
                 <action android:name="com.android.vending.billing.IN_APP_NOTIFY" />
                 <action android:name="com.android.vending.billing.RESPONSE_CODE" />

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -61,7 +61,7 @@
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
                   android:configChanges="keyboardHidden|orientation{% if args.min_sdk_version >= 13 %}|screenSize{% endif %}"
-                  >
+                  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -86,7 +86,8 @@
         <service android:name="org.kivy.android.billing.BillingReceiver"
                  android:process=":pythonbilling" />
         <receiver android:name="org.kivy.android.billing.BillingReceiver"
-                  android:process=":pythonbillingreceiver">
+                  android:process=":pythonbillingreceiver"
+                  android:exported="false">
             <intent-filter>
                 <action android:name="com.android.vending.billing.IN_APP_NOTIFY" />
                 <action android:name="com.android.vending.billing.RESPONSE_CODE" />

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -65,6 +65,7 @@
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.orientation }}"
+                  android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"
                   {% endif %}
@@ -91,7 +92,8 @@
         <service android:name="org.kivy.android.billing.BillingReceiver"
                  android:process=":pythonbilling" />
         <receiver android:name="org.kivy.android.billing.BillingReceiver"
-                  android:process=":pythonbillingreceiver">
+                  android:process=":pythonbillingreceiver"
+                  android:exported="false">
             <intent-filter>
                 <action android:name="com.android.vending.billing.IN_APP_NOTIFY" />
                 <action android:name="com.android.vending.billing.RESPONSE_CODE" />


### PR DESCRIPTION
For the apps targeting api level 31 (A12) and contain activities, services, or broadcast receivers that use intent filters, you must explicitly declare the android:exported attribute for these app components. If an activity, service, or broadcast receiver uses intent filters and doesn't have an explicitly-declared value for android:exported, your app can't be installed on a device that runs Android 12 or higher. (https://developer.android.com/about/versions/12/behavior-changes-12). I added three changes accordingly with the requirements.