### PR TITLE
Introduces pkg_config_location in Prerequisite and use OpenSSLPrerequisite().pkg_config_location in hostpython3, so we can support ssl on hostpython3 just out of the box also on macOS

### DIFF
--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -66,7 +66,9 @@ class HostPython3Recipe(Recipe):
         env = os.environ.copy()
         openssl_prereq = OpenSSLPrerequisite()
         if env.get("PKG_CONFIG_PATH", ""):
-            os.pathsep.join(openssl_prereq.pkg_config_location, env["PKG_CONFIG_PATH"])
+            env["PKG_CONFIG_PATH"] = os.pathsep.join(
+                openssl_prereq.pkg_config_location, env["PKG_CONFIG_PATH"]
+            )
         else:
             env["PKG_CONFIG_PATH"] = openssl_prereq.pkg_config_location
         return env

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -1,4 +1,5 @@
 import sh
+import os
 
 from multiprocessing import cpu_count
 from pathlib import Path
@@ -11,6 +12,7 @@ from pythonforandroid.util import (
     current_directory,
     ensure_dir,
 )
+from pythonforandroid.prerequisites import OpenSSLPrerequisite
 
 HOSTPYTHON_VERSION_UNSET_MESSAGE = (
     'The hostpython recipe must have set version'
@@ -60,6 +62,15 @@ class HostPython3Recipe(Recipe):
         '''Returns the full path of the hostpython executable.'''
         return join(self.get_path_to_python(), self._exe_name)
 
+    def get_recipe_env(self, arch=None):
+        env = os.environ.copy()
+        openssl_prereq = OpenSSLPrerequisite()
+        if env.get("PKG_CONFIG_PATH", ""):
+            os.pathsep.join(openssl_prereq.pkg_config_location, env["PKG_CONFIG_PATH"])
+        else:
+            env["PKG_CONFIG_PATH"] = openssl_prereq.pkg_config_location
+        return env
+
     def should_build(self, arch):
         if Path(self.python_exe).exists():
             # no need to build, but we must set hostpython for our Context
@@ -83,6 +94,8 @@ class HostPython3Recipe(Recipe):
         return join(self.get_build_dir(), self.build_subdir)
 
     def build_arch(self, arch):
+        env = self.get_recipe_env(arch)
+
         recipe_build_dir = self.get_build_dir(arch.arch)
 
         # Create a subdirectory to actually perform the build
@@ -92,7 +105,7 @@ class HostPython3Recipe(Recipe):
         # Configure the build
         with current_directory(build_dir):
             if not Path('config.status').exists():
-                shprint(sh.Command(join(recipe_build_dir, 'configure')))
+                shprint(sh.Command(join(recipe_build_dir, 'configure')), _env=env)
 
         with current_directory(recipe_build_dir):
             # Create the Setup file. This copying from Setup.dist is
@@ -110,7 +123,7 @@ class HostPython3Recipe(Recipe):
                         SETUP_DIST_NOT_FIND_MESSAGE
                     )
 
-            shprint(sh.make, '-j', str(cpu_count()), '-C', build_dir)
+            shprint(sh.make, '-j', str(cpu_count()), '-C', build_dir, _env=env)
 
             # make a copy of the python executable giving it the name we want,
             # because we got different python's executable names depending on


### PR DESCRIPTION
✂️ (Partially) from #2586 
- `hostpython3` requires `PKG_CONFIG_PATH` to be set on macOS in order to have `ssl` support (which is needed by `pip`)
- Introduces `pkg_config_location` property in `Prerequisite`.
- Introduced `homebrew_formula_name` in `Prerequisite`, to avoid some DRY violations.