### PR TITLE
Gradle: Run the clean task before anything else to make sure nothing is cached.

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1108,7 +1108,10 @@ class ToolchainCL:
             else:
                 raise BuildInterruptingException(
                     "Unknown build mode {} for apk()".format(args.build_mode))
-            output = shprint(gradlew, gradle_task, _tail=20,
+
+            # WARNING: We should make sure to clean the build directory before building.
+            # Looks like our private.tar is causing issues to gradle.
+            output = shprint(gradlew, "clean", gradle_task, _tail=20,
                              _critical=True, _env=env)
         return output, build_args
 

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -1110,7 +1110,7 @@ class ToolchainCL:
                     "Unknown build mode {} for apk()".format(args.build_mode))
 
             # WARNING: We should make sure to clean the build directory before building.
-            # Looks like our private.tar is causing issues to gradle.
+            # See PR: kivy/python-for-android#2705
             output = shprint(gradlew, "clean", gradle_task, _tail=20,
                              _critical=True, _env=env)
         return output, build_args


### PR DESCRIPTION
Headache time 🤕⏱️!

As clearly described by @DexerBR in #2704 :
> The app size grows unexpectedly from 18.5MB to 26.4MB in the second build. From the second to next builds, the sudden size changes seem to stabilize.

For a still unknown(likely a Gradle bug) reason, the produced `APK` is bigger on non-first builds.
After some analysis (unpacked the APK, checked and compared the content), I can say that only the size of the APK itself is different, not the content, as when it gets unzipped, the size of the unzipped content is the same between the first build and subsequent ones.

The files md5 hashes are the same, except for the `assets/private.tar` file (and its content), as I'm not building with `SOURCE_DATE_EPOCH` set, which means that [compileall](https://docs.python.org/3/library/compileall.html#cmdoption-compileall-invalidation-mode) uses the `timestamp` as the invalidation mode, making the build non-reproducible.

That's where the 💡 toggled on.

What's the size of my `assets/private.tar`? `17MB`
What's the APK size difference between the first and subsequent builds? `17MB`
Ouch! 😓

For some reason, Gradle creates a bigger APK, which is able to contain all the assets and code + 2x `private.tar` (the old one, and the new one), but then only packages into it the newer one.

I will try to investigate it on Gradle (and Android Gradle Plugin) codebase, but meanwhile, cleaning the build folder (via `./gradlew clean *****`) avoids any caching and ensures a clean build, every time, and doesn't seem to take any considerable amount of time.

EDIT:
Found a discussion on Google Issue Tracker about something similar: https://issuetracker.google.com/issues/172762362
> If an entry has been deleted in the middle of the archive, Zipflinger will not leave a “hole” there. This is done in order to be compatible with top-down parsers such as jarsigner or the JDK zip classes. To this effect, Zipflinger fills empty space with virtual entries (a.k.a a Local File Header with no name, up to 64KiB extra and no Central Directory entry). Alignment is also done via “extra field”.
