### PR TITLE
fix foreground service start for Android O+

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
@@ -1,5 +1,6 @@
 package {{ args.package }};
 
+import android.os.Build;
 import android.content.Intent;
 import android.content.Context;
 import {{ args.service_class_name }};
@@ -20,7 +21,16 @@ public class Service{{ name|capitalize }} extends {{ base_service_class }} {
 
     static public void start(Context ctx, String pythonServiceArgument) {
         Intent intent = getDefaultIntent(ctx, pythonServiceArgument);
+        //foreground: {{foreground}}
+        {% if foreground %}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ctx.startForegroundService(intent);
+        } else {
+            ctx.startService(intent);
+        }
+        {% else %}
         ctx.startService(intent);
+        {% endif %}
     }
 
     static public Intent getDefaultIntent(Context ctx, String pythonServiceArgument) {


### PR DESCRIPTION
**Problem**
Foreground Service doesn't work correctly on android O+.  Here is trace:

```
04-03 15:27:21.277 24236 24236 E AndroidRuntime: FATAL EXCEPTION: main
04-03 15:27:21.277 24236 24236 E AndroidRuntime: Process: org.myapp.myapp, PID: 24236
04-03 15:27:21.277 24236 24236 E AndroidRuntime: java.lang.RuntimeException: Unable to start receiver org.myapp.myapp.TaskReceiver: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=org.myapp.myapp/.ServiceNotifier (has extras) }: app is in background uid UidRecord{64a6ed0 u0a301 RCVR idle change:idle|uncached procs:1 seq(0,0,0)}
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:4358)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ActivityThread.access$2500(ActivityThread.java:296)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2238)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:107)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:213)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8178)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: Caused by: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=org.myapp.myapp/.ServiceNotifier (has extras) }: app is in background uid UidRecord{64a6ed0 u0a301 RCVR idle change:idle|uncached procs:1 seq(0,0,0)}
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1720)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ContextImpl.startService(ContextImpl.java:1675)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.content.ContextWrapper.startService(ContextWrapper.java:669)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.content.ContextWrapper.startService(ContextWrapper.java:669)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at org.myapp.myapp.ServiceNotifier.start(ServiceNotifier.java:18)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at org.myapp.myapp.TaskReceiver.onReceive(TaskReceiver.java:24)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:4349)
04-03 15:27:21.277 24236 24236 E AndroidRuntime: 	... 8 more
```
`Not allowed to start service Intent` - it's about background service limitations: https://developer.android.com/about/versions/oreo/background 
 
 , But I use `:foreground` in `buildozer.spec`:
 ```
 services = Notifier:notifier.py:foreground
 ```

**Fix**
The fix repeats part of closed pull request https://github.com/kivy/python-for-android/pull/1786/files#diff-91249b27761ee10b96c07b64959a33951619a2547223ebeaaf82ece873e1e594R104

