### PR TITLE
Set PATH using real SDK and NDK directories

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -370,9 +370,9 @@ class Context:
 
         self.env["PATH"] = ":".join(
             [
-                f"{ndk_dir}/toolchains/llvm/prebuilt/{py_platform}-x86_64/bin",
-                ndk_dir,
-                f"{sdk_dir}/tools",
+                f"{self.ndk_dir}/toolchains/llvm/prebuilt/{py_platform}-x86_64/bin",
+                self.ndk_dir,
+                f"{self.sdk_dir}/tools",
                 environ.get("PATH"),
             ]
         )

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -294,7 +294,7 @@ class TesSTLRecipe(BaseClassSetupBootstrap, unittest.TestCase):
         #  check that the mocks have been called
         mock_ensure_dir.assert_called()
         mock_find_executable.assert_called_once_with(
-            expected_compiler, path=os.environ['PATH']
+            expected_compiler, path=self.ctx.env['PATH']
         )
         self.assertIsInstance(env, dict)
 


### PR DESCRIPTION
This is a regression from f7f8cea636714dc4843b8818c553510f99084b6a.
Previously, `self.sdk_dir` and `self.ndk_dir` were passed to
`select_and_check_toolchain_version`.