### PR TITLE
`liblzma`: Use `p4a_install` instead of `install`, as a file named `INSTALL` is already present.

### DIFF
--- a/pythonforandroid/recipes/liblzma/__init__.py
+++ b/pythonforandroid/recipes/liblzma/__init__.py
@@ -6,18 +6,18 @@ from os.path import exists, join
 from pythonforandroid.archs import Arch
 from pythonforandroid.logger import shprint
 from pythonforandroid.recipe import Recipe
-from pythonforandroid.util import current_directory, ensure_dir
+from pythonforandroid.util import current_directory
 
 
 class LibLzmaRecipe(Recipe):
 
     version = '5.2.4'
     url = 'https://tukaani.org/xz/xz-{version}.tar.gz'
-    built_libraries = {'liblzma.so': 'install/lib'}
+    built_libraries = {'liblzma.so': 'p4a_install/lib'}
 
     def build_arch(self, arch: Arch) -> None:
         env = self.get_recipe_env(arch)
-        install_dir = join(self.get_build_dir(arch.arch), 'install')
+        install_dir = join(self.get_build_dir(arch.arch), 'p4a_install')
         with current_directory(self.get_build_dir(arch.arch)):
             if not exists('configure'):
                 shprint(sh.Command('./autogen.sh'), _env=env)
@@ -42,7 +42,6 @@ class LibLzmaRecipe(Recipe):
                 _env=env
             )
 
-            ensure_dir('install')
             shprint(sh.make, 'install', _env=env)
 
     def get_library_includes(self, arch: Arch) -> str:
@@ -52,7 +51,7 @@ class LibLzmaRecipe(Recipe):
         variable `CPPFLAGS`.
         """
         return " -I" + join(
-            self.get_build_dir(arch.arch), 'install', 'include',
+            self.get_build_dir(arch.arch), 'p4a_install', 'include',
         )
 
     def get_library_ldflags(self, arch: Arch) -> str:

--- a/tests/recipes/test_liblzma.py
+++ b/tests/recipes/test_liblzma.py
@@ -15,7 +15,7 @@ class TestLibLzmaRecipe(BaseTestForMakeRecipe, unittest.TestCase):
         recipe_build_dir = self.recipe.get_build_dir(self.arch.arch)
         self.assertEqual(
             self.recipe.get_library_includes(self.arch),
-            f" -I{join(recipe_build_dir, 'install/include')}",
+            f" -I{join(recipe_build_dir, 'p4a_install/include')}",
         )
 
     def test_get_library_ldflags(self):
@@ -25,7 +25,7 @@ class TestLibLzmaRecipe(BaseTestForMakeRecipe, unittest.TestCase):
         recipe_build_dir = self.recipe.get_build_dir(self.arch.arch)
         self.assertEqual(
             self.recipe.get_library_ldflags(self.arch),
-            f" -L{join(recipe_build_dir, 'install/lib')}",
+            f" -L{join(recipe_build_dir, 'p4a_install/lib')}",
         )
 
     def test_link_libs_flags(self):
@@ -33,3 +33,19 @@ class TestLibLzmaRecipe(BaseTestForMakeRecipe, unittest.TestCase):
         Test :meth:`~pythonforandroid.recipes.liblzma.get_library_libs_flag`.
         """
         self.assertEqual(self.recipe.get_library_libs_flag(), " -llzma")
+
+    def test_install_dir_not_named_install(self):
+        """
+        Tests that the install directory is not named ``install``.
+
+        liblzma already have a file named ``INSTALL`` in its source directory.
+        On case-insensitive filesystems, using a folder named ``install`` will
+        cause a conflict. (See issue: #2343).
+
+        WARNING: This test is quite flaky, but should be enough to
+        ensure that someone in the future will not accidentally rename
+        the install directory without seeing this test to fail.
+        """
+        liblzma_install_dir = self.recipe.built_libraries["liblzma.so"]
+
+        self.assertNotIn("install", liblzma_install_dir.split("/"))


### PR DESCRIPTION
Fixes issue #2343 

On macOS with a case-insensitive filesystem (which is the default), `install` and `INSTALL` are the same thing, and `INSTALL` is a file that already exists.

- The folder used to store the build results (`lib` and `headers`) was previously named `install` and now got renamed to `p4a_install` so it doesn't interfere with the file named `INSTALL`

- Removed an `ensure_dir('install')` call, which was creating an unused folder in the wrong place.

- Added a test that may help us to notice if the folder name gets reverted to `install`