### PR TITLE
Fixes some E275 - assert is a keyword.

### DIFF
--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -45,7 +45,7 @@ def get_dependency_tuple_list_for_recipe(recipe, blacklist=None):
     """
     if blacklist is None:
         blacklist = set()
-    assert(type(blacklist) == set)
+    assert type(blacklist) == set
     if recipe.depends is None:
         dependencies = []
     else:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -115,7 +115,7 @@ def test_get_dependency_tuple_list_for_recipe(monkeypatch):
     dep_list = get_dependency_tuple_list_for_recipe(
         r, blacklist={"libffi"}
     )
-    assert(dep_list == [("pillow",)])
+    assert dep_list == [("pillow",)]
 
 
 @pytest.mark.parametrize('names,bootstrap', valid_combinations)


### PR DESCRIPTION
- Assert is a keyword and a space is needed + the parentheses are not needed.
- A recent change in `pycodestyle` (See: https://github.com/PyCQA/pycodestyle/pull/1063) introduced this check.
- CI runs started to fail this evening. (See: https://github.com/kivy/python-for-android/runs/7599511212)