### PR TITLE
Flake8 does not support inline comments for any of the keys.

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -631,7 +631,7 @@ class Recipe(metaclass=RecipeMeta):
         shprint(sh.cp, *args)
 
     def has_libs(self, arch, *libs):
-        return all(map(lambda l: self.ctx.has_lib(arch.arch, l), libs))
+        return all(map(lambda lib: self.ctx.has_lib(arch.arch, lib), libs))
 
     def get_libraries(self, arch_name, in_context=False):
         """Return the full path of the library depending on the architecture.

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,19 @@ commands = flake8 pythonforandroid/ tests/ ci/ setup.py
 
 [flake8]
 ignore =
-    E123,  # Closing bracket does not match indentation of opening bracket's line
-    E124,  # Closing bracket does not match visual indentation
-    E126,  # Continuation line over-indented for hanging indent
-    E226,  # Missing whitespace around arithmetic operator
-    E402,  # Module level import not at top of file
-    E501,  # Line too long (82 > 79 characters)
-    W503,  # Line break occurred before a binary operator
-    W504   # Line break occurred after a binary operator
+    # Closing bracket does not match indentation of opening bracket's line
+    E123,
+    # Closing bracket does not match visual indentation
+    E124,
+    # Continuation line over-indented for hanging indent
+    E126,
+    # Missing whitespace around arithmetic operator
+    E226,
+    # Module level import not at top of file
+    E402,
+    # Line too long (82 > 79 characters)
+    E501,
+    # Line break occurred before a binary operator
+    W503,
+    # Line break occurred after a binary operator
+    W504


### PR DESCRIPTION
See:
- https://github.com/PyCQA/flake8/issues/1760

From https://flake8.pycqa.org/en/latest/user/configuration.html :
> Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
```
[flake8]
per-file-ignores =
    # imported but unused
    __init__.py: F401
```
> this is not:
```
[flake8]
per-file-ignores =
    __init__.py: F401 # imported but unused
```