### PR TITLE
Remove six and enum34 dependency

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1,7 +1,6 @@
 from os.path import basename, dirname, exists, isdir, isfile, join, realpath, split
 import glob
 from shutil import rmtree
-from six import with_metaclass
 
 import hashlib
 from re import match
@@ -40,7 +39,7 @@ class RecipeMeta(type):
         return super().__new__(cls, name, bases, dct)
 
 
-class Recipe(with_metaclass(RecipeMeta)):
+class Recipe(metaclass=RecipeMeta):
     _url = None
     '''The address from which the recipe may be downloaded. This is not
     essential, it may be omitted if the source is available some other

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -29,8 +29,7 @@ def check_python_dependencies():
 
     ok = True
 
-    modules = [('colorama', '0.3.3'), 'appdirs', ('sh', '1.10'), 'jinja2',
-               'six']
+    modules = [('colorama', '0.3.3'), 'appdirs', ('sh', '1.10'), 'jinja2']
 
     for module in modules:
         if isinstance(module, tuple):

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ data_files = []
 # must be a single statement since buildozer is currently parsing it, refs:
 # https://github.com/kivy/buildozer/issues/722
 install_reqs = [
-    'appdirs', 'colorama>=0.3.3', 'jinja2', 'six',
-    'enum34; python_version<"3.4"', 'sh>=1.10; sys_platform!="nt"',
+    'appdirs', 'colorama>=0.3.3', 'jinja2',
+    'sh>=1.10; sys_platform!="nt"',
     'pep517<0.7.0', 'toml',
 ]
 # (pep517 and toml are used by pythonpackage.py)


### PR DESCRIPTION
- Python 2 is not supported anymore, so `six` is not needed.
- The same applies for `enum34` as python versions < 3.4 are not supported anymore.