### PR TITLE
`toml` may not be available on systemwide python

### DIFF
--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -269,11 +269,15 @@ class TestGetSystemPythonExecutable():
             p2 = os.path.normpath(pybin)
             assert p1 == p2
         except RuntimeError as e:
+            # (remember this is not in a virtualenv)
+            # Some deps may not be installed, so we just avoid to raise
+            # an exception here, as a missing dep should not make the test
+            # fail.
             if "pep517" in str(e.args):
                 # System python probably doesn't have pep517 available!
-                # (remember this is not in a virtualenv)
-                # Not much we can do in that case since pythonpackage needs it,
-                # so we'll skip this particular check.
+                pass
+            elif "toml" in str(e.args):
+                # System python probably doesn't have toml available!
                 pass
             else:
                 raise


### PR DESCRIPTION
- Added clarification about this test.
- `toml` is not available on system-wide Python installation on the latest Github Actions runner images.
- The CI started to fail recently, see: https://github.com/kivy/python-for-android/runs/8256955240