### PR TITLE
⬆️ version: Updated `ffpyplayer` version and url

### DIFF
--- a/pythonforandroid/recipes/ffpyplayer/__init__.py
+++ b/pythonforandroid/recipes/ffpyplayer/__init__.py
@@ -4,8 +4,8 @@ from os.path import join
 
 
 class FFPyPlayerRecipe(CythonRecipe):
-    version = 'v4.3.2'
-    url = 'https://github.com/matham/ffpyplayer/archive/{version}.zip'
+    version = 'v4.4.0'
+    url = 'https://github.com/matham/ffpyplayer/archive/refs/tags/{version}.zip'
     depends = ['python3', 'sdl2', 'ffmpeg']
     opt_depends = ['openssl', 'ffpyplayer_codecs']
 


### PR DESCRIPTION
Updated the `ffpyplayer` version from 4.3.2 (2020) to the [latest](https://github.com/matham/ffpyplayer/releases) release (2023). Also updated the url. 

I'm already using the version `ffpyplayer` 4.4.0 on computer and on my phone (on my Kivy app), and it works fine on both.