### PR TITLE
macOS CI: ADD APK, AAB & Updated Recipes build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,8 +47,8 @@ jobs:
         parallel: true
         flag-name: run-${{ matrix.os }}-${{ matrix.python-version }}
 
-  build_apk:
-    name: Unit test apk
+  ubuntu_build_apk:
+    name: Unit test apk [ ubuntu-latest ]
     needs: [flake8]
     runs-on: ubuntu-latest
     steps:
@@ -75,8 +75,37 @@ jobs:
         name: bdist_unit_tests_app-debug-1.1-.apk
         path: apks
 
-  build_aab:
-    name: Unit test aab
+  macos_build_apk:
+    name: Unit test apk [ ${{ matrix.runs_on }} ]
+    needs: [flake8]
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      matrix:
+        include:
+          - runs_on: macos-latest
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+    env:
+      ANDROID_HOME: ${HOME}/.android
+      ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
+      ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
+      ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
+    steps:
+      - name: Checkout python-for-android
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install autoconf automake libtool openssl pkg-config
+          make --file ci/makefiles/osx.mk
+      - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
+        run: |
+          make testapps-with-numpy
+
+  ubuntu_build_aab:
+    name: Unit test aab [ ubuntu-latest ]
     needs: [flake8]
     runs-on: ubuntu-latest
     steps:
@@ -103,8 +132,37 @@ jobs:
         name: bdist_unit_tests_app-release-1.1-.aab
         path: aabs
 
-  rebuild_updated_recipes:
-    name: Test updated recipes
+  macos_build_aab:
+    name: Unit test aab [ ${{ matrix.runs_on }} ]
+    needs: [flake8]
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      matrix:
+        include:
+          - runs_on: macos-latest
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+    env:
+      ANDROID_HOME: ${HOME}/.android
+      ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
+      ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
+      ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
+    steps:
+      - name: Checkout python-for-android
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install autoconf automake libtool openssl pkg-config
+          make --file ci/makefiles/osx.mk
+      - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
+        run: |
+          make testapps-with-numpy-aab
+
+  ubuntu_rebuild_updated_recipes:
+    name: Test updated recipes [ ubuntu-latest ]
     needs: [flake8]
     runs-on: ubuntu-latest
     steps:
@@ -127,6 +185,35 @@ jobs:
     - name: Rebuild updated recipes
       run: |
         make docker/run/make/rebuild_updated_recipes
+
+  macos_rebuild_updated_recipes:
+    name: Test updated recipes [ ${{ matrix.runs_on }} ]
+    needs: [flake8]
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      matrix:
+        include:
+          - runs_on: macos-latest
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+    env:
+      ANDROID_HOME: ${HOME}/.android
+      ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
+      ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
+      ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
+    steps:
+      - name: Checkout python-for-android
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install autoconf automake libtool openssl pkg-config
+          make --file ci/makefiles/osx.mk
+      - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
+        run: |
+          make rebuild_updated_recipes
 
   coveralls_finish:
     needs: test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -98,10 +98,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           make testapps-with-numpy
 
   ubuntu_build_aab:
@@ -155,10 +159,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           make testapps-with-numpy-aab
 
   ubuntu_rebuild_updated_recipes:
@@ -209,10 +217,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
         run: |
+          source ci/osx_ci.sh
+          arm64_set_path_and_python_version 3.9.7
           make rebuild_updated_recipes
 
   coveralls_finish:

--- a/ci/osx_ci.sh
+++ b/ci/osx_ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e -x
+
+arm64_set_path_and_python_version(){
+  python_version="$1"
+  if [[ $(/usr/bin/arch) = arm64 ]]; then
+      export PATH=/opt/homebrew/bin:$PATH
+      eval "$(pyenv init --path)"
+      pyenv install $python_version -s
+      pyenv global $python_version
+      export PATH=$(pyenv prefix)/bin:$PATH
+  fi
+}


### PR DESCRIPTION
- Fixes issue #2569 
- macOS builds are expected to fail ( `hostpython3`, `python3` and `numpy` builds are failing on macOS >= 11) https://github.com/kivy/python-for-android/pull/2566 should fix `python3` and `hostpython3`, but `numpy` needs to be updated accordingly.
- Builds on Apple Silicon are expected to fail until #2550 is ready and merged)
- On macOS (Github hosted) runners `ANDROID_*` env vars override is needed as are already defined https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#environment-variables-2 (Could be interesting to use the runner-environment contained version when we will migrate to a recent version of the NDK).