### PR TITLE
build: add --android-target-sdk-version arg (defaults to android_api)

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -497,6 +497,12 @@ main.py that loads it.''')
         sdk_dir = fileh.read().strip()
     sdk_dir = sdk_dir[8:]
 
+    if args.android_target_sdk_version == -1:
+        args.android_target_sdk_version = android_api
+    if args.android_target_sdk_version != android_api:
+        print(f'WARNING: android_target_sdk_version ({args.android_target_sdk_version}) '
+              f'was set explicitly, and it does not match android_api ({android_api}).')
+
     # Try to build with the newest available build tools
     ignored = {".DS_Store", ".ds_store"}
     build_tools_versions = [x for x in listdir(join(sdk_dir, 'build-tools')) if x not in ignored]
@@ -805,6 +811,9 @@ tools directory of the Android SDK.
                     action='store_true',
                     help=('Allow the --minsdk argument to be different from '
                           'the discovered ndk_api in the dist'))
+    ap.add_argument('--android-target-sdk-version', dest='android_target_sdk_version',
+                    default=-1, type=int,
+                    help='targetSdkVersion to put in manifest. Matches android-api by default.')
     ap.add_argument('--intent-filters', dest='intent_filters',
                     help=('Add intent-filters xml rules to the '
                           'AndroidManifest.xml file. The argument is a '

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -33,7 +33,7 @@ android {
     buildToolsVersion '{{ build_tools_version }}'
     defaultConfig {
         minSdkVersion {{ args.min_sdk_version }}
-        targetSdkVersion {{ android_api }}
+        targetSdkVersion {{ args.android_target_sdk_version }}
         versionCode {{ args.numeric_version }}
         versionName '{{ args.version }}'
         manifestPlaceholders = {{ args.manifest_placeholders}}

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -19,7 +19,7 @@
     />
 
     <!-- Android 2.3.3 -->
-    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
+    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.android_target_sdk_version }}" />
 
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />

--- a/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
@@ -5,7 +5,7 @@
       android:versionName="{{ args.version }}">
 
     <!-- Android 2.3.3 -->
-    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
+    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.android_target_sdk_version }}" />
 
     <application {% if debug %}android:debuggable="true"{% endif %} >
         {% for name in service_names %}

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -16,7 +16,7 @@
     />
 
     <!-- Android 2.3.3 -->
-    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
+    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.android_target_sdk_version }}" />
 
     <!-- Set permissions -->
     {% for perm in args.permissions %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -16,7 +16,7 @@
     />
 
     <!-- Android 2.3.3 -->
-    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
+    <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ args.android_target_sdk_version }}" />
 
     <!-- Allow writing to external storage -->
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Currently p4a has a variable named `android_api` (set by e.g. buildozer via the `app.android.api` config key). In `AndroidManifest.xml`, both `compileSdkVersion` and `targetSdkVersion` are set to `android_api`.

This PR allows setting the targetSdkVersion and compileSdkVersion independently, by adding a `--android-target-sdk-version` build arg.

`compileSdkVersion` is a compilation setting used by e.g. the NDK at build-time, while `targetSdkVersion` is just a field to set in the manifest, only used at runtime (mainly in the Java world). (see e.g. https://stackoverflow.com/a/26694276 )

-----

note: my current use case is to set `targetSdkVersion` to higher than `compileSdkVersion`, as I am using an older NDK (r22b) that only supports `compileSdkVersion<=30`, but the google play store now requires `targetSdkVersion>=31`. Historically it has sometimes been the case that p4a was using an old NDK, and I had to use this trick once already a few years ago, for the same reason _(but atm p4a is using a very new NDK, I am just having troubles rebasing my fork)_. Regardless, I believe setting the two parameters independently might have other use cases.