### PR TITLE
Added py3dns recipe

### DIFF
--- a/pythonforandroid/recipes/py3dns/__init__.py
+++ b/pythonforandroid/recipes/py3dns/__init__.py
@@ -4,7 +4,7 @@ from pythonforandroid.recipe import PythonRecipe
 class Py3DNSRecipe(PythonRecipe):
     site_packages_name = 'DNS'
     version = '3.2.1'
-    url = 'https://github.com/Neizvestnyj/py3dns/archive/{version}.zip'
+    url = 'https://launchpad.net/py3dns/trunk/{version}/+download/py3dns-{version}.tar.gz'
     depends = ['setuptools']
     patches = ['patches/android.patch']
     call_hostpython_via_targetpython = False

--- a/pythonforandroid/recipes/py3dns/__init__.py
+++ b/pythonforandroid/recipes/py3dns/__init__.py
@@ -1,0 +1,13 @@
+from pythonforandroid.recipe import PythonRecipe
+
+
+class Py3DNSRecipe(PythonRecipe):
+    site_packages_name = 'DNS'
+    version = '3.2.1'
+    url = 'https://github.com/Neizvestnyj/py3dns/archive/{version}.zip'
+    depends = ['setuptools']
+    patches = ['patches/android.patch']
+    call_hostpython_via_targetpython = False
+
+
+recipe = Py3DNSRecipe()

--- a/pythonforandroid/recipes/py3dns/patches/android.patch
+++ b/pythonforandroid/recipes/py3dns/patches/android.patch
@@ -1,19 +1,25 @@
 diff --git a/DNS/Base.py b/DNS/Base.py
-index 34a6da7..15f83a2 100644
+index 34a6da7..a558889 100644
 --- a/DNS/Base.py
 +++ b/DNS/Base.py
-@@ -49,9 +49,13 @@ defaults= { 'protocol':'udp', 'port':53, 'opcode':Opcode.QUERY,
-             'server': [] }
+@@ -15,6 +15,7 @@ import socket, string, types, time, select
+ import errno
+ from . import Type,Class,Opcode
+ import asyncore
++import os
+ #
+ # This random generator is used for transaction ids and port selection.  This
+ # is important to prevent spurious results from lost packets, and malicious
+@@ -50,8 +51,12 @@ defaults= { 'protocol':'udp', 'port':53, 'opcode':Opcode.QUERY,
  
  def ParseResolvConf(resolv_path="/etc/resolv.conf"):
--    "parses the /etc/resolv.conf file and sets defaults for name servers"
+     "parses the /etc/resolv.conf file and sets defaults for name servers"
 -    with open(resolv_path, 'r') as stream:
 -        return ParseResolvConfFromIterable(stream)
-+    try:
-+        "parses the /etc/resolv.conf file and sets defaults for name servers"
++    if os.path.exists(resolv_path):
 +        with open(resolv_path, 'r') as stream:
 +            return ParseResolvConfFromIterable(stream)
-+    except FileNotFoundError:
++    else:
 +        defaults['server'].append('127.0.0.1')
 +        return
  

--- a/pythonforandroid/recipes/py3dns/patches/android.patch
+++ b/pythonforandroid/recipes/py3dns/patches/android.patch
@@ -1,0 +1,21 @@
+diff --git a/DNS/Base.py b/DNS/Base.py
+index 34a6da7..15f83a2 100644
+--- a/DNS/Base.py
++++ b/DNS/Base.py
+@@ -49,9 +49,13 @@ defaults= { 'protocol':'udp', 'port':53, 'opcode':Opcode.QUERY,
+             'server': [] }
+ 
+ def ParseResolvConf(resolv_path="/etc/resolv.conf"):
+-    "parses the /etc/resolv.conf file and sets defaults for name servers"
+-    with open(resolv_path, 'r') as stream:
+-        return ParseResolvConfFromIterable(stream)
++    try:
++        "parses the /etc/resolv.conf file and sets defaults for name servers"
++        with open(resolv_path, 'r') as stream:
++            return ParseResolvConfFromIterable(stream)
++    except FileNotFoundError:
++        defaults['server'].append('127.0.0.1')
++        return
+ 
+ def ParseResolvConfFromIterable(lines):
+     "parses a resolv.conf formatted stream and sets defaults for name servers"


### PR DESCRIPTION
I found an error in the `py3dns` module for android. And since this library is not on github and it has not been updated for more than 3 years, I decided to copy the library to my repository and fix the bug by adding a patch. This is a fairly popular library, used as a dependency for `validate_email`.

```py
from kivy.app import App
from kivy.uix.button import Button

import DNS
import smtplib


class TestApp(App):
    def build(self):
        return Button(text='Get DNS',
                      on_release=lambda *args: print(self.get_dns_host('gmail.com')),
                      )

    @staticmethod
    def get_dns_host(hostname: str, timeout=5):
        valid_host = None
        try:
            DNS.DiscoverNameServers()
            mx_hosts = DNS.mxlookup(hostname, timeout)
            for mx in mx_hosts:
                smtp = smtplib.SMTP()
                try:
                    smtp.connect(mx[1])
                except smtplib.SMTPConnectError:
                    continue  # try the next MX server in list
                else:
                    valid_host = mx[1]
        except Exception as err:
            print(err)

        return valid_host


TestApp().run()
```