### PR TITLE
Bump tflite-runtime recipe version

### DIFF
--- a/pythonforandroid/recipes/tflite-runtime/__init__.py
+++ b/pythonforandroid/recipes/tflite-runtime/__init__.py
@@ -23,7 +23,7 @@ class TFLiteRuntimeRecipe(PythonRecipe):
     #
     ###############################################################
 
-    version = '2.8.0'
+    version = '2.11.0'
     url = 'https://github.com/tensorflow/tensorflow/archive/refs/tags/v{version}.zip'
     depends = ['pybind11', 'numpy']
     patches = ['CMakeLists.patch', 'build_with_cmake.patch']
@@ -99,6 +99,7 @@ class TFLiteRuntimeRecipe(PythonRecipe):
             hostpython = sh.Command(self.hostpython_location)
             install_dir = self.ctx.get_python_install_dir(arch.arch)
             env['PACKAGE_VERSION'] = self.version
+            env['PROJECT_NAME'] = self.site_packages_name
             shprint(hostpython, 'setup.py', 'install', '-O2',
                     '--root={}'.format(install_dir),
                     '--install-lib=.',

--- a/pythonforandroid/recipes/tflite-runtime/build_with_cmake.patch
+++ b/pythonforandroid/recipes/tflite-runtime/build_with_cmake.patch
@@ -1,15 +1,17 @@
---- tflite-runtime/tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh	2022-01-22 08:57:16.000000000 -1000
-+++ build_pip_package_with_cmake.sh	2022-03-02 18:19:05.185550500 -1000
-@@ -28,7 +28,7 @@
+--- tflite-runtime/tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh	2023-02-21 21:07:56.249520148 -1000
++++ build_pip_package_with_cmake.sh	2023-02-22 02:32:09.687768544 -1000
+@@ -29,8 +29,8 @@
    export TENSORFLOW_TARGET="armhf"
  fi
  PYTHON_INCLUDE=$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")
 -PYBIND11_INCLUDE=$(${PYTHON} -c "import pybind11; print (pybind11.get_include())")
+-NUMPY_INCLUDE=$(${PYTHON} -c "import numpy; print (numpy.get_include())")
 +# PYBIND11_INCLUDE=$(${PYTHON} -c "import pybind11; print (pybind11.get_include())")
++# NUMPY_INCLUDE=$(${PYTHON} -c "import numpy; print (numpy.get_include())")
  export CROSSTOOL_PYTHON_INCLUDE_PATH=${PYTHON_INCLUDE}
  
  # Fix container image for cross build.
-@@ -58,7 +58,7 @@
+@@ -60,7 +60,7 @@
     "${TENSORFLOW_LITE_DIR}/python/metrics/metrics_portable.py" \
     "${BUILD_DIR}/tflite_runtime"
  echo "__version__ = '${PACKAGE_VERSION}'" >> "${BUILD_DIR}/tflite_runtime/__init__.py"
@@ -18,7 +20,7 @@
  
  # Build python interpreter_wrapper.
  mkdir -p "${BUILD_DIR}/cmake_build"
-@@ -111,6 +111,18 @@
+@@ -113,6 +113,18 @@
        -DCMAKE_CXX_FLAGS="${BUILD_FLAGS}" \
        "${TENSORFLOW_LITE_DIR}"
      ;;
@@ -33,11 +35,11 @@
 +      -DANDROID_PLATFORM="${ANDROID_PLATFORM}" \
 +      -DANDROID_ABI="${ANDROID_ABI}" \
 +      "${TENSORFLOW_LITE_DIR}" 
-+    ;;
++    ;;  
    *)
-     BUILD_FLAGS=${BUILD_FLAGS:-"-I${PYTHON_INCLUDE} -I${PYBIND11_INCLUDE}"}
+     BUILD_FLAGS=${BUILD_FLAGS:-"-I${PYTHON_INCLUDE} -I${PYBIND11_INCLUDE} -I${NUMPY_INCLUDE}"}
      cmake \
-@@ -162,7 +174,7 @@
+@@ -164,7 +176,7 @@
        ${PYTHON} setup.py bdist --plat-name=${WHEEL_PLATFORM_NAME} \
                           bdist_wheel --plat-name=${WHEEL_PLATFORM_NAME}
      else


### PR DESCRIPTION
Change version number, and minor patch changes to match changes in package build scripts.

Builds and runs https://github.com/Android-for-Python/c4k_tflite_example