### PR TITLE
Bumps libffi to v3.4.2 + adds -fPIC on i686-linux-android

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -264,6 +264,7 @@ class Archx86(Arch):
         '-mssse3',
         '-mfpmath=sse',
         '-m32',
+        '-fPIC',
     ]
 
 

--- a/pythonforandroid/recipes/libffi/__init__.py
+++ b/pythonforandroid/recipes/libffi/__init__.py
@@ -14,7 +14,7 @@ class LibffiRecipe(Recipe):
         - `libltdl-dev` which defines the `LT_SYS_SYMBOL_USCORE` macro
     """
     name = 'libffi'
-    version = 'v3.3'
+    version = 'v3.4.2'
     url = 'https://github.com/libffi/libffi/archive/{version}.tar.gz'
 
     patches = ['remove-version-info.patch']


### PR DESCRIPTION
- Bumps `libffi` from `v3.3` to `v3.4.2` ( `v3.3` was failing to build via Android-LLVM on macOS as `-flto` flag is present in `CFLAGS` by default (See: libffi/pull/590)
- Added missing `-fPIC` to `Archx86` (i686-linux-android)

~~⚠️ Do not merge it yet as it needs some tests during runtime.~~
✅  Tests passed during runtime on `on_device_unit_tests` (On a `arm64-v8a` device)