### PR TITLE
WRITE_EXTERNAL_STORAGE maxSdk

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -25,7 +25,7 @@
     <uses-feature android:glEsVersion="0x00020000" />
 
     <!-- Allow writing to external storage -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
     {% for perm in args.permissions %}
     {% if '.' in perm %}
     <uses-permission android:name="{{ perm }}" />


### PR DESCRIPTION
On Android 11 / sdk 30 WRITE_EXTERNAL_STORAGE no longer has any meaning. 

Ref: https://developer.android.com/about/versions/11/privacy/storage#permissions-target-11

This PR removed a Gradle warning message.
