### PR TITLE
Include HOME in build environment

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -109,6 +109,18 @@ class Arch:
     def get_env(self, with_flags_in_cc=True):
         env = {}
 
+        # HOME: User's home directory
+        #
+        # Many tools including p4a store outputs in the user's home
+        # directory. This is found from the HOME environment variable
+        # and falls back to the system account database. Setting HOME
+        # can be used to globally divert these tools to use a different
+        # path. Furthermore, in containerized environments the user may
+        # not exist in the account database, so if HOME isn't set than
+        # these tools will fail.
+        if 'HOME' in environ:
+            env['HOME'] = environ['HOME']
+
         # CFLAGS/CXXFLAGS: the processor flags
         env['CFLAGS'] = ' '.join(self.common_cflags).format(target=self.target)
         if self.arch_cflags:


### PR DESCRIPTION
Many of the tools run by p4a store intermediate files in the user's home
directory. Passing the HOME environment variable to the build
environment has 2 positive effects:

1. To completely encapsulate the build, HOME can be set to an alternate
   directory than the user's actual home directory. Many tools such as
   p4a have options to override these paths, but that must be done on a
   case by case basis and it would require that p4a pass through these
   options or environment variables.

2. In containerized environments the user may not be registered in the
   accounts database. If the user's home directory can't be found from
   the HOME environment variable or the accounts database, many tools
   will fail. An example of this is python2.7 when run by `ndk-build`.

I don't know if this is the best place to put this, but it seemed the most common location where the build environment is setup.