### PR TITLE
Include paths for sdl2_mixer have changed. Added a method to return the right one.

### DIFF
--- a/pythonforandroid/recipes/audiostream/__init__.py
+++ b/pythonforandroid/recipes/audiostream/__init__.py
@@ -17,14 +17,18 @@ class AudiostreamRecipe(CythonRecipe):
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)
         sdl_include = 'SDL2'
-        sdl_mixer_include = 'SDL2_mixer'
+
         env['USE_SDL2'] = 'True'
         env['SDL2_INCLUDE_DIR'] = join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include')
 
-        env['CFLAGS'] += ' -I{jni_path}/{sdl_include}/include -I{jni_path}/{sdl_mixer_include}'.format(
+        env['CFLAGS'] += ' -I{jni_path}/{sdl_include}/include'.format(
                               jni_path=join(self.ctx.bootstrap.build_dir, 'jni'),
-                              sdl_include=sdl_include,
-                              sdl_mixer_include=sdl_mixer_include)
+                              sdl_include=sdl_include)
+
+        sdl2_mixer_recipe = self.get_recipe('sdl2_mixer', self.ctx)
+        for include_dir in sdl2_mixer_recipe.get_include_dirs(arch):
+            env['CFLAGS'] += ' -I{include_dir}'.format(include_dir=include_dir)
+
         # NDKPLATFORM is our switch for detecting Android platform, so can't be None
         env['NDKPLATFORM'] = "NOTNONE"
         env['LIBLINK'] = 'NOTNONE'  # Hacky fix. Needed by audiostream setup.py

--- a/pythonforandroid/recipes/ffpyplayer/__init__.py
+++ b/pythonforandroid/recipes/ffpyplayer/__init__.py
@@ -20,7 +20,11 @@ class FFPyPlayerRecipe(CythonRecipe):
         env["SDL_LIB_DIR"] = join(self.ctx.bootstrap.build_dir, 'libs', arch.arch)
 
         env["USE_SDL2_MIXER"] = '1'
-        env["SDL2_MIXER_INCLUDE_DIR"] = join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer')
+
+        # ffpyplayer does not allow to pass more than one include dir for sdl2_mixer (and ATM is
+        # not needed), so we only pass the first one.
+        sdl2_mixer_recipe = self.get_recipe('sdl2_mixer', self.ctx)
+        env["SDL2_MIXER_INCLUDE_DIR"] = sdl2_mixer_recipe.get_include_dirs(arch)[0]
 
         # NDKPLATFORM and LIBLINK are our switches for detecting Android platform, so can't be empty
         # FIXME: We may want to introduce a cleaner approach to this?

--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -65,10 +65,11 @@ class KivyRecipe(CythonRecipe):
         if 'sdl2' in self.ctx.recipe_build_order:
             env['USE_SDL2'] = '1'
             env['KIVY_SPLIT_EXAMPLES'] = '1'
+            sdl2_mixer_recipe = self.get_recipe('sdl2_mixer', self.ctx)
             env['KIVY_SDL2_PATH'] = ':'.join([
                 join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include'),
                 join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_image'),
-                join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer', 'include'),
+                *sdl2_mixer_recipe.get_include_dirs(arch),
                 join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
             ])
 

--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -37,6 +37,11 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
             jpeg = self.get_recipe('jpeg', self.ctx)
             jpeg_inc_dir = jpeg_lib_dir = jpeg.get_build_dir(arch.arch)
 
+            sdl_mixer_includes = ""
+            sdl2_mixer_recipe = self.get_recipe('sdl2_mixer', self.ctx)
+            for include_dir in sdl2_mixer_recipe.get_include_dirs(arch):
+                sdl_mixer_includes += f"-I{include_dir} "
+
             setup_file = setup_template.format(
                 sdl_includes=(
                     " -I" + join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include') +
@@ -44,7 +49,7 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
                     " -L" + png_lib_dir + " -L" + jpeg_lib_dir + " -L" + arch.ndk_lib_dir_versioned),
                 sdl_ttf_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
                 sdl_image_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_image'),
-                sdl_mixer_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer'),
+                sdl_mixer_includes=sdl_mixer_includes,
                 jpeg_includes="-I"+jpeg_inc_dir,
                 png_includes="-I"+png_inc_dir,
                 freetype_includes=""

--- a/pythonforandroid/recipes/sdl2_mixer/__init__.py
+++ b/pythonforandroid/recipes/sdl2_mixer/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from pythonforandroid.recipe import BootstrapNDKRecipe
 
 
@@ -5,6 +7,11 @@ class LibSDL2Mixer(BootstrapNDKRecipe):
     version = '2.6.2'
     url = 'https://github.com/libsdl-org/SDL_mixer/releases/download/release-{version}/SDL2_mixer-{version}.tar.gz'
     dir_name = 'SDL2_mixer'
+
+    def get_include_dirs(self, arch):
+        return [
+            os.path.join(self.ctx.bootstrap.build_dir, "jni", "SDL2_mixer", "include")
+        ]
 
 
 recipe = LibSDL2Mixer()

--- a/tests/recipes/test_sdl2_mixer.py
+++ b/tests/recipes/test_sdl2_mixer.py
@@ -1,0 +1,14 @@
+import unittest
+from tests.recipes.recipe_lib_test import RecipeCtx
+
+
+class TestSDL2MixerRecipe(RecipeCtx, unittest.TestCase):
+    """
+    An unittest for recipe :mod:`~pythonforandroid.recipes.sdl2_mixer`
+    """
+    recipe_name = "sdl2_mixer"
+
+    def test_get_include_dirs(self):
+        list_of_includes = self.recipe.get_include_dirs(self.arch)
+        self.assertIsInstance(list_of_includes, list)
+        self.assertTrue(list_of_includes[0].endswith("include"))


### PR DESCRIPTION
Fixes issue: https://github.com/kivy/python-for-android/issues/2698

Include paths for `sdl2_mixer` changed recently, so recipes (like `ffpyplayer`) that were using a hardcoded path are failing to build.

- Added a `get_include_dirs` method (like the one we have in `libffi`), for `sdl2_mixer`.
- Replaced any hardcoded path with the new `get_include_dirs` method.
- Added a (very) minimal test to check the new method.