### PR TITLE
Bump to a version of `SDL` with patches for the TextInput / TextEditing (SDL `2.26.0`)

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
+++ b/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/org/libsdl/app/SDLActivity.java
 +++ b/src/main/java/org/libsdl/app/SDLActivity.java
-@@ -225,6 +225,8 @@
+@@ -222,6 +222,8 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
      // This is what SDL runs in. It invokes SDL_main(), eventually
      protected static Thread mSDLThread;
  
@@ -9,7 +9,7 @@
      protected static SDLGenericMotionListener_API12 getMotionListener() {
          if (mMotionListener == null) {
              if (Build.VERSION.SDK_INT >= 26) {
-@@ -323,6 +325,15 @@
+@@ -324,6 +326,15 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
          Log.v(TAG, "onCreate()");
          super.onCreate(savedInstanceState);
  
@@ -25,7 +25,7 @@
          try {
              Thread.currentThread().setName("SDLActivity");
          } catch (Exception e) {
-@@ -824,7 +835,7 @@
+@@ -835,7 +846,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
      Handler commandHandler = new SDLCommandHandler();
  
      // Send a message from the SDLMain thread
@@ -34,11 +34,11 @@
          Message msg = commandHandler.obtainMessage();
          msg.arg1 = command;
          msg.obj = data;
-@@ -1302,6 +1313,20 @@
+@@ -1384,6 +1395,20 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
          return SDLActivity.mSurface.getNativeSurface();
      }
  
-+     /**
++      /**
 +      * Calls turnActive() on singleton to keep loading screen active
 +      */
 +     public static void triggerAppConfirmedActive() {
@@ -55,21 +55,21 @@
      // Input
  
      /**
-@@ -1795,7 +1820,7 @@
-         }
+@@ -1878,6 +1903,7 @@ class SDLMain implements Runnable {
  
          Log.v("SDL", "Running main function " + function + " from library " + library);
--
+ 
 +        SDLActivity.mSingleton.appConfirmedActive();
          SDLActivity.nativeRunMain(library, function, arguments);
  
          Log.v("SDL", "Finished main function");
-@@ -2316,7 +2341,7 @@
+@@ -1935,8 +1961,7 @@ class DummyEdit extends View implements View.OnKeyListener {
      public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
          ic = new SDLInputConnection(this, true);
  
--        outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
-+        outAttrs.inputType = SDLActivity.keyboardInputType;
-         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
-                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
+-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT |
+-                             InputType.TYPE_TEXT_FLAG_MULTI_LINE;
++        outAttrs.inputType = SDLActivity.keyboardInputType | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI |
+                               EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
  

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -6,15 +6,13 @@ import sh
 
 
 class LibSDL2Recipe(BootstrapNDKRecipe):
-    # version = "2.24.0"
-    # url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.tar.gz"
-    # md5sum = 'cf539ffe9e0dd6f943ac9de75fd2e56e'
-
-    # This hash refers to a post 2.24.0 commit, which fixes a bug in the Android
-    # TextInput / IME
-    url = "https://github.com/libsdl-org/SDL/archive/a905a7869f18332579ff06ba3f7f3777708a3007.zip"
+    version = "2.26.0"
+    url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.tar.gz"
+    md5sum = '35bc58cfe41b8fb6c8e6646be26fa47e'
 
     dir_name = 'SDL'
+
+    patches = ['remove-extra-include.patch']
 
     depends = ['sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
 

--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -6,9 +6,13 @@ import sh
 
 
 class LibSDL2Recipe(BootstrapNDKRecipe):
-    version = "2.24.0"
-    url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.tar.gz"
-    md5sum = 'cf539ffe9e0dd6f943ac9de75fd2e56e'
+    # version = "2.24.0"
+    # url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.tar.gz"
+    # md5sum = 'cf539ffe9e0dd6f943ac9de75fd2e56e'
+
+    # This hash refers to a post 2.24.0 commit, which fixes a bug in the Android
+    # TextInput / IME
+    url = "https://github.com/libsdl-org/SDL/archive/a905a7869f18332579ff06ba3f7f3777708a3007.zip"
 
     dir_name = 'SDL'
 

--- a/pythonforandroid/recipes/sdl2/remove-extra-include.patch
+++ b/pythonforandroid/recipes/sdl2/remove-extra-include.patch
@@ -1,0 +1,12 @@
+diff -Naur SDL.orig/Android.mk SDL/Android.mk
+--- SDL.orig/Android.mk	2022-11-22 07:41:32
++++ SDL/Android.mk	2022-11-22 07:42:00
+@@ -12,7 +12,7 @@
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
+ 
+-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)/include
++LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
+ 
+ LOCAL_SRC_FILES := \
+ 	$(subst $(LOCAL_PATH)/,, \


### PR DESCRIPTION
This is a WIP PR meant for testing a pre-release SDL feature that should fix the following issues:
- https://github.com/kivy/python-for-android/issues/2010
- https://github.com/kivy/kivy/issues/7337

Edit:
SDL `2.26.0` has been released, and even if it needs a small patch during build-time, works great!
The SDL team said that `2.26.1` (which doesn't need `remove-extra-include.patch` anymore) is expected to be released in a month.

But, considering that we're not targeting anymore a pre-release version, this PR could be considered ready to merge.

