### PR TITLE
Upgrading the flask version to avoid exception at the start of webview application

### DIFF
--- a/pythonforandroid/recipes/flask/__init__.py
+++ b/pythonforandroid/recipes/flask/__init__.py
@@ -3,7 +3,7 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class FlaskRecipe(PythonRecipe):
-    version = '1.1.2'
+    version = '2.0.3'
     url = 'https://github.com/pallets/flask/archive/{version}.zip'
 
     depends = ['setuptools']


### PR DESCRIPTION
The depencies of flask on itsdangerous and itsdangerous is unable to find the name json hence the application fails to start with the following exception.
ImportError: cannot import name 'json' from itsdangerous
This issue needs to fixed by upgrading the version of the flask the recipie.
I have tested with the modified reciepe with the latest version of flask and found that application works after the fix.