### PR TITLE
Update __init__.py from `scrypt` recipe

### DIFF
--- a/pythonforandroid/recipes/scrypt/__init__.py
+++ b/pythonforandroid/recipes/scrypt/__init__.py
@@ -3,8 +3,8 @@ from pythonforandroid.recipe import CythonRecipe
 
 class ScryptRecipe(CythonRecipe):
 
-    version = '0.8.6'
-    url = 'https://bitbucket.org/mhallin/py-scrypt/get/v{version}.zip'
+    version = '0.8.20'
+    url = 'https://github.com/holgern/py-scrypt/archive/refs/tags/v{version}.zip'
     depends = ['setuptools', 'openssl']
     call_hostpython_via_targetpython = False
     patches = ["remove_librt.patch"]


### PR DESCRIPTION
`scrypt` recipe is not working...

Updating the version to `0.8.20` and the url to `https://github.com/holgern/py-scrypt/archive/refs/tags/v{version}.zip` fixes it

You can check the latest release of `scrypt` here: https://github.com/holgern/py-scrypt/releases/tag/v0.8.20

Already tested it on my phone, it works only after applying this fix 