### PR TITLE
`InputType.TYPE_TEXT_FLAG_MULTI_LINE` forces `InputType.TYPE_TEXT` even if `SDLActivity.keyboardInputType` is `NULL`

### DIFF
--- a/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
+++ b/pythonforandroid/bootstraps/sdl2/build/src/patches/SDLActivity.java.patch
@@ -69,7 +69,7 @@
  
 -        outAttrs.inputType = InputType.TYPE_CLASS_TEXT |
 -                             InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-+        outAttrs.inputType = SDLActivity.keyboardInputType | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
++        outAttrs.inputType = SDLActivity.keyboardInputType;
          outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI |
                                EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
  


### PR DESCRIPTION
Unfortunately (and I'm creating a detailed report for us and the SDL team), suggestions from Android keyboards are still not completely usable. 😔

A logic, that mimics every possible scenario should be implemented on our side or on SDL's side if we decide to keep using input from SDL on mobile devices (which still makes sense ATM).

In one of the recents SDL updates, `InputType.TYPE_TEXT_FLAG_MULTI_LINE` has been or-ed with the InputType.

That is preventing `InputType.TYPE_NULL` (which is the default on `kivy/kivy==master`) to work, as `InputType.TYPE_TEXT_FLAG_MULTI_LINE` forces `InputType.TYPE_TEXT` even if `SDLActivity.keyboardInputType` is `InputType.TYPE_NULL`.

If needed `InputType.TYPE_TEXT_FLAG_MULTI_LINE` should be moved on our InputType selection logic in `kivy/kivy`.

See: https://github.com/kivy/kivy/pull/7744 for further details.