### PR TITLE
Fixes an issue regarding blacklist and bytecode compile + some cleanup

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -89,7 +89,7 @@ options (this list may not be exhaustive):
 - ``--service``: A service name and the Python script it should
   run. See :ref:`arbitrary_scripts_services`.
 - ``--add-source``: Add a source directory to the app's Java code.
-- ``--no-compile-pyo``: Do not optimise .py files to .pyo.
+- ``--no-byte-compile-python``: Skip byte compile for .py files.
 - ``--enable-androidx``: Enable AndroidX support library.
 
 

--- a/doc/source/launcher.rst
+++ b/doc/source/launcher.rst
@@ -48,7 +48,7 @@ grab an old (cached) package instead of a fresh one.
 .. warning::
 
     Do not use any of `--private`, `--public`, `--dir` or other arguments for
-    adding `main.py` or `main.pyo` to the app. The argument `--launcher` is
+    adding `main.py` or `main.pyc` to the app. The argument `--launcher` is
     above them and tells the p4a to build the launcher version of the APK.
 
 Usage

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -108,7 +108,7 @@ class Bdist(Command):
                     makedirs(new_dir)
                 print('Including {}'.format(filen))
                 copyfile(filen, join(bdist_dir, filen))
-                if basename(filen) in ('main.py', 'main.pyo'):
+                if basename(filen) in ('main.py', 'main.pyc'):
                     main_py_dirs.append(filen)
 
         # This feels ridiculous, but how else to define the main.py dir?

--- a/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
+++ b/pythonforandroid/bootstraps/common/build/jni/application/src/start.c
@@ -251,14 +251,10 @@ int main(int argc, char *argv[]) {
    */
   LOGP("Run user program, change dir and execute entrypoint");
 
-  /* Get the entrypoint, search the .pyo then .py
+  /* Get the entrypoint, search the .pyc then .py
    */
   char *dot = strrchr(env_entrypoint, '.');
-#if PY_MAJOR_VERSION > 2
   char *ext = ".pyc";
-#else
-  char *ext = ".pyo";
-#endif
   if (dot <= 0) {
     LOGP("Invalid entrypoint, abort.");
     return -1;
@@ -281,14 +277,10 @@ int main(int argc, char *argv[]) {
       strcpy(entrypoint, env_entrypoint);
     }
   } else if (!strcmp(dot, ".py")) {
-    /* if .py is passed, check the pyo version first */
+    /* if .py is passed, check the pyc version first */
     strcpy(entrypoint, env_entrypoint);
     entrypoint[strlen(env_entrypoint) + 1] = '\0';
-#if PY_MAJOR_VERSION > 2
     entrypoint[strlen(env_entrypoint)] = 'c';
-#else
-    entrypoint[strlen(env_entrypoint)] = 'o';
-#endif
     if (!file_exists(entrypoint)) {
       /* fallback on pure python version */
       if (!file_exists(env_entrypoint)) {

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -419,11 +419,10 @@ public class PythonActivity extends SDLActivity {
     }
 
     public String getEntryPoint(String search_dir) {
-        /* Get the main file (.pyc|.pyo|.py) depending on if we
+        /* Get the main file (.pyc|.py) depending on if we
          * have a compiled version or not.
         */
         List<String> entryPoints = new ArrayList<String>();
-        entryPoints.add("main.pyo");  // python 2 compiled files
         entryPoints.add("main.pyc");  // python 3 compiled files
 		for (String value : entryPoints) {
             File mainFile = new File(search_dir + "/" + value);

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -46,11 +46,10 @@ public class PythonActivity extends Activity {
     }
 
     public String getEntryPoint(String search_dir) {
-        /* Get the main file (.pyc|.pyo|.py) depending on if we
+        /* Get the main file (.pyc|.py) depending on if we
          * have a compiled version or not.
         */
         List<String> entryPoints = new ArrayList<String>();
-        entryPoints.add("main.pyo");  // python 2 compiled files
         entryPoints.add("main.pyc");  // python 3 compiled files
 		for (String value : entryPoints) {
             File mainFile = new File(search_dir + "/" + value);

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -68,11 +68,10 @@ public class PythonActivity extends Activity {
     }
 
     public String getEntryPoint(String search_dir) {
-        /* Get the main file (.pyc|.pyo|.py) depending on if we
+        /* Get the main file (.pyc|.py) depending on if we
          * have a compiled version or not.
         */
         List<String> entryPoints = new ArrayList<String>();
-        entryPoints.add("main.pyo");  // python 2 compiled files
         entryPoints.add("main.pyc");  // python 3 compiled files
         for (String value : entryPoints) {
             File mainFile = new File(search_dir + "/" + value);

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -456,7 +456,6 @@ class Context:
         return (exists(join(site_packages_dir, name)) or
                 exists(join(site_packages_dir, name + '.py')) or
                 exists(join(site_packages_dir, name + '.pyc')) or
-                exists(join(site_packages_dir, name + '.pyo')) or
                 exists(join(site_packages_dir, name + '.so')) or
                 glob.glob(join(site_packages_dir, name + '-*.egg')))
 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -364,11 +364,11 @@ class Python3Recipe(TargetPythonRecipe):
                 self.major_minor_version_string
             ))
 
-        # Compile to *.pyc/*.pyo the python modules
+        # Compile to *.pyc the python modules
         self.compile_python_files(modules_build_dir)
-        # Compile to *.pyc/*.pyo the standard python library
+        # Compile to *.pyc the standard python library
         self.compile_python_files(join(self.get_build_dir(arch.arch), 'Lib'))
-        # Compile to *.pyc/*.pyo the other python packages (site-packages)
+        # Compile to *.pyc the other python packages (site-packages)
         self.compile_python_files(self.ctx.get_python_install_dir(arch.arch))
 
         # Bundle compiled python modules to a folder


### PR DESCRIPTION
When building an app via `python-for-android` (without using `buildozer` on top of it), the app may fail to build.

`python-for-android` refuses to build due to a python file that is located in a blacklisted folder (via `blacklist.txt`) as that file is failing the byte-compile step.

That should not happen, as a blacklisted folder (E.g. `venv` or `.git`) may contain a python file that can't be byte-compiled.
Also, byte-compiling a blacklisted folder may lead to an increase of the build time.

This PR targets the above-mentioned issue, and the following minor ones:
- **As of Python 3.5, the `.pyo` filename extension is no longer used and has been removed in favour of extension `.pyc`**
All the references to `pyo` has been removed. `--no-compile-pyo` build option has been removed in favor of `--no-byte-compile-python`, which doesn't refer to a specific filename extension.
- `.apk` and `.aab` are not blacklisted by default. The first ever build will work, but the subsequent one will try to also include the `.apk` or `.aab` into the artifact. That will lead to an increase in size and a potential failure during the final gradle step.
