### PR TITLE
🐛 fix: Update `pydantic` recipe

### DIFF
--- a/pythonforandroid/recipes/pydantic/__init__.py
+++ b/pythonforandroid/recipes/pydantic/__init__.py
@@ -2,10 +2,10 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class PydanticRecipe(PythonRecipe):
-    version = '1.8.2'
-    url = 'https://github.com/samuelcolvin/pydantic/archive/refs/tags/v{version}.zip'
+    version = '1.10.4'
+    url = 'https://github.com/pydantic/pydantic/archive/refs/tags/v{version}.zip'
     depends = ['setuptools']
-    python_depends = ['Cython', 'devtools', 'email-validator', 'dataclasses', 'typing-extensions', 'python-dotenv']
+    python_depends = ['Cython', 'devtools', 'email-validator', 'typing-extensions', 'python-dotenv']
     call_hostpython_via_targetpython = False
 
 


### PR DESCRIPTION
There is [incompatibility](https://github.com/huggingface/transformers/issues/8638) between python > 3.6 and package `dataclasses`.

This error was happening after my compilations: `AttributeError: module 'typing' has no attribute '_ClassVar'`

The fix is removing `dataclasses` from `python_depends`.

I also updated the pydantic version to the newest release `1.10.4`, it can be checked [here](https://github.com/pydantic/pydantic/releases) and its url.

I already compiled my app after applying these changes, and the compilation is working successfully again.