### PR TITLE
Our self-hosted Apple Silicon runner now has been migrated to actions/runner v2.292.0 which now supports arm64 natively

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -96,9 +96,6 @@ jobs:
   macos_build_apk:
     name: Unit test apk [ ${{ matrix.runs_on }} | ${{ matrix.bootstrap.name }} ]
     needs: [flake8]
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
     runs-on: ${{ matrix.runs_on }}
     continue-on-error: true
     strategy:
@@ -109,9 +106,6 @@ jobs:
             target: testapps-with-numpy
           - name: webview
             target: testapps-webview
-        include:
-          - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
@@ -193,9 +187,6 @@ jobs:
   macos_build_aab:
     name: Unit test aab [ ${{ matrix.runs_on }} | ${{ matrix.bootstrap.name }} ]
     needs: [flake8]
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
     runs-on: ${{ matrix.runs_on }}
     continue-on-error: true
     strategy:
@@ -206,9 +197,6 @@ jobs:
             target: testapps-with-numpy-aab
           - name: webview
             target: testapps-webview-aab
-        include:
-          - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
@@ -280,18 +268,12 @@ jobs:
   macos_rebuild_updated_recipes:
     name: Test updated recipes for arch ${{ matrix.android_arch }} [ ${{ matrix.runs_on }} ]
     needs: [flake8]
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
     runs-on: ${{ matrix.runs_on }}
     continue-on-error: true
     strategy:
       matrix:
         android_arch: ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
         runs_on: [macos-latest, apple-silicon-m1]
-        include:
-          - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk


### PR DESCRIPTION

- Same of https://github.com/kivy/kivy/pull/7885

- https://github.com/actions/runner/releases/tag/v2.292.0 now supports Apple Silicon natively. 🥳

- The run_wrapper that was enforcing arm64 on top of a x86_64 process is now un-needed.

- There's a pending PR in actions/python-versions which is expected to introduce support for universal2 versions of Python, so hopefully, we will be able to rely on actions/setup-python also for our self hosted runner in a while..