### PR TITLE
Android manifest XML: Pass activity meta-data

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -684,6 +684,8 @@ tools directory of the Android SDK.
                     help='The permissions to give this app.', nargs='+')
     ap.add_argument('--meta-data', dest='meta_data', action='append', default=[],
                     help='Custom key=value to add in application metadata')
+    ap.add_argument('--activity-meta-data', dest='activity_meta_data', action='append', default=[],
+                    help='Custom key=value to add in activity metadata')
     ap.add_argument('--uses-library', dest='android_used_libs', action='append', default=[],
                     help='Used shared libraries included using <uses-library> tag in AndroidManifest.xml')
     ap.add_argument('--asset', dest='assets',

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -97,6 +97,8 @@
             {%- if args.intent_filters -%}
             {{- args.intent_filters -}}
             {%- endif -%}
+            {% for m in args.activity_meta_data %}
+            <meta-data android:name="{{ m.split('=', 1)[0] }}" android:value="{{ m.split('=', 1)[-1] }}"/>{% endfor %}
         </activity>
 
         {% if args.launcher %}

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -70,6 +70,8 @@
             {%- if args.intent_filters -%}
             {{- args.intent_filters -}}
             {%- endif -%}
+            {% for m in args.activity_meta_data %}
+            <meta-data android:name="{{ m.split('=', 1)[0] }}" android:value="{{ m.split('=', 1)[-1] }}"/>{% endfor %}
         </activity>
 
         {% if service %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -78,6 +78,8 @@
             {%- if args.intent_filters -%}
             {{- args.intent_filters -}}
             {%- endif -%}
+            {% for m in args.activity_meta_data %}
+            <meta-data android:name="{{ m.split('=', 1)[0] }}" android:value="{{ m.split('=', 1)[-1] }}"/>{% endfor %}
         </activity>
 
         {% if service %}


### PR DESCRIPTION
Allow passing meta-data fields to the activity.