### PR TITLE
*_rebuild_updated_recipes CI jobs now test the updated recipe along all the supported Android archs (arm64-v8a, armeabi-v7a, x86_64, x86)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -202,9 +202,15 @@ jobs:
           path: ${{ matrix.runs_on }}-${{ env.AAB_ARTIFACT_FILENAME }}
 
   ubuntu_rebuild_updated_recipes:
-    name: Test updated recipes [ ubuntu-latest ]
+    name: Test updated recipes for arch ${{ matrix.android_arch }} [ ubuntu-latest ]
     needs: [flake8]
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        android_arch: ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
+    env:
+      REBUILD_UPDATED_RECIPES_EXTRA_ARGS: --arch=${{ matrix.android_arch }}
     steps:
     - name: Checkout python-for-android
       uses: actions/checkout@v2
@@ -227,16 +233,18 @@ jobs:
         make docker/run/make/rebuild_updated_recipes
 
   macos_rebuild_updated_recipes:
-    name: Test updated recipes [ ${{ matrix.runs_on }} ]
+    name: Test updated recipes for arch ${{ matrix.android_arch }} [ ${{ matrix.runs_on }} ]
     needs: [flake8]
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
     runs-on: ${{ matrix.runs_on }}
+    continue-on-error: true
     strategy:
       matrix:
+        android_arch: ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
+        runs_on: [macos-latest, apple-silicon-m1]
         include:
-          - runs_on: macos-latest
           - runs_on: apple-silicon-m1
             run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
     env:
@@ -244,6 +252,7 @@ jobs:
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
       ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
       ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
+      REBUILD_UPDATED_RECIPES_EXTRA_ARGS: --arch=${{ matrix.android_arch }}
     steps:
       - name: Checkout python-for-android
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PYTHON_WITH_VERSION=python$(PYTHON_VERSION)
 DOCKER_IMAGE=kivy/python-for-android
 ANDROID_SDK_HOME ?= $(HOME)/.android/android-sdk
 ANDROID_NDK_HOME ?= $(HOME)/.android/android-ndk
+REBUILD_UPDATED_RECIPES_EXTRA_ARGS ?= ''
 
 
 all: virtualenv
@@ -32,7 +33,7 @@ test:
 rebuild_updated_recipes: virtualenv
 	. $(ACTIVATE) && \
 	ANDROID_SDK_HOME=$(ANDROID_SDK_HOME) ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
-	$(PYTHON) ci/rebuild_updated_recipes.py
+	$(PYTHON) ci/rebuild_updated_recipes.py $(REBUILD_UPDATED_RECIPES_EXTRA_ARGS)
 
 testapps-with-numpy: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
@@ -83,6 +84,9 @@ docker/run/make/with-artifact/aab/%: docker/build
 	docker run --name p4a-latest --env-file=.env $(DOCKER_IMAGE) make $*
 	docker cp p4a-latest:/home/user/app/testapps/on_device_unit_tests/bdist_unit_tests_app-release-1.1-.aab ./aabs
 	docker rm -fv p4a-latest
+
+docker/run/make/rebuild_updated_recipes: docker/build
+	docker run --name p4a-latest -e REBUILD_UPDATED_RECIPES_EXTRA_ARGS --env-file=.env $(DOCKER_IMAGE) make rebuild_updated_recipes
 
 docker/run/make/%: docker/build
 	docker run --rm --env-file=.env $(DOCKER_IMAGE) make $*


### PR DESCRIPTION
✂️ (Partially) from #2586 

- `rebuild_updated_recipes.py` now accepts (multiple) `--arch ...` parameters so can build the updated recipes againist the selected archs.
- CI jobs for `*_rebuild_updated_recipes` (that run on `ubuntu-latest`, `macos-latest`, `apple-silicon-m1`) now are configured to run for each of the supported archs (`x86`, `x86_64`, `arm64-v8a`, `armeabi-v7a`).
- `continue-on-error: true` allow us to see if the build only fails for a specific arch.