### PR TITLE
requirements: relax version bound on "pep517"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ data_files = []
 install_reqs = [
     'appdirs', 'colorama>=0.3.3', 'jinja2',
     'sh>=1.10; sys_platform!="nt"',
-    'pep517<0.7.0', 'toml',
+    'pep517', 'toml',
 ]
 # (pep517 and toml are used by pythonpackage.py)
 

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -304,7 +304,7 @@ class TestGetSystemPythonExecutable():
             ])
             subprocess.check_output([
                 os.path.join(test_dir, "venv", "bin", "pip"),
-                "install", "-U", "pep517<0.7.0"
+                "install", "-U", "pep517"
             ])
             subprocess.check_output([
                 os.path.join(test_dir, "venv", "bin", "pip"),


### PR DESCRIPTION
The "<0.7.0" bound was added in https://github.com/kivy/python-for-android/commit/9f6d6fcce748be96ed606815aca9294644ac90cc to fix https://github.com/kivy/python-for-android/issues/1994 :

> The `TestGetSystemPythonExecutable.test_virtualenv` and `TestGetSystemPythonExecutable.test_venv` tests started failing all of a sudden. Error was:
>
> ```
> ModuleNotFoundError: No module named \'pytoml\'\n'
> ```
>
> This ca be reproduced in local via:
>
> ```shell
> pytest tests/test_pythonpackage_basic.py::TestGetSystemPythonExecutable::test_virtualenv
> ```

I think this no longer applies,
`$ pytest tests/test_pythonpackage_basic.py::TestGetSystemPythonExecutable` runs successfully for me, using latest `pep517==0.13.0`.

---

Also, let's see if the CI tests pass.