### PR TITLE
Add debug loggings for identifying a matching dist

### DIFF
--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -140,13 +140,13 @@ class Distribution:
         # If any dist has perfect recipes, arch and NDK API, return it
         for dist in possible_dists:
             if force_build:
-                debug(f"Skipping dist due to forced build")
+                debug("Skipping dist due to forced build")
                 continue
             if ndk_api is not None and dist.ndk_api != ndk_api:
-                debug(f"Skipping dist due to ndk_api mismatch")
+                debug("Skipping dist due to ndk_api mismatch")
                 continue
             if not all(arch_name in dist.archs for arch_name in archs):
-                debug(f"Skipping dist due to arch mismatch")
+                debug("Skipping dist due to arch mismatch")
                 continue
             if (set(dist.recipes) == set(recipes) or
                 (set(recipes).issubset(set(dist.recipes)) and

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -2,7 +2,7 @@ from os.path import exists, join
 import glob
 import json
 
-from pythonforandroid.logger import (info, info_notify, warning, Err_Style, Err_Fore)
+from pythonforandroid.logger import (debug, info, info_notify, warning, Err_Style, Err_Fore)
 from pythonforandroid.util import current_directory, BuildInterruptingException
 from shutil import rmtree
 
@@ -91,6 +91,7 @@ class Distribution:
         '''
 
         possible_dists = Distribution.get_distributions(ctx)
+        debug(f"All possible dists: {possible_dists}")
 
         # Will hold dists that would be built in the same folder as an existing dist
         folder_match_dist = None
@@ -100,6 +101,7 @@ class Distribution:
             possible_dists = [
                 d for d in possible_dists if
                 (d.name == name) and all(arch_name in d.archs for arch_name in archs)]
+            debug(f"Dist matching name and arch: {possible_dists}")
 
             if possible_dists:
                 # There should only be one folder with a given dist name *and* arch.
@@ -115,13 +117,18 @@ class Distribution:
             if (
                 ndk_api is not None and dist.ndk_api != ndk_api
             ) or dist.ndk_api is None:
+                debug(
+                    f"dist {dist} failed to match ndk_api, target api {ndk_api}, dist api {dist.ndk_api}"
+                )
                 continue
             for recipe in recipes:
                 if recipe not in dist.recipes:
+                    debug(f"dist {dist} missing recipe {recipe}")
                     break
             else:
                 _possible_dists.append(dist)
         possible_dists = _possible_dists
+        debug(f"Dist matching ndk_api and recipe: {possible_dists}")
 
         if possible_dists:
             info('Of the existing distributions, the following meet '
@@ -133,10 +140,13 @@ class Distribution:
         # If any dist has perfect recipes, arch and NDK API, return it
         for dist in possible_dists:
             if force_build:
+                debug(f"Skipping dist due to forced build")
                 continue
             if ndk_api is not None and dist.ndk_api != ndk_api:
+                debug(f"Skipping dist due to ndk_api mismatch")
                 continue
             if not all(arch_name in dist.archs for arch_name in archs):
+                debug(f"Skipping dist due to arch mismatch")
                 continue
             if (set(dist.recipes) == set(recipes) or
                 (set(recipes).issubset(set(dist.recipes)) and
@@ -144,6 +154,10 @@ class Distribution:
                 info_notify('{} has compatible recipes, using this one'
                             .format(dist.name))
                 return dist
+            else:
+                debug(
+                    f"Skipping dist due to recipes mismatch, expected {set(recipes)}, actual {set(dist.recipes)}"
+                )
 
         # If there was a name match but we didn't already choose it,
         # then the existing dist is incompatible with the requested


### PR DESCRIPTION
Sometimes the android dist is being rebuilt every time, and it's hard to understand why that happens. This PR adds some debug logging so that it's easier to investigate when this happens.

In my case, I incorrectly used `Cython` and `Pillow`  in the `requirements` of my `buildozer.spec`, and this caused my dist to be rebuild every time, because `dist.recipes` would have `cython` and `pillow` in it, and p4a thinks it's missing the recipes `Cython` and `Pillow`.