### PR TITLE
Bump minimal and recommended Android NDK version to 25b

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -109,17 +109,11 @@ jobs:
             target: testapps-with-numpy
           - name: webview
             target: testapps-webview
-        include:
-          - runs_on: macos-latest
-            ndk_version: '23b'
-          - runs_on: apple-silicon-m1
-            ndk_version: '24'
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
       ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
       ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
-      ANDROID_NDK_VERSION: ${{ matrix.ndk_version }}
     steps:
       - name: Checkout python-for-android
         uses: actions/checkout@v2
@@ -247,17 +241,11 @@ jobs:
             target: testapps-with-numpy-aab
           - name: webview
             target: testapps-webview-aab
-        include:
-          - runs_on: macos-latest
-            ndk_version: '23b'
-          - runs_on: apple-silicon-m1
-            ndk_version: '24'
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
       ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
       ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
-      ANDROID_NDK_VERSION: ${{ matrix.ndk_version }}
     steps:
       - name: Checkout python-for-android
         uses: actions/checkout@v2
@@ -330,18 +318,12 @@ jobs:
       matrix:
         android_arch: ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
         runs_on: [macos-latest, apple-silicon-m1]
-        include:
-          - runs_on: macos-latest
-            ndk_version: '23b'
-          - runs_on: apple-silicon-m1
-            ndk_version: '24'
     env:
       ANDROID_HOME: ${HOME}/.android
       ANDROID_SDK_ROOT: ${HOME}/.android/android-sdk
       ANDROID_SDK_HOME: ${HOME}/.android/android-sdk
       ANDROID_NDK_HOME: ${HOME}/.android/android-ndk
       REBUILD_UPDATED_RECIPES_EXTRA_ARGS: --arch=${{ matrix.android_arch }}
-      ANDROID_NDK_VERSION: ${{ matrix.ndk_version }}
     steps:
       - name: Checkout python-for-android
         uses: actions/checkout@v2

--- a/ci/makefiles/android.mk
+++ b/ci/makefiles/android.mk
@@ -1,7 +1,7 @@
 # Downloads and installs the Android SDK depending on supplied platform: darwin or linux
 
 # Those android NDK/SDK variables can be override when running the file
-ANDROID_NDK_VERSION ?= 23b
+ANDROID_NDK_VERSION ?= 25b
 ANDROID_NDK_VERSION_LEGACY ?= 21e
 ANDROID_SDK_TOOLS_VERSION ?= 6514223
 ANDROID_SDK_BUILD_TOOLS_VERSION ?= 29.0.3

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -120,7 +120,7 @@ named ``tools``, and you will need to run extra commands to install
 the SDK packages needed. 
 
 For Android NDK, note that modern releases will only work on a 64-bit
-operating system. **The minimal, and recommended, NDK version to use is r23b:**
+operating system. **The minimal, and recommended, NDK version to use is r25b:**
 
  - `Go to ndk downloads page <https://developer.android.com/ndk/downloads/>`_
  - Windows users should create a virtual machine with an GNU Linux os

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -8,11 +8,11 @@ from pythonforandroid.logger import info, warning
 from pythonforandroid.util import BuildInterruptingException
 
 # We only check the NDK major version
-MIN_NDK_VERSION = 23
-MAX_NDK_VERSION = 23
+MIN_NDK_VERSION = 25
+MAX_NDK_VERSION = 25
 
 # DO NOT CHANGE LINE FORMAT: buildozer parses the existence of a RECOMMENDED_NDK_VERSION
-RECOMMENDED_NDK_VERSION = "23b"
+RECOMMENDED_NDK_VERSION = "25b"
 
 NDK_DOWNLOAD_URL = "https://developer.android.com/ndk/downloads/"
 


### PR DESCRIPTION
- Android NDK `25b` fully supports Apple Silicon 🎉 
- Android NDK `25b` is the new LTS version, and ATM, is the only one marked as supported by Google.

Here's a summary of the major changes (NDK 23 -- > NDK 25)  from Google release notes:

- The GNU Assembler (GAS), has been removed. If you were building with -fno-integrated-as you'll need to remove that flag. See [Clang Migration Notes](https://android.googlesource.com/platform/ndk/+/refs/heads/master/docs/ClangMigration.md) for advice on making assembly compatible with LLVM.
- GDB has been removed. Use LLDB instead. Note that ndk-gdb uses LLDB by default, and Android Studio has only ever supported LLDB.
- Jelly Bean (APIs 16, 17, and 18) is no longer supported. The minimum OS supported by the NDK is KitKat (API level 19).
- Non-Neon devices are no longer supported. A very small number of very old devices do not support Neon so most apps will not notice aside from the performance improvement.
- RenderScript build support has been removed. RenderScript was [deprecated](https://developer.android.com/about/versions/12/deprecations#renderscript) in Android 12. If you have not finished migrating your apps away from RenderScript, NDK r23 LTS can be used.
- Includes Android 13 APIs.
- Updated LLVM to clang-r450784d, based on LLVM 14 development.

Everything can happen, but that should not impact any of our recipes (I've been on NDK 25 for a month now).