### PR TITLE
changed arch.ndk_platform to arch.ndk_lib_dir in `librt` recipe

### DIFF
--- a/pythonforandroid/recipes/librt/__init__.py
+++ b/pythonforandroid/recipes/librt/__init__.py
@@ -19,7 +19,7 @@ class LibRt(Recipe):
         finishes'''
 
     def build_arch(self, arch):
-        libc_path = join(arch.ndk_platform, 'usr', 'lib', 'libc')
+        libc_path = join(arch.ndk_lib_dir, 'usr', 'lib', 'libc')
         # Create a temporary folder to add to link path with a fake librt.so:
         fake_librt_temp_folder = join(
             self.get_build_dir(arch.arch),


### PR DESCRIPTION
fix for 
```python
AttributeError: 'ArchARMv7_a' object has no attribute 'ndk_platform'
```