### PR TITLE
secp256k1 Update "--host="

### DIFF
--- a/pythonforandroid/recipes/secp256k1/cross_compile.patch
+++ b/pythonforandroid/recipes/secp256k1/cross_compile.patch
@@ -6,7 +6,7 @@ index bba4bce..b86b369 100644
              "--disable-dependency-tracking",
              "--with-pic",
              "--enable-module-recovery",
-+            "--host=%s" % os.environ['TOOLCHAIN_PREFIX'],
++            "--host=" + arch.command_prefix,
              "--prefix",
              os.path.abspath(self.build_clib),
          ]


### PR DESCRIPTION
Fix recipe that doesn't build without setting an environment variable.
"--host=" is now implemented in the same manner as other recipes. 