### PR TITLE
Handle all the macOS prerequisites (except NDK/SDK) via prerequisites.py

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -122,7 +122,6 @@ jobs:
         run: |
           source ci/osx_ci.sh
           arm64_set_path_and_python_version 3.9.7
-          brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Build multi-arch apk Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
         run: |
@@ -207,7 +206,6 @@ jobs:
         run: |
           source ci/osx_ci.sh
           arm64_set_path_and_python_version 3.9.7
-          brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Build multi-arch aab Python 3 (armeabi-v7a, arm64-v8a, x86_64, x86)
         run: |
@@ -293,7 +291,6 @@ jobs:
         run: |
           source ci/osx_ci.sh
           arm64_set_path_and_python_version 3.9.7
-          brew install autoconf automake libtool openssl pkg-config
           make --file ci/makefiles/osx.mk
       - name: Rebuild updated recipes
         run: |

--- a/ci/makefiles/osx.mk
+++ b/ci/makefiles/osx.mk
@@ -1,4 +1,4 @@
-# installs java 1.8, android's SDK/NDK, cython and p4a
+# installs Android's SDK/NDK, cython
 
 # The following variable/s can be override when running the file
 ANDROID_HOME ?= $(HOME)/.android
@@ -10,4 +10,4 @@ upgrade_cython:
 
 install_android_ndk_sdk:
 	mkdir -p $(ANDROID_HOME)
-	make -f ci/makefiles/android.mk JAVA_HOME=`/usr/libexec/java_home -v 13`
+	make -f ci/makefiles/android.mk

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -67,7 +67,8 @@ def check_python_dependencies():
         exit(1)
 
 
-check_and_install_default_prerequisites()
+if not environ.get('SKIP_PREREQUISITES_CHECK', '0') == '1':
+    check_and_install_default_prerequisites()
 check_python_dependencies()
 
 

--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -1,0 +1,263 @@
+import unittest
+from unittest import mock
+
+from pythonforandroid.prerequisites import (
+    JDKPrerequisite,
+    HomebrewPrerequisite,
+    OpenSSLPrerequisite,
+    AutoconfPrerequisite,
+    AutomakePrerequisite,
+    LibtoolPrerequisite,
+    PkgConfigPrerequisite,
+    CmakePrerequisite,
+    get_required_prerequisites,
+)
+
+
+class PrerequisiteSetUpBaseClass:
+    def setUp(self):
+        self.mandatory = dict(linux=False, darwin=False)
+        self.installer_is_supported = dict(linux=False, darwin=False)
+
+    def test_is_mandatory_on_darwin(self):
+        assert self.prerequisite.mandatory["darwin"] == self.mandatory["darwin"]
+
+    def test_is_mandatory_on_linux(self):
+        assert self.prerequisite.mandatory["linux"] == self.mandatory["linux"]
+
+    def test_installer_is_supported_on_darwin(self):
+        assert (
+            self.prerequisite.installer_is_supported["darwin"]
+            == self.installer_is_supported["darwin"]
+        )
+
+    def test_installer_is_supported_on_linux(self):
+        assert (
+            self.prerequisite.installer_is_supported["linux"]
+            == self.installer_is_supported["linux"]
+        )
+
+
+class TestJDKPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = JDKPrerequisite()
+
+
+class TestBrewPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=False)
+        self.prerequisite = HomebrewPrerequisite()
+
+    @mock.patch("shutil.which")
+    def test_darwin_checker(self, shutil_which):
+        shutil_which.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        shutil_which.return_value = "/opt/homebrew/bin/brew"
+        self.assertTrue(self.prerequisite.darwin_checker())
+
+    @mock.patch("pythonforandroid.prerequisites.info")
+    def test_darwin_helper(self, info):
+        self.prerequisite.darwin_helper()
+        info.assert_called_once_with(
+            "Installer for homebrew is not yet supported on macOS,"
+            "the nice news is that the installation process is easy!"
+            "See: https://brew.sh for further instructions."
+        )
+
+
+class TestOpenSSLPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = OpenSSLPrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/openssl@1.1"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "openssl@1.1", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "openssl@1.1"])
+
+
+class TestAutoconfPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = AutoconfPrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/autoconf"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "autoconf", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "autoconf"])
+
+
+class TestAutomakePrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = AutomakePrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/automake"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "automake", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "automake"])
+
+
+class TestLibtoolPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = LibtoolPrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/libtool"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "libtool", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "libtool"])
+
+
+class TestPkgConfigPrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = PkgConfigPrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/pkg-config"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "pkg-config", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "pkg-config"])
+
+
+class TestCmakePrerequisite(PrerequisiteSetUpBaseClass, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mandatory = dict(linux=False, darwin=True)
+        self.installer_is_supported = dict(linux=False, darwin=True)
+        self.prerequisite = CmakePrerequisite()
+
+    @mock.patch(
+        "pythonforandroid.prerequisites.Prerequisite._darwin_get_brew_formula_location_prefix"
+    )
+    def test_darwin_checker(self, _darwin_get_brew_formula_location_prefix):
+        _darwin_get_brew_formula_location_prefix.return_value = None
+        self.assertFalse(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.return_value = (
+            "/opt/homebrew/opt/cmake"
+        )
+        self.assertTrue(self.prerequisite.darwin_checker())
+        _darwin_get_brew_formula_location_prefix.assert_called_with(
+            "cmake", installed=True
+        )
+
+    @mock.patch("pythonforandroid.prerequisites.subprocess.check_output")
+    def test_darwin_installer(self, check_output):
+        self.prerequisite.darwin_installer()
+        check_output.assert_called_once_with(["brew", "install", "cmake"])
+
+
+class TestDefaultPrerequisitesCheckandInstall(unittest.TestCase):
+
+    def test_default_darwin_prerequisites_set(self):
+        self.assertListEqual(
+            [
+                p.__class__.__name__
+                for p in get_required_prerequisites(platform="darwin")
+            ],
+            [
+                "HomebrewPrerequisite",
+                "AutoconfPrerequisite",
+                "AutomakePrerequisite",
+                "LibtoolPrerequisite",
+                "PkgConfigPrerequisite",
+                "CmakePrerequisite",
+                "OpenSSLPrerequisite",
+                "JDKPrerequisite",
+            ],
+        )
+
+    def test_default_linux_prerequisites_set(self):
+        self.assertListEqual(
+            [
+                p.__class__.__name__
+                for p in get_required_prerequisites(platform="linux")
+            ],
+            [
+            ],
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands = pytest {posargs:tests/}
 passenv = GITHUB_*
 setenv =
     PYTHONPATH={toxinidir}
+    SKIP_PREREQUISITES_CHECK=1
 
 [testenv:py3]
 # for py3 env we will get code coverage


### PR DESCRIPTION
✂️ Partially sliced from #2586

- Is still experimental
- Moved `autoconf`, `automake`, `libtool`, `openssl` and `pkg-config`
- Added some generic tests and specific ones.
- Changed the logic around `mandatory` and `installer_is_supported`
- Added `SKIP_PREREQUISITES_CHECK` so we can skip prerequisites checks during recipe tests.
- brew-installable prerequisites can follow a DRY approach, but we should make sure that also doesn't over-complicate the `linux` implementation, so I'll leave the improvements for later.
