### PR TITLE
Support permission properties (`maxSdkVersion` and `usesPermissionFlags`) + remove `WRITE_EXTERNAL_STORAGE` permission, which has been previously declared by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ testapps-with-numpy: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py apk --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
     --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,urllib3,chardet,idna,sqlite3,setuptools,numpy \
-    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86
+    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86 \
+	--permission "(name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)" --permission "(name=android.permission.INTERNET)"
 
 testapps-with-scipy: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
@@ -53,7 +54,8 @@ testapps-with-numpy-aab: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \
     python setup.py aab --sdk-dir $(ANDROID_SDK_HOME) --ndk-dir $(ANDROID_NDK_HOME) \
     --requirements libffi,sdl2,pyjnius,kivy,python3,openssl,requests,urllib3,chardet,idna,sqlite3,setuptools,numpy \
-    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86 --release
+    --arch=armeabi-v7a --arch=arm64-v8a --arch=x86_64 --arch=x86 --release \
+	--permission "(name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)" --permission "(name=android.permission.INTERNET)"
 
 testapps-service_library-aar: virtualenv
 	. $(ACTIVATE) && cd testapps/on_device_unit_tests/ && \

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -64,9 +64,24 @@ options (this list may not be exhaustive):
   ``android:screenOrientation`` in the `Android documentation
   <https://developer.android.com/guide/topics/manifest/activity-element.html>`__.
 - ``--icon``: A path to the png file to use as the application icon.
-- ``--permission``: A permission name for the app,
-  e.g. ``--permission VIBRATE``. For multiple permissions, add
-  multiple ``--permission`` arguments.
+- ``--permission``: A permission that needs to be declared into the App ``AndroidManifest.xml``.
+  For multiple permissions, add multiple ``--permission`` arguments.
+
+  .. Note ::
+    ``--permission`` accepts the following syntaxes: 
+    ``--permission (name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)``
+    or ``--permission android.permission.WRITE_EXTERNAL_STORAGE``.
+
+    The first syntax is used to set additional properties to the permission 
+    (``android:maxSdkVersion`` and ``android:usesPermissionFlags`` are the only ones supported for now).
+
+    The second one can be used when there's no need to add any additional properties.
+
+  .. Warning ::
+    The syntax ``--permission VIBRATE`` (only the permission name, without the prefix),
+    is also supported for backward compatibility, but it will be removed in the future.
+
+
 - ``--meta-data``: Custom key=value pairs to add in the application metadata.
 - ``--presplash``: A path to the image file to use as a screen while
   the application is loading.

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -24,14 +24,9 @@
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />
 
-    <!-- Allow writing to external storage -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
+    <!-- Set permissions -->
     {% for perm in args.permissions %}
-    {% if '.' in perm %}
-    <uses-permission android:name="{{ perm }}" />
-    {% else %}
-    <uses-permission android:name="android.permission.{{ perm }}" />
-    {% endif %}
+        <uses-permission android:name="{{ perm.name }}"{% if perm.maxSdkVersion %} android:maxSdkVersion="{{ perm.maxSdkVersion }}"{% endif %}{% if perm.usesPermissionFlags %} android:usesPermissionFlags="{{ perm.usesPermissionFlags }}"{% endif %} />
     {% endfor %}
 
     {% if args.wakelock %}

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -20,11 +20,7 @@
 
     <!-- Set permissions -->
     {% for perm in args.permissions %}
-    {% if '.' in perm %}
-    <uses-permission android:name="{{ perm }}" />
-    {% else %}
-    <uses-permission android:name="android.permission.{{ perm }}" />
-    {% endif %}
+        <uses-permission android:name="{{ perm.name }}"{% if perm.maxSdkVersion %} android:maxSdkVersion="{{ perm.maxSdkVersion }}"{% endif %}{% if perm.usesPermissionFlags %} android:usesPermissionFlags="{{ perm.usesPermissionFlags }}"{% endif %} />
     {% endfor %}
 
     {% if args.wakelock %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -21,11 +21,7 @@
     <!-- Allow writing to external storage -->
     <uses-permission android:name="android.permission.INTERNET" />
     {% for perm in args.permissions %}
-    {% if '.' in perm %}
-    <uses-permission android:name="{{ perm }}" />
-    {% else %}
-    <uses-permission android:name="android.permission.{{ perm }}" />
-    {% endif %}
+        <uses-permission android:name="{{ perm.name }}"{% if perm.maxSdkVersion %} android:maxSdkVersion="{{ perm.maxSdkVersion }}"{% endif %}{% if perm.usesPermissionFlags %} android:usesPermissionFlags="{{ perm.usesPermissionFlags }}"{% endif %} />
     {% endfor %}
 
     {% if args.wakelock %}

--- a/tests/test_bootstrap_build.py
+++ b/tests/test_bootstrap_build.py
@@ -1,0 +1,86 @@
+import unittest
+import os
+import argparse
+
+from pythonforandroid.util import load_source
+
+
+class TestParsePermissions(unittest.TestCase):
+    def test_parse_permissions_with_migrations(self):
+        # Test that permissions declared in the old format are migrated to the
+        # new format.
+        # (Users can new declare permissions in both formats, even a mix)
+        os.environ["P4A_BUILD_IS_RUNNING_UNITTESTS"] = "1"
+
+        ap = argparse.ArgumentParser()
+        ap.add_argument(
+            "--permission",
+            dest="permissions",
+            action="append",
+            default=[],
+            help="The permissions to give this app.",
+            nargs="+",
+        )
+
+        args = [
+            "--permission",
+            "INTERNET",
+            "--permission",
+            "com.android.voicemail.permission.ADD_VOICEMAIL",
+            "--permission",
+            "(name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)",
+            "--permission",
+            "(name=android.permission.BLUETOOTH_SCAN;usesPermissionFlags=neverForLocation)",
+        ]
+
+        args = ap.parse_args(args)
+
+        build_src = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../pythonforandroid/bootstraps/common/build/build.py",
+        )
+
+        buildpy = load_source("buildpy", build_src)
+        parsed_permissions = buildpy.parse_permissions(args.permissions)
+
+        assert parsed_permissions == [
+            dict(name="android.permission.INTERNET"),
+            dict(name="com.android.voicemail.permission.ADD_VOICEMAIL"),
+            dict(name="android.permission.WRITE_EXTERNAL_STORAGE", maxSdkVersion="18"),
+            dict(
+                name="android.permission.BLUETOOTH_SCAN",
+                usesPermissionFlags="neverForLocation",
+            ),
+        ]
+
+    def test_parse_permissions_invalid_property(self):
+        os.environ["P4A_BUILD_IS_RUNNING_UNITTESTS"] = "1"
+
+        ap = argparse.ArgumentParser()
+        ap.add_argument(
+            "--permission",
+            dest="permissions",
+            action="append",
+            default=[],
+            help="The permissions to give this app.",
+            nargs="+",
+        )
+
+        args = [
+            "--permission",
+            "(name=android.permission.BLUETOOTH_SCAN;propertyThatFails=neverForLocation)",
+        ]
+
+        args = ap.parse_args(args)
+
+        build_src = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../pythonforandroid/bootstraps/common/build/build.py",
+        )
+
+        buildpy = load_source("buildpy", build_src)
+
+        try:
+            parsed_permissions = buildpy.parse_permissions(args.permissions)  # noqa: F841
+        except ValueError as _e:
+            assert "Property 'propertyThatFails' is not supported." in str(_e)

--- a/tests/test_bootstrap_build.py
+++ b/tests/test_bootstrap_build.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import os
 import argparse
 
@@ -80,7 +81,7 @@ class TestParsePermissions(unittest.TestCase):
 
         buildpy = load_source("buildpy", build_src)
 
-        try:
-            parsed_permissions = buildpy.parse_permissions(args.permissions)  # noqa: F841
-        except ValueError as _e:
-            assert "Property 'propertyThatFails' is not supported." in str(_e)
+        with pytest.raises(
+            ValueError, match="Property 'propertyThatFails' is not supported."
+        ):
+            buildpy.parse_permissions(args.permissions)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -64,7 +64,10 @@ class TestTemplates(unittest.TestCase):
         args.min_sdk_version = 12
         args.build_mode = 'debug'
         args.native_services = ['abcd', ]
-        args.permissions = []
+        args.permissions = [
+            dict(name="android.permission.INTERNET"),
+            dict(name="android.permission.WRITE_EXTERNAL_STORAGE", maxSdkVersion=18),
+            dict(name="android.permission.BLUETOOTH_SCAN", usesPermissionFlags="neverForLocation")]
         args.add_activity = []
         args.android_used_libs = []
         args.meta_data = []
@@ -91,6 +94,9 @@ class TestTemplates(unittest.TestCase):
         assert xml.count('targetSdkVersion="1234"') == 1
         assert xml.count('android:debuggable="true"') == 1
         assert xml.count('<service android:name="abcd" />') == 1
+        assert xml.count('<uses-permission android:name="android.permission.INTERNET" />') == 1
+        assert xml.count('<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />') == 1
+        assert xml.count('<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />') == 1
         # TODO: potentially some other checks to be added here to cover other "logic" (flags and loops) in the template
 
 


### PR DESCRIPTION
The `--permission` argument historically only accepted something like `--permission android.permission.WRITE_EXTERNAL_STORAGE` and `--permission VIBRATE` which is not enough in certain use cases.

As an example, when dealing with bluetooth permissions and targeting API 31, the legacy `android.permission.BLUETOOTH` and `android.permission.BLUETOOTH_ADMIN` permissions need the property `android:maxSdkVersion` be set to `30`, and 
the `"android.permission.BLUETOOTH_SCAN` needs to strongly assert that the app never derives physical location from Bluetooth scan results via `android:usesPermissionFlags="neverForLocation"`.

Basically, nowadays, android permissions declarations need a lot of fine-tuning, which is not possible at this time via `python-for-android`, unless an extra manifest is used.

This PR introduces a new syntax: `--permission (name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)` that allows the user to set every single (and currently available/supported) property of the `<uses-permission>` element.

The old syntaxes are migrated before the template gets processed, so users will only notice this change when needed, and when reading the docs.

I also started to add some tests for our `build.py` script. I needed to add a switch to skip some things as ATM are not patchable (at least easily). The whole script needs some refactoring in order to be well-tested.