### PR TITLE
Add support for Python 3.10 and make it the default while building hostpython3 and python3

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -54,6 +54,7 @@ public class PythonUtil {
         libsList.add("python3.7m");
         libsList.add("python3.8");
         libsList.add("python3.9");
+        libsList.add("python3.10");
         libsList.add("main");
         return libsList;
     }
@@ -73,7 +74,7 @@ public class PythonUtil {
                 // load, and it has failed, give a more
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
-                if (lib.startsWith("python3.9") && !foundPython) {
+                if (lib.startsWith("python3.10") && !foundPython) {
                     throw new RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -35,7 +35,7 @@ class HostPython3Recipe(Recipe):
         :class:`~pythonforandroid.python.HostPythonRecipe`
     '''
 
-    version = '3.9.9'
+    version = '3.10.8'
     name = 'hostpython3'
 
     build_subdir = 'native-build'

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -35,7 +35,7 @@ class HostPython3Recipe(Recipe):
         :class:`~pythonforandroid.python.HostPythonRecipe`
     '''
 
-    version = '3.10.8'
+    version = '3.10.10'
     name = 'hostpython3'
 
     build_subdir = 'native-build'

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -56,7 +56,7 @@ class Python3Recipe(TargetPythonRecipe):
         :class:`~pythonforandroid.python.GuestPythonRecipe`
     '''
 
-    version = '3.9.9'
+    version = '3.10.8'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 
@@ -70,14 +70,16 @@ class Python3Recipe(TargetPythonRecipe):
 
         # Python 3.8.1 & 3.9.X
         ('patches/py3.8.1.patch', version_starts_with("3.8")),
-        ('patches/py3.8.1.patch', version_starts_with("3.9"))
+        ('patches/py3.8.1.patch', version_starts_with("3.9")),
+        ('patches/py3.8.1.patch', version_starts_with("3.10"))
     ]
 
     if shutil.which('lld') is not None:
         patches = patches + [
             ("patches/py3.7.1_fix_cortex_a8.patch", version_starts_with("3.7")),
             ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.8")),
-            ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.9"))
+            ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.9")),
+            ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.10"))
         ]
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
@@ -96,6 +98,7 @@ class Python3Recipe(TargetPythonRecipe):
         'ac_cv_file__dev_ptc=no',
         '--without-ensurepip',
         'ac_cv_little_endian_double=yes',
+        'ac_cv_header_sys_eventfd_h=no',
         '--prefix={prefix}',
         '--exec-prefix={exec_prefix}',
         '--enable-loadable-sqlite-extensions')

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -56,7 +56,7 @@ class Python3Recipe(TargetPythonRecipe):
         :class:`~pythonforandroid.python.GuestPythonRecipe`
     '''
 
-    version = '3.10.8'
+    version = '3.10.10'
     url = 'https://www.python.org/ftp/python/{version}/Python-{version}.tgz'
     name = 'python3'
 


### PR DESCRIPTION
- Adds support for Python 3.10 in `hostpython3` and `python3` recipes.
- Makes Python 3.10 the default version.
