### PR TITLE
removed `usr` and `lib` from ndk library path in `librt` recipe

### DIFF
--- a/pythonforandroid/recipes/librt/__init__.py
+++ b/pythonforandroid/recipes/librt/__init__.py
@@ -19,7 +19,7 @@ class LibRt(Recipe):
         finishes'''
 
     def build_arch(self, arch):
-        libc_path = join(arch.ndk_lib_dir, 'usr', 'lib', 'libc')
+        libc_path = join(arch.ndk_lib_dir, 'libc')
         # Create a temporary folder to add to link path with a fake librt.so:
         fake_librt_temp_folder = join(
             self.get_build_dir(arch.arch),


### PR DESCRIPTION
fix for lxml build error
```sh
ld: error: unable to find library -lrt
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
error: command '/usr/bin/ccache' failed with exit status 1
```

the above error is using this path
```sh
/home/<user>/.buildozer/android/platform/android-ndk-r23b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/21/usr/lib
```
instead of 
```sh
/home/<user>/.buildozer/android/platform/android-ndk-r23b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/21
```