### PR TITLE
Update `MIN_TARGET_API` to `30` and `RECOMMENDED_TARGET_API` to `33`

### DIFF
--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -135,15 +135,15 @@ def read_ndk_version(ndk_dir):
     return ndk_version
 
 
-MIN_TARGET_API = 26
+MIN_TARGET_API = 30
 
 # highest version tested to work fine with SDL2
 # should be a good default for other bootstraps too
-RECOMMENDED_TARGET_API = 27
+RECOMMENDED_TARGET_API = 33
 
 ARMEABI_MAX_TARGET_API = 21
 OLD_API_MESSAGE = (
-    'Target APIs lower than 26 are no longer supported on Google Play, '
+    'Target APIs lower than 30 are no longer supported on Google Play, '
     'and are not recommended. Note that the Target API can be higher than '
     'your device Android version, and should usually be as high as possible.')
 

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -163,7 +163,7 @@ class TestRecommendations(unittest.TestCase):
         self.assertEqual(
             cm.output,
             [
-                "WARNING:p4a:[WARNING]: Target API 25 < 26",
+                "WARNING:p4a:[WARNING]: Target API 29 < 30",
                 "WARNING:p4a:[WARNING]: {old_api_msg}".format(
                     old_api_msg=OLD_API_MESSAGE
                 ),

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -74,7 +74,7 @@ class TestToolchainCL:
             'pythonforandroid.bootstraps.service_only.'
             'ServiceOnlyBootstrap.assemble_distribution'
         ) as m_run_distribute:
-            m_get_available_apis.return_value = [27]
+            m_get_available_apis.return_value = [33]
             tchain = ToolchainCL()
             assert tchain.ctx.activity_class_name == 'abc.myapp.android.CustomPythonActivity'
             assert tchain.ctx.service_class_name == 'xyz.myapp.android.CustomPythonService'


### PR DESCRIPTION
Google Play is enforcing to target a recent API, as it follows:

Android OS version | New app | Updated app ** | Existing app
-- | -- | -- | --
Android 13 (API level 33) | August 1, 2023 | November 1, 2023 | November 1, 2024
Android 12 (API level 31) | August 1, 2022 | November 1, 2022 | November 1, 2023
Android 11 (API level 30) | August 1, 2021 | November 1, 2021 | November 1, 2022

Name | Description
-- | --
New app | An app that is not yet published on Google Play (for example, a brand new app).
Updated app | A new version of an app that is already published on Google Play.
Existing app | A published app that is not receiving updates.

Further info: https://support.google.com/googleplay/android-developer/answer/11926878?hl=en

This PR bumps `MIN_TARGET_API` and `RECOMMENDED_TARGET_API` respectively to `30` and `33`, in order to comply with Google Play policy.

✅ Tested during runtime on top of current `develop` branch (with recent SDL2 changes https://github.com/kivy/python-for-android/pull/2673)