### PR TITLE
add set type start service (START_STICKY/START_NOT_STICKY/START_RED…

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonService.java
@@ -39,13 +39,26 @@ public class PythonService extends Service implements Runnable {
     private Intent startIntent = null;
 
     private boolean autoRestartService = false;
+    private int start = START_NOT_STICKY;
 
     public void setAutoRestartService(boolean restart) {
         autoRestartService = restart;
     }
 
+    public void setTypeStartSticky() {
+        start = START_STICKY;
+    }
+    
+    public void setTypeStartNotSticky() {
+        start = START_NOT_STICKY;
+    }
+    
+    public void setTypeStartRedeliverIntent() {
+        start = START_REDELIVER_INTENT;
+    }
+
     public int startType() {
-        return START_NOT_STICKY;
+        return start;
     }
 
     @Override


### PR DESCRIPTION
I added choice type start service  **START_STICKY**, **START_NOT_STICKY** and **START_REDELIVER_INTENT**.
Default use now and before START_NOT_STICKY, but when you close app, service close too. 

And I used this code for restart service.
```python
PythonService = autoclass('org.kivy.android.PythonService')
PythonService.mService.setAutoRestartService(True)
```

Now you can use 
```python
PythonService.mService.setTypeStartSticky()
PythonService.mService.setTypeStartNotSticky()
PythonService.mService.setTypeStartRedeliverIntent()
```

With setTypeStartNotSticky, service doesnt close when app swipping or close.