### PR TITLE
android sdk tools: adapt path to file hierarchy changes

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -29,7 +29,9 @@ def get_targets(sdk_dir):
     if exists(join(sdk_dir, 'cmdline-tools', 'latest', 'bin', 'avdmanager')):
         avdmanager = sh.Command(join(sdk_dir, 'cmdline-tools', 'latest', 'bin', 'avdmanager'))
         targets = avdmanager('list', 'target').stdout.decode('utf-8').split('\n')
-
+    elif exists(join(sdk_dir, 'cmdline-tools', 'bin', 'avdmanager')):
+        avdmanager = sh.Command(join(sdk_dir, 'cmdline-tools', 'bin', 'avdmanager'))
+        targets = avdmanager('list', 'target').stdout.decode('utf-8').split('\n')
     elif exists(join(sdk_dir, 'tools', 'bin', 'avdmanager')):
         avdmanager = sh.Command(join(sdk_dir, 'tools', 'bin', 'avdmanager'))
         targets = avdmanager('list', 'target').stdout.decode('utf-8').split('\n')


### PR DESCRIPTION
Recent Android SDK tools, including e.g. ["8092744"](https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip) and ["8512546"](https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip), use a different path structure than e.g. ["6514223"](https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip).

E.g. `sdkmanager` in older sdk tools used to be located at
  `${ANDROID_SDK_HOME}/tools/bin/sdkmanager`
but now it is at
  `${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager`

Related:
https://github.com/kivy/python-for-android/issues/2540
https://github.com/kivy/python-for-android/pull/2593