### PR TITLE
Fixes libvpx build

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -16,7 +16,6 @@ BROKEN_RECIPES_PYTHON3 = set([
     # build_dir = glob.glob('build/lib.*')[0]
     # IndexError: list index out of range
     'secp256k1',
-    'ffpyplayer',
     # requires `libpq-dev` system dependency e.g. for `pg_config` binary
     'psycopg2',
     # most likely some setup in the Docker container, because it works in host

--- a/pythonforandroid/recipes/libvpx/__init__.py
+++ b/pythonforandroid/recipes/libvpx/__init__.py
@@ -44,7 +44,6 @@ class VPXRecipe(Recipe):
                 '--disable-docs',
                 '--disable-install-docs',
                 '--disable-realtime-only',
-                '--enable-external-build',
                 f'--prefix={realpath(".")}',
             ]
             configure = sh.Command('./configure')

--- a/pythonforandroid/recipes/libvpx/__init__.py
+++ b/pythonforandroid/recipes/libvpx/__init__.py
@@ -46,6 +46,10 @@ class VPXRecipe(Recipe):
                 '--disable-realtime-only',
                 f'--prefix={realpath(".")}',
             ]
+
+            if arch.arch == 'armeabi-v7a':
+                flags.append('--disable-neon-asm')
+
             configure = sh.Command('./configure')
             shprint(configure, *flags, _env=env)
             shprint(sh.make, '-j', str(cpu_count()), _env=env)


### PR DESCRIPTION
Fixes issue #2665 

- `libvpx` build was silently failing.
- `--enable-external-build` is preventing the build to success.
- Disabled `neon-asm` on `armeabi-v7a`
- Removed `ffpyplayer` from `BROKEN_RECIPES`
