### PR TITLE
recipe.download_file: implement shallow git cloning

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -213,24 +213,26 @@ class Recipe(metaclass=RecipeMeta):
                 break
             return target
         elif parsed_url.scheme in ('git', 'git+file', 'git+ssh', 'git+http', 'git+https'):
-            if isdir(target):
-                with current_directory(target):
-                    shprint(sh.git, 'fetch', '--tags', '--recurse-submodules')
-                    if self.version:
-                        shprint(sh.git, 'checkout', self.version)
-                    branch = sh.git('branch', '--show-current')
-                    if branch:
-                        shprint(sh.git, 'pull')
-                        shprint(sh.git, 'pull', '--recurse-submodules')
-                    shprint(sh.git, 'submodule', 'update', '--recursive')
-            else:
+            if not isdir(target):
                 if url.startswith('git+'):
                     url = url[4:]
-                shprint(sh.git, 'clone', '--recursive', url, target)
+                # if 'version' is specified, do a shallow clone
                 if self.version:
+                    shprint(sh.mkdir, '-p', target)
                     with current_directory(target):
-                        shprint(sh.git, 'checkout', self.version)
-                        shprint(sh.git, 'submodule', 'update', '--recursive')
+                        shprint(sh.git, 'init')
+                        shprint(sh.git, 'remote', 'add', 'origin', url)
+                else:
+                    shprint(sh.git, 'clone', '--recursive', url, target)
+            with current_directory(target):
+                if self.version:
+                    shprint(sh.git, 'fetch', '--depth', '1', 'origin', self.version)
+                    shprint(sh.git, 'checkout', self.version)
+                branch = sh.git('branch', '--show-current')
+                if branch:
+                    shprint(sh.git, 'pull')
+                    shprint(sh.git, 'pull', '--recurse-submodules')
+                shprint(sh.git, 'submodule', 'update', '--recursive', '--init', '--depth', '1')
             return target
 
     def apply_patch(self, filename, arch, build_dir=None):


### PR DESCRIPTION
When a recipe uses a "git+..." `url`, and has a `version` specified, only do a shallow git clone. This saves disk space and bandwidth.

Tested with a custom qt5 recipe.
Without this patch, the git clone on disk was 8.5 GB, now it is 5.0 GB.

```
class Qt5Recipe(BootstrapNDKRecipe):
    url = 'git+https://code.qt.io/qt/qt5.git'
    version = '9b43a43ee96198674060c6b9591e515e2d27c28f'  # version 5.15.2
```