### PR TITLE
Remove stray - in output file name

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,9 +3,9 @@ name: Unit tests & build apps
 on: ['push', 'pull_request']
 
 env:
-  APK_ARTIFACT_FILENAME: bdist_unit_tests_app-debug-1.1-.apk
-  AAB_ARTIFACT_FILENAME: bdist_unit_tests_app-release-1.1-.aab
-  AAR_ARTIFACT_FILENAME: bdist_unit_tests_app-release-1.1-.aar
+  APK_ARTIFACT_FILENAME: bdist_unit_tests_app-debug-1.1.apk
+  AAB_ARTIFACT_FILENAME: bdist_unit_tests_app-release-1.1.aab
+  AAR_ARTIFACT_FILENAME: bdist_unit_tests_app-release-1.1.aar
   PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE: 0
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -106,17 +106,17 @@ docker/run/command: docker/build
 
 docker/run/make/with-artifact/apk/%: docker/build
 	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
-	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-debug-1.1-.apk ./apks
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-debug-1.1.apk ./apks
 	docker rm -fv p4a-latest
 
 docker/run/make/with-artifact/aar/%: docker/build
 	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
-	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1-.aar ./aars
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1.aar ./aars
 	docker rm -fv p4a-latest
 
 docker/run/make/with-artifact/aab/%: docker/build
 	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
-	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1-.aab ./aabs
+	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1.aab ./aabs
 	docker rm -fv p4a-latest
 
 docker/run/make/rebuild_updated_recipes: docker/build

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1147,7 +1147,7 @@ class ToolchainCL:
         if package_add_version:
             info('# Add version number to android package')
             package_name = basename(package_file)[:-len(package_extension)]
-            package_file_dest = "{}-{}-{}".format(
+            package_file_dest = "{}-{}{}".format(
                 package_name, build_args.version, package_extension)
             info('# Android package renamed to {}'.format(package_file_dest))
             shprint(sh.cp, package_file, package_file_dest)


### PR DESCRIPTION
The final component in the package name is just the extension, so
prefixing it with a - means the output file ends in `-.<ext>`.