### PR TITLE
Resize webview when keyboard is shown

### DIFF
--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -70,6 +70,7 @@
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"
                   {% endif %}
+                  android:windowSoftInputMode="adjustResize"
                   >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
When the adjust mode is unspecified, Android will not resize the webview when showing the on screen keyboard to keep the input element on screen. Explicitly instruct it to use `adjustResize` mode. Possibly this is because the webview bootstrap uses an `AbsoluteLayout` as the top level widget. See
https://developer.android.com/guide/topics/manifest/activity-element#wsoft for details.