### PR TITLE
Add resources

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -91,6 +91,7 @@ options (this list may not be exhaustive):
 - ``--add-source``: Add a source directory to the app's Java code.
 - ``--no-compile-pyo``: Do not optimise .py files to .pyo.
 - ``--enable-androidx``: Enable AndroidX support library.
+- ``--add-resource``: Put this file or directory in the apk res directory.
 
 
 webview

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -347,7 +347,7 @@ main.py that loads it.''')
         shutil.copytree(res_dir_initial, res_dir)
     else:
         shutil.copytree(res_dir, res_dir_initial)
-    
+
     # Add user resouces
     for resource in args.resources:
         resource_src, resource_dest = resource.split(":")

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -341,8 +341,6 @@ main.py that loads it.''')
     # Prepare some variables for templating process
     res_dir = "src/main/res"
     # Add user resouces
-    shutil.rmtree(res_dir, ignore_errors=True)
-    ensure_dir(res_dir)
     for resource in args.resources:
         resource_src, resource_dest = resource.split(":")
         if isfile(realpath(resource_src)):

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -340,6 +340,14 @@ main.py that loads it.''')
 
     # Prepare some variables for templating process
     res_dir = "src/main/res"
+    res_dir_initial = "src/res_initial"
+    # make res_dir stateless
+    if exists(res_dir_initial):
+        shutil.rmtree(res_dir, ignore_errors=True)
+        shutil.copytree(res_dir_initial, res_dir)
+    else:
+        shutil.copytree(res_dir, res_dir_initial)
+    
     # Add user resouces
     for resource in args.resources:
         resource_src, resource_dest = resource.split(":")
@@ -347,7 +355,8 @@ main.py that loads it.''')
             ensure_dir(dirname(join(res_dir, resource_dest)))
             shutil.copy(realpath(resource_src), join(res_dir, resource_dest))
         else:
-            shutil.copytree(realpath(resource_src), join(res_dir, resource_dest))
+            shutil.copytree(realpath(resource_src),
+                            join(res_dir, resource_dest), dirs_exist_ok=True)
 
     default_icon = 'templates/kivy-icon.png'
     default_presplash = 'templates/kivy-presplash.jpg'

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -340,6 +340,17 @@ main.py that loads it.''')
 
     # Prepare some variables for templating process
     res_dir = "src/main/res"
+    # Add user resouces
+    shutil.rmtree(res_dir, ignore_errors=True)
+    ensure_dir(res_dir)
+    for resource in args.resources:
+        resource_src, resource_dest = resource.split(":")
+        if isfile(realpath(resource_src)):
+            ensure_dir(dirname(join(res_dir, resource_dest)))
+            shutil.copy(realpath(resource_src), join(res_dir, resource_dest))
+        else:
+            shutil.copytree(realpath(resource_src), join(res_dir, resource_dest))
+
     default_icon = 'templates/kivy-icon.png'
     default_presplash = 'templates/kivy-presplash.jpg'
     shutil.copy(
@@ -698,6 +709,10 @@ tools directory of the Android SDK.
                     action="append", default=[],
                     metavar="/path/to/source:dest",
                     help='Put this in the assets folder at assets/dest')
+    ap.add_argument('--resource', dest='resources',
+                    action="append", default=[],
+                    metavar="/path/to/source:kind/asset",
+                    help='Put this in the res folder at res/kind')
     ap.add_argument('--icon', dest='icon',
                     help=('A png file to use as the icon for '
                           'the application.'))

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1008,7 +1008,8 @@ class ToolchainCL:
             if ":" in resource:
                 resource_src, resource_dest = resource.split(":")
             else:
-                resource_src = resource_dest = resource
+                resource_src = resource
+                resource_dest = ""
             # take abspath now, because build.py will be run in bootstrap dir
             unknown_args += ["--resource", os.path.abspath(resource_src)+":"+resource_dest]
         for i, arg in enumerate(unknown_args):

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -513,6 +513,10 @@ class ToolchainCL:
             action="append", default=[],
             help='Put this in the assets folder in the apk.')
         parser_packaging.add_argument(
+            '--add-resource', dest='resources',
+            action="append", default=[],
+            help='Put this in the res folder in the apk.')
+        parser_packaging.add_argument(
             '--private', dest='private',
             help='the directory with the app source code files' +
                  ' (containing your main.py entrypoint)',
@@ -1000,6 +1004,13 @@ class ToolchainCL:
                 asset_src = asset_dest = asset
             # take abspath now, because build.py will be run in bootstrap dir
             unknown_args += ["--asset", os.path.abspath(asset_src)+":"+asset_dest]
+        for resource in args.resources:
+            if ":" in resource:
+                resource_src, resource_dest = resource.split(":")
+            else:
+                resource_src = resource_dest = resource
+            # take abspath now, because build.py will be run in bootstrap dir
+            unknown_args += ["--resource", os.path.abspath(resource_src)+":"+resource_dest]
         for i, arg in enumerate(unknown_args):
             argx = arg.split('=')
             if argx[0] in fix_args:


### PR DESCRIPTION
Why does adding Android resources have so many PRs but no implementation? Clearly users think it is a necessary feature. This is another try.

There are two outstanding PRs, https://github.com/kivy/python-for-android/pull/2580 and https://github.com/kivy/python-for-android/pull/2299. And a partial solution has previously been incorporated https://github.com/kivy/python-for-android/pull/2330, but is not documented in buildozer.spec and apparently doesn't work https://github.com/kivy/buildozer/issues/1508.

This PR is based on the observation that there is a simple hack for adding resources using `add_assets` and prefixing the second field with `../res/` like this 
```
android.add_assets = icons/all-inclusive.png:../res/drawable/all_inclusive.png
```

This implementation simply copies the add_assets code fragments, and changes 'asset' to 'resourse'. The associated Buildozer PR is https://github.com/kivy/buildozer/pull/1513

A test case is here https://github.com/RobertFlatt/add_resourse_test , this test sets a service icon (a custom service is created because setting the icon is not standard feature - but that is another issue). A drawable resource is declared using:
```
android.add_resources = icons/all-inclusive.png:drawable/all_inclusive.png
```
And the required resource ID is obtained with:
```
	    iconId = getResources().getIdentifier("all_inclusive",
						  "drawable",
						  getPackageName());
```

The test service is sticky, the app can be stopped but the service and its icon continue. So don't forget the stop the service at some point.
