### PR TITLE
Apply a patch from SDL upstream that fixes orientation settings

### DIFF
--- a/pythonforandroid/recipes/sdl2/__init__.py
+++ b/pythonforandroid/recipes/sdl2/__init__.py
@@ -14,6 +14,8 @@ class LibSDL2Recipe(BootstrapNDKRecipe):
 
     depends = ['sdl2_image', 'sdl2_mixer', 'sdl2_ttf']
 
+    patches = ['sdl-orientation-pr-6984.diff']
+
     def get_recipe_env(self, arch=None, with_flags_in_cc=True, with_python=True):
         env = super().get_recipe_env(
             arch=arch, with_flags_in_cc=with_flags_in_cc, with_python=with_python)

--- a/pythonforandroid/recipes/sdl2/sdl-orientation-pr-6984.diff
+++ b/pythonforandroid/recipes/sdl2/sdl-orientation-pr-6984.diff
@@ -1,0 +1,27 @@
+diff --git a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+index 2d7d69b76a25..edb42fb55461 100644
+--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
++++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+@@ -971,15 +971,18 @@ public void setOrientationBis(int w, int h, boolean resizable, String hint)
+         /* If set, hint "explicitly controls which UI orientations are allowed". */
+         if (hint.contains("LandscapeRight") && hint.contains("LandscapeLeft")) {
+             orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+-        } else if (hint.contains("LandscapeRight")) {
+-            orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+         } else if (hint.contains("LandscapeLeft")) {
++            orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
++        } else if (hint.contains("LandscapeRight")) {
+             orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+         }
+ 
+-        if (hint.contains("Portrait") && hint.contains("PortraitUpsideDown")) {
++        /* exact match to 'Portrait' to distinguish with PortraitUpsideDown */
++        boolean contains_Portrait = hint.contains("Portrait ") || hint.endsWith("Portrait");
++
++        if (contains_Portrait && hint.contains("PortraitUpsideDown")) {
+             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
+-        } else if (hint.contains("Portrait")) {
++        } else if (contains_Portrait) {
+             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+         } else if (hint.contains("PortraitUpsideDown")) {
+             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;


### PR DESCRIPTION
- inverse landscapeLeft and landscapeRight (now behaves as described in SDL docs)
- fix to match exactly Portrait (as it is contained in PortraitUpsideDown)

See: https://github.com/libsdl-org/SDL/pull/6964 and https://github.com/kivy/python-for-android/issues/2724#issuecomment-1368142168