### PR TITLE
Fix webview Back button behaviour

### DIFF
--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -177,19 +177,22 @@ public class PythonActivity extends Activity {
             new File(getApplicationInfo().nativeLibraryDir));
     }
 
-    long lastBackClick = SystemClock.elapsedRealtime();
+    long lastBackClick = 0;
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // If it wasn't the Back key or there's no web page history, bubble up to the default
-        // system behavior (probably exit the activity)
-        if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
+        // Check if the key event was the Back button
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // If there's no web page history, bubble up to the default
+            // system behavior (probably exit the activity)
+            if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
+                lastBackClick = SystemClock.elapsedRealtime();
+                Toast.makeText(this, "Tap again to close the app", Toast.LENGTH_LONG).show();
+                return true;
+            }
+
             lastBackClick = SystemClock.elapsedRealtime();
-            Toast.makeText(this, "Click again to close the app",
-            Toast.LENGTH_LONG).show();
-            return true;
         }
 
-        lastBackClick = SystemClock.elapsedRealtime();
         return super.onKeyDown(keyCode, event);
     }
 

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -32,6 +32,7 @@ import android.graphics.Color;
 import android.widget.AbsoluteLayout;
 import android.view.ViewGroup.LayoutParams;
 
+import android.webkit.WebBackForwardList;
 import android.webkit.WebViewClient;
 import android.webkit.WebView;
 import android.webkit.CookieManager;
@@ -269,24 +270,30 @@ public class PythonActivity extends Activity {
         return   mLayout;
     }
 
-    long lastBackClick = SystemClock.elapsedRealtime();
+    long lastBackClick = 0;
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // Check if the key event was the Back button and if there's history
-        if ((keyCode == KeyEvent.KEYCODE_BACK) && mWebView.canGoBack()) {
-            mWebView.goBack();
-            return true;
-        }
-        // If it wasn't the Back key or there's no web page history, bubble up to the default
-        // system behavior (probably exit the activity)
-        if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
+        // Check if the key event was the Back button
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // Go back if there is web page history behind,
+            // but not to the start preloader
+            WebBackForwardList webViewBackForwardList = mWebView.copyBackForwardList();
+            if (webViewBackForwardList.getCurrentIndex() > 1) {
+                mWebView.goBack();
+                return true;
+            }
+
+            // If there's no web page history, bubble up to the default
+            // system behavior (probably exit the activity)
+            if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
+                lastBackClick = SystemClock.elapsedRealtime();
+                Toast.makeText(this, "Tap again to close the app", Toast.LENGTH_LONG).show();
+                return true;
+            }
+
             lastBackClick = SystemClock.elapsedRealtime();
-            Toast.makeText(this, "Click again to close the app",
-            Toast.LENGTH_LONG).show();
-            return true;
         }
 
-        lastBackClick = SystemClock.elapsedRealtime();
         return super.onKeyDown(keyCode, event);
     }
 


### PR DESCRIPTION
Fix #1907 
Back button currently fall to the start [preloader](https://github.com/kivy/python-for-android/blob/develop/pythonforandroid/bootstraps/webview/build/webview_includes/_load.html) and stuck on it.
We better keep that in mind and not let it happen.

Also fixed bug when app get closed without confirmation when you launch  it and immediately press back.


https://user-images.githubusercontent.com/20641837/179565742-39e1b920-dc1b-421c-8773-b5a214c0343a.mp4


