### PR TITLE
Implements `--manifest-orientation` and changes how `--orientation` works so we can now pass the setting to the SDL orientation hint

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -57,12 +57,17 @@ options (this list may not be exhaustive):
 - ``--package``: The Java package name for your project. e.g. ``org.example.yourapp``.
 - ``--name``: The app name.
 - ``--version``: The version number.
-- ``--orientation``: Usually one of ``portait``, ``landscape``,
-  ``sensor`` to automatically rotate according to the device
-  orientation, or ``user`` to do the same but obeying the user's
-  settings. The full list of valid options is given under
-  ``android:screenOrientation`` in the `Android documentation
-  <https://developer.android.com/guide/topics/manifest/activity-element.html>`__.
+- ``--orientation``: The orientations that the app will display in.
+  (Available options are ``portrait``, ``landscape``, ``portrait-reverse``, ``landscape-reverse``).
+  Since Android ignores ``android:screenOrientation`` when in multi-window mode
+  (Which is the default on Android 12+), this option will also set the window orientation hints
+  for the SDL bootstrap. If multiple orientations are given,
+``android:screenOrientation`` will be set to ``unspecified``.
+- ``--manifest-orientation``: The orientation that will be set for the ``android:screenOrientation``
+  attribute of the activity in the ``AndroidManifest.xml`` file. If not set, the value 
+  will be synthesized from the ``--orientation`` option.
+  The full list of valid options is given under ``android:screenOrientation``
+  in the `Android documentation <https://developer.android.com/guide/topics/manifest/activity-element.html>`__.
 - ``--icon``: A path to the png file to use as the application icon.
 - ``--permission``: A permission that needs to be declared into the App ``AndroidManifest.xml``.
   For multiple permissions, add multiple ``--permission`` arguments.
@@ -136,12 +141,16 @@ ready.
 - ``--package``: The Java package name for your project. e.g. ``org.example.yourapp``.
 - ``--name``: The app name.
 - ``--version``: The version number.
-- ``--orientation``: Usually one of ``portait``, ``landscape``,
-  ``sensor`` to automatically rotate according to the device
-  orientation, or ``user`` to do the same but obeying the user's
-  settings. The full list of valid options is given under
-  ``android:screenOrientation`` in the `Android documentation
-  <https://developer.android.com/guide/topics/manifest/activity-element.html>`__.
+- ``--orientation``: The orientations that the app will display in.
+  (Available options are ``portrait``, ``landscape``, ``portrait-reverse``, ``landscape-reverse``).
+  Since Android ignores ``android:screenOrientation`` when in multi-window mode
+  (Which is the default on Android 12+), this setting is not guaranteed to work, and
+  you should consider to implement a custom orientation change handler in your app.
+- ``--manifest-orientation``: The orientation that will be set in the ``android:screenOrientation``
+  attribute of the activity in the ``AndroidManifest.xml`` file. If not set, the value 
+  will be synthesized from the ``--orientation`` option.
+  The full list of valid options is given under ``android:screenOrientation``
+  in the `Android documentation <https://developer.android.com/guide/topics/manifest/activity-element.html>`__.
 - ``--icon``: A path to the png file to use as the application icon.
 - ``--permission``: A permission name for the app,
   e.g. ``--permission VIBRATE``. For multiple permissions, add

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -43,6 +43,9 @@ class Bdist(Command):
                 if option == 'permissions':
                     for perm in value:
                         sys.argv.append('--permission={}'.format(perm))
+                elif option == 'orientation':
+                    for orient in value:
+                        sys.argv.append('--orientation={}'.format(orient))
                 elif value in (None, 'None'):
                     sys.argv.append('--{}'.format(option))
                 else:

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -249,8 +249,8 @@ main.py that loads it.''')
     with open(os.path.join(env_vars_tarpath, "p4a_env_vars.txt"), "w") as f:
         if hasattr(args, "window"):
             f.write("P4A_IS_WINDOWED=" + str(args.window) + "\n")
-        if hasattr(args, "orientation"):
-            f.write("P4A_ORIENTATION=" + str(args.orientation) + "\n")
+        if hasattr(args, "sdl_orientation_hint"):
+            f.write("KIVY_ORIENTATION=" + str(args.sdl_orientation_hint) + "\n")
         f.write("P4A_NUMERIC_VERSION=" + str(args.numeric_version) + "\n")
         f.write("P4A_MINSDK=" + str(args.min_sdk_version) + "\n")
 
@@ -690,20 +690,54 @@ def parse_permissions(args_permissions):
     return _permissions
 
 
-def parse_args_and_make_package(args=None):
-    global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
+def get_sdl_orientation_hint(orientations):
+    SDL_ORIENTATION_MAP = {
+        "landscape": "LandscapeLeft",
+        "portrait": "Portrait",
+        "portrait-reverse": "PortraitUpsideDown",
+        "landscape-reverse": "LandscapeRight",
+    }
+    return " ".join(
+        [SDL_ORIENTATION_MAP[x] for x in orientations if x in SDL_ORIENTATION_MAP]
+    )
 
+
+def get_manifest_orientation(orientations, manifest_orientation=None):
+    # If the user has specifically set an orientation to use in the manifest,
+    # use that.
+    if manifest_orientation is not None:
+        return manifest_orientation
+
+    # If multiple or no orientations are specified, use unspecified in the manifest,
+    # as we can only specify one orientation in the manifest.
+    if len(orientations) != 1:
+        return "unspecified"
+
+    # Convert the orientation to a value that can be used in the manifest.
+    # If the specified orientation is not supported, use unspecified.
+    MANIFEST_ORIENTATION_MAP = {
+        "landscape": "landscape",
+        "portrait": "portrait",
+        "portrait-reverse": "reversePortrait",
+        "landscape-reverse": "reverseLandscape",
+    }
+    return MANIFEST_ORIENTATION_MAP.get(orientations[0], "unspecified")
+
+
+def get_dist_ndk_min_api_level():
     # Get the default minsdk, equal to the NDK API that this dist is built against
     try:
         with open('dist_info.json', 'r') as fileh:
             info = json.load(fileh)
-            default_min_api = int(info['ndk_api'])
-            ndk_api = default_min_api
+            ndk_api = int(info['ndk_api'])
     except (OSError, KeyError, ValueError, TypeError):
         print('WARNING: Failed to read ndk_api from dist info, defaulting to 12')
-        default_min_api = 12  # The old default before ndk_api was introduced
-        ndk_api = 12
+        ndk_api = 12  # The old default before ndk_api was introduced
+    return ndk_api
 
+
+def create_argument_parser():
+    ndk_api = get_dist_ndk_min_api_level()
     import argparse
     ap = argparse.ArgumentParser(description='''\
 Package a Python application for Android (using
@@ -786,19 +820,21 @@ tools directory of the Android SDK.
         ap.add_argument('--window', dest='window', action='store_true',
                         default=False,
                         help='Indicate if the application will be windowed')
+        ap.add_argument('--manifest-orientation', dest='manifest_orientation',
+                        help=('The orientation that will be set in the '
+                              'android:screenOrientation attribute of the activity '
+                              'in the AndroidManifest.xml file. If not set, '
+                              'the value will be synthesized from the --orientation option.'))
         ap.add_argument('--orientation', dest='orientation',
-                        default='portrait',
-                        help=('The orientation that the game will '
-                              'display in. '
-                              'Usually one of "landscape", "portrait", '
-                              '"sensor", or "user" (the same as "sensor" '
-                              'but obeying the '
-                              'user\'s Android rotation setting). '
-                              'The full list of options is given under '
-                              'android_screenOrientation at '
-                              'https://developer.android.com/guide/'
-                              'topics/manifest/'
-                              'activity-element.html'))
+                        action="append", default=[],
+                        choices=['portrait', 'landscape', 'landscape-reverse', 'portrait-reverse'],
+                        help=('The orientations that the app will display in. '
+                              'Since Android ignores android:screenOrientation '
+                              'when in multi-window mode (Which is the default on Android 12+), '
+                              'this option will also set the window orientation hints '
+                              'for apps using the (default) SDL bootstrap.'
+                              'If multiple orientations are given, android:screenOrientation '
+                              'will be set to "unspecified"'))
 
     ap.add_argument('--enable-androidx', dest='enable_androidx',
                     action='store_true',
@@ -853,9 +889,9 @@ tools directory of the Android SDK.
     ap.add_argument('--sdk', dest='sdk_version', default=-1,
                     type=int, help=('Deprecated argument, does nothing'))
     ap.add_argument('--minsdk', dest='min_sdk_version',
-                    default=default_min_api, type=int,
+                    default=ndk_api, type=int,
                     help=('Minimum Android SDK version that the app supports. '
-                          'Defaults to {}.'.format(default_min_api)))
+                          'Defaults to {}.'.format(ndk_api)))
     ap.add_argument('--allow-minsdk-ndkapi-mismatch', default=False,
                     action='store_true',
                     help=('Allow the --minsdk argument to be different from '
@@ -918,6 +954,15 @@ tools directory of the Android SDK.
     ap.add_argument('--activity-class-name', dest='activity_class_name', default=DEFAULT_PYTHON_ACTIVITY_JAVA_CLASS,
                     help='The full java class name of the main activity')
 
+    return ap
+
+
+def parse_args_and_make_package(args=None):
+    global BLACKLIST_PATTERNS, WHITELIST_PATTERNS, PYTHON
+
+    ndk_api = get_dist_ndk_min_api_level()
+    ap = create_argument_parser()
+
     # Put together arguments, and add those from .p4a config file:
     if args is None:
         args = sys.argv[1:]
@@ -963,6 +1008,13 @@ tools directory of the Android SDK.
         args.sdk_version = -1  # ensure it is not used
 
     args.permissions = parse_permissions(args.permissions)
+
+    args.manifest_orientation = get_manifest_orientation(
+        args.orientation, args.manifest_orientation
+    )
+
+    if get_bootstrap_name() == "sdl2":
+        args.sdl_orientation_hint = get_sdl_orientation_hint(args.orientation)
 
     if args.res_xmls and isinstance(args.res_xmls[0], list):
         args.res_xmls = [x for res in args.res_xmls for x in res]

--- a/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/sdl2/build/templates/AndroidManifest.tmpl.xml
@@ -69,7 +69,7 @@
         <activity android:name="{{args.android_entrypoint}}"
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
-                  android:screenOrientation="{{ args.orientation }}"
+                  android:screenOrientation="{{ args.manifest_orientation }}"
                   android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -61,7 +61,7 @@
         <activity android:name="org.kivy.android.PythonActivity"
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
-                  android:screenOrientation="{{ args.orientation }}"
+                  android:screenOrientation="{{ args.manifest_orientation }}"
                   android:exported="true"
                   {% if args.activity_launch_mode %}
                   android:launchMode="{{ args.activity_launch_mode }}"

--- a/testapps/on_device_unit_tests/setup.py
+++ b/testapps/on_device_unit_tests/setup.py
@@ -48,7 +48,7 @@ options = {
             'arch': 'armeabi-v7a',
             'bootstrap' : 'sdl2',
             'permissions': ['INTERNET', 'VIBRATE'],
-            'orientation': 'sensor',
+            'orientation': ['portrait', 'landscape'],
             'service': 'P4a_test_service:app_service.py',
         },
     'aab':
@@ -62,7 +62,7 @@ options = {
             'arch': 'armeabi-v7a',
             'bootstrap' : 'sdl2',
             'permissions': ['INTERNET', 'VIBRATE'],
-            'orientation': 'sensor',
+            'orientation': ['portrait', 'landscape'],
             'service': 'P4a_test_service:app_service.py',
         },
     'aar':

--- a/tests/test_bootstrap_build.py
+++ b/tests/test_bootstrap_build.py
@@ -1,29 +1,45 @@
 import unittest
+from unittest import mock
 import pytest
 import os
-import argparse
 
 from pythonforandroid.util import load_source
 
 
-class TestParsePermissions(unittest.TestCase):
+class TestBootstrapBuild(unittest.TestCase):
+    def setUp(self):
+        os.environ["P4A_BUILD_IS_RUNNING_UNITTESTS"] = "1"
+
+        build_src = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../pythonforandroid/bootstraps/common/build/build.py",
+        )
+
+        self.buildpy = load_source("buildpy", build_src)
+        self.buildpy.get_bootstrap_name = mock.Mock(return_value="sdl2")
+
+        self.ap = self.buildpy.create_argument_parser()
+
+        self.common_args = [
+            "--package",
+            "org.test.app",
+            "--name",
+            "TestApp",
+            "--version",
+            "0.1",
+        ]
+
+
+class TestParsePermissions(TestBootstrapBuild):
     def test_parse_permissions_with_migrations(self):
         # Test that permissions declared in the old format are migrated to the
         # new format.
         # (Users can new declare permissions in both formats, even a mix)
-        os.environ["P4A_BUILD_IS_RUNNING_UNITTESTS"] = "1"
 
-        ap = argparse.ArgumentParser()
-        ap.add_argument(
-            "--permission",
-            dest="permissions",
-            action="append",
-            default=[],
-            help="The permissions to give this app.",
-            nargs="+",
-        )
+        self.ap = self.buildpy.create_argument_parser()
 
         args = [
+            *self.common_args,
             "--permission",
             "INTERNET",
             "--permission",
@@ -34,15 +50,9 @@ class TestParsePermissions(unittest.TestCase):
             "(name=android.permission.BLUETOOTH_SCAN;usesPermissionFlags=neverForLocation)",
         ]
 
-        args = ap.parse_args(args)
+        args = self.ap.parse_args(args)
 
-        build_src = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../pythonforandroid/bootstraps/common/build/build.py",
-        )
-
-        buildpy = load_source("buildpy", build_src)
-        parsed_permissions = buildpy.parse_permissions(args.permissions)
+        parsed_permissions = self.buildpy.parse_permissions(args.permissions)
 
         assert parsed_permissions == [
             dict(name="android.permission.INTERNET"),
@@ -55,33 +65,116 @@ class TestParsePermissions(unittest.TestCase):
         ]
 
     def test_parse_permissions_invalid_property(self):
-        os.environ["P4A_BUILD_IS_RUNNING_UNITTESTS"] = "1"
 
-        ap = argparse.ArgumentParser()
-        ap.add_argument(
-            "--permission",
-            dest="permissions",
-            action="append",
-            default=[],
-            help="The permissions to give this app.",
-            nargs="+",
-        )
+        self.ap = self.buildpy.create_argument_parser()
 
         args = [
+            *self.common_args,
             "--permission",
             "(name=android.permission.BLUETOOTH_SCAN;propertyThatFails=neverForLocation)",
         ]
 
-        args = ap.parse_args(args)
-
-        build_src = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../pythonforandroid/bootstraps/common/build/build.py",
-        )
-
-        buildpy = load_source("buildpy", build_src)
+        args = self.ap.parse_args(args)
 
         with pytest.raises(
             ValueError, match="Property 'propertyThatFails' is not supported."
         ):
-            buildpy.parse_permissions(args.permissions)
+            self.buildpy.parse_permissions(args.permissions)
+
+
+class TestOrientationArg(TestBootstrapBuild):
+    def test_no_orientation_args(self):
+
+        args = self.common_args
+
+        args = self.ap.parse_args(args)
+
+        assert (
+            self.buildpy.get_manifest_orientation(
+                args.orientation, args.manifest_orientation
+            )
+            == "unspecified"
+        )
+        assert self.buildpy.get_sdl_orientation_hint(args.orientation) == ""
+
+    def test_manifest_orientation_present(self):
+
+        args = [
+            *self.common_args,
+            "--orientation",
+            "landscape",
+            "--orientation",
+            "portrait",
+            "--manifest-orientation",
+            "fullSensor",
+        ]
+
+        args = self.ap.parse_args(args)
+
+        assert (
+            self.buildpy.get_manifest_orientation(
+                args.orientation, manifest_orientation=args.manifest_orientation
+            )
+            == "fullSensor"
+        )
+
+    def test_manifest_orientation_supported(self):
+
+        args = [*self.common_args, "--orientation", "landscape"]
+
+        args = self.ap.parse_args(args)
+
+        assert (
+            self.buildpy.get_manifest_orientation(
+                args.orientation, manifest_orientation=args.manifest_orientation
+            )
+            == "landscape"
+        )
+
+    def test_android_manifest_multiple_orientation_supported(self):
+
+        args = [
+            *self.common_args,
+            "--orientation",
+            "landscape",
+            "--orientation",
+            "portrait",
+        ]
+
+        args = self.ap.parse_args(args)
+
+        assert (
+            self.buildpy.get_manifest_orientation(
+                args.orientation, manifest_orientation=args.manifest_orientation
+            )
+            == "unspecified"
+        )
+
+    def test_sdl_orientation_hint_single(self):
+
+        args = [*self.common_args, "--orientation", "landscape"]
+
+        args = self.ap.parse_args(args)
+
+        assert (
+            self.buildpy.get_sdl_orientation_hint(args.orientation) == "LandscapeLeft"
+        )
+
+    def test_sdl_orientation_hint_multiple(self):
+
+        args = [
+            *self.common_args,
+            "--orientation",
+            "landscape",
+            "--orientation",
+            "portrait",
+        ]
+
+        args = self.ap.parse_args(args)
+
+        sdl_orientation_hint = self.buildpy.get_sdl_orientation_hint(
+            args.orientation
+        ).split(" ")
+
+        assert "LandscapeLeft" in sdl_orientation_hint
+        assert "Portrait" in sdl_orientation_hint


### PR DESCRIPTION
As discussed on issue #2724 , when targeting API 31 and above, on Android 12 and above, the attribute `android:screenOrientation` is ignored, as the activity will run in multi-window mode.

This PR takes advantage of changes made on SDL side which have been applied as a patch to `python-for-android` SDL build: https://github.com/kivy/python-for-android/pull/2730.

After these changes, orientation can be controlled in two ways:

`--orientation` will control the allowed orientations (`portrait`, `landscape`, `portrait-reverse`, `landscape-reverse`). The allowed orientations list is then set to `KIVY_ORIENTATION`, which is used during window setup time to populate the `SDL_HINT_ORIENTATIONS` value, as we're doing for other platforms.

`--manifest-orientation` has been added to keep the `android:screenOrientation` personalisation functionality, even if Android will be likely deprecate this attribute in future. Valid values can be find [here](https://developer.android.com/guide/topics/manifest/activity-element.html).

If `--manifest-orientation` is not set, and only (one of multiple) `--orientation` options are passed, the value for `android:screenOrientation` is guessed and synthesised from the `--orientation` option. Since `android:screenOrientation` accepts only 1 value, if multiple `--orientation` are given, `android:screenOrientation` will be set to `unspecified`.

A `buildozer` PR will follow.

P.S. : I'm slowly changing `pythonforandroid/bootstraps/common/build/build.py` in order to make it deeply testable, so some changes may seem to be unrelated, but are needed in order to actually test the code.

⚠️ The changes applied in this PR will likely break existing third party examples and automated builds, if a now unsupported orientation setting is used, so the user will need to migrate, if needed. Specifically, `--orientation sensor` or `--orientation user` are not valid anymore, and an error will be raised, and the user will be forced to migrate.



