### PR TITLE
Fixes TypeError: str.join() takes exactly one argument (2 given) in hostpython3/__init__.py", line 69

### DIFF
--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -67,7 +67,7 @@ class HostPython3Recipe(Recipe):
         openssl_prereq = OpenSSLPrerequisite()
         if env.get("PKG_CONFIG_PATH", ""):
             env["PKG_CONFIG_PATH"] = os.pathsep.join(
-                openssl_prereq.pkg_config_location  # , env["PKG_CONFIG_PATH"]
+                [openssl_prereq.pkg_config_location, env["PKG_CONFIG_PATH"]]
             )
         else:
             env["PKG_CONFIG_PATH"] = openssl_prereq.pkg_config_location

--- a/pythonforandroid/recipes/hostpython3/__init__.py
+++ b/pythonforandroid/recipes/hostpython3/__init__.py
@@ -67,7 +67,7 @@ class HostPython3Recipe(Recipe):
         openssl_prereq = OpenSSLPrerequisite()
         if env.get("PKG_CONFIG_PATH", ""):
             env["PKG_CONFIG_PATH"] = os.pathsep.join(
-                openssl_prereq.pkg_config_location, env["PKG_CONFIG_PATH"]
+                openssl_prereq.pkg_config_location  # , env["PKG_CONFIG_PATH"]
             )
         else:
             env["PKG_CONFIG_PATH"] = openssl_prereq.pkg_config_location


### PR DESCRIPTION
fix .buildozer/android/platform/python-for-android/pythonforandroid/recipes/hostpython3/__init__.py", line 69, in get_recipe_env
    env["PKG_CONFIG_PATH"] = os.pathsep.join(
TypeError: str.join() takes exactly one argument (2 given)