### PR TITLE
Add missing fetch-depth: 0 on macos_rebuild_updated_recipes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -215,6 +215,8 @@ jobs:
     steps:
       - name: Checkout python-for-android
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           source ci/osx_ci.sh


### PR DESCRIPTION
Like `ubuntu_rebuild_updated_recipes`, `macos_rebuild_updated_recipes` step `Checkout python-for-android` needs `fetch-depth: 0` in order to successfully process changes that have been made to recipes.