### PR TITLE
Fixes a typo in macos_rebuild_updated_recipes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -223,7 +223,7 @@ jobs:
           arm64_set_path_and_python_version 3.9.7
           brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
-      - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
+      - name: Rebuild updated recipes
         run: |
           source ci/osx_ci.sh
           arm64_set_path_and_python_version 3.9.7


### PR DESCRIPTION
- Fixes a typo introduced in https://github.com/kivy/python-for-android/pull/2574