### PR TITLE
Use `shutil.which` instead of `sh.which`

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -336,7 +336,7 @@ class Context:
         self.ndk = AndroidNDK(self.ndk_dir)
 
         # path to some tools
-        self.ccache = sh.which("ccache")
+        self.ccache = shutil.which("ccache")
         if not self.ccache:
             info('ccache is missing, the build will not be optimized in the '
                  'future.')
@@ -905,7 +905,7 @@ def copylibs_function(soname, objs_paths, extra_link_dirs=None, env=None):
     elif 'READELF' in os.environ:
         readelf = os.environ['READELF']
     else:
-        readelf = sh.which('readelf').strip()
+        readelf = shutil.which('readelf').strip()
     readelf = sh.Command(readelf).bake('-d')
 
     dest = dirname(soname)

--- a/pythonforandroid/recipes/lapack/__init__.py
+++ b/pythonforandroid/recipes/lapack/__init__.py
@@ -9,6 +9,7 @@ from pythonforandroid.util import current_directory, ensure_dir, BuildInterrupti
 from multiprocessing import cpu_count
 from os.path import join
 import sh
+import shutil
 from os import environ
 from pythonforandroid.util import build_platform
 
@@ -43,7 +44,7 @@ class LapackRecipe(Recipe):
         sysroot = f"{ndk_dir}/platforms/{env['NDK_API']}/arch-{sysroot_suffix}"
         FC = f"{ndk_dir}/toolchains/{arch_to_toolchain(arch)}-{GCC_VER}/prebuilt/{HOST}/bin/{arch.command_prefix}-gfortran"
         env['FC'] = f'{FC} --sysroot={sysroot}'
-        if sh.which(FC) is None:
+        if shutil.which(FC) is None:
             raise BuildInterruptingException(f"{FC} not found. See https://github.com/mzakharo/android-gfortran")
         return env
 

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -5,6 +5,7 @@ from multiprocessing import cpu_count
 from os.path import join
 import glob
 import sh
+import shutil
 
 
 class NumpyRecipe(CompiledComponentsPythonRecipe):
@@ -67,7 +68,7 @@ class NumpyRecipe(CompiledComponentsPythonRecipe):
 
     def get_hostrecipe_env(self, arch):
         env = super().get_hostrecipe_env(arch)
-        env['RANLIB'] = sh.which('ranlib')
+        env['RANLIB'] = shutil.which('ranlib')
         return env
 
 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -6,7 +6,7 @@ from multiprocessing import cpu_count
 from os import environ, utime
 from os.path import dirname, exists, join
 from pathlib import Path
-from shutil import copy2
+import shutil
 
 from pythonforandroid.logger import info, warning, shprint
 from pythonforandroid.patching import version_starts_with
@@ -73,7 +73,7 @@ class Python3Recipe(TargetPythonRecipe):
         ('patches/py3.8.1.patch', version_starts_with("3.9"))
     ]
 
-    if sh.which('lld') is not None:
+    if shutil.which('lld') is not None:
         patches = patches + [
             ("patches/py3.7.1_fix_cortex_a8.patch", version_starts_with("3.7")),
             ("patches/py3.8.1_fix_cortex_a8.patch", version_starts_with("3.8")),
@@ -208,7 +208,7 @@ class Python3Recipe(TargetPythonRecipe):
         )
 
         env['LDFLAGS'] = env.get('LDFLAGS', '')
-        if sh.which('lld') is not None:
+        if shutil.which('lld') is not None:
             # Note: The -L. is to fix a bug in python 3.7.
             # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234409
             env['LDFLAGS'] += ' -L. -fuse-ld=lld'
@@ -380,7 +380,7 @@ class Python3Recipe(TargetPythonRecipe):
         info("Copy {} files into the bundle".format(len(module_filens)))
         for filen in module_filens:
             info(" - copy {}".format(filen))
-            copy2(filen, modules_dir)
+            shutil.copy2(filen, modules_dir)
 
         # zip up the standard library
         stdlib_zip = join(dirn, 'stdlib.zip')
@@ -408,7 +408,7 @@ class Python3Recipe(TargetPythonRecipe):
             for filen in filens:
                 info(" - copy {}".format(filen))
                 ensure_dir(join(dirn, 'site-packages', dirname(filen)))
-                copy2(filen, join(dirn, 'site-packages', filen))
+                shutil.copy2(filen, join(dirn, 'site-packages', filen))
 
         # copy the python .so files into place
         python_build_dir = join(self.get_build_dir(arch.arch),


### PR DESCRIPTION
- Recently our CI started to fail when checking the availability of certain tools (E.g. `lld`, `ccache` ...)
See: https://github.com/kivy/python-for-android/runs/7394641730
- `sh` released a new version (1.14.3, 12 hours ago) with a breaking change on our side.
- This is due to https://github.com/amoffat/sh/pull/584
- They are right, and in order to achieve what we expect `shutil.which("name")` should be used instead, as returns `None` when a cmd is not found.

  From [Python](https://docs.python.org/3/library/shutil.html#shutil.which) docs:
  > Return the path to an executable which would be run if the given cmd was called. If no cmd would be called, return None.