### PR TITLE
android_api to integer

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -497,15 +497,9 @@ main.py that loads it.''')
     # Find the SDK directory and target API
     with open('project.properties', 'r') as fileh:
         target = fileh.read().strip()
-    android_api = int(target.split('-')[1])
-    try:
-        int(android_api)
-    except (ValueError, TypeError):
-        raise ValueError(
-            "failed to extract the Android API level from " +
-            "build.properties. expected int, got: '" +
-            str(android_api) + "'"
-        )
+    aapi = target.split('-')[1]
+    android_api = int(aapi) if aapi.isdigit() else -1
+
     with open('local.properties', 'r') as fileh:
         sdk_dir = fileh.read().strip()
     sdk_dir = sdk_dir[8:]

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -497,7 +497,7 @@ main.py that loads it.''')
     # Find the SDK directory and target API
     with open('project.properties', 'r') as fileh:
         target = fileh.read().strip()
-    android_api = target.split('-')[1]
+    android_api = int(target.split('-')[1])
     try:
         int(android_api)
     except (ValueError, TypeError):

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -497,8 +497,16 @@ main.py that loads it.''')
     # Find the SDK directory and target API
     with open('project.properties', 'r') as fileh:
         target = fileh.read().strip()
-    aapi = target.split('-')[1]
-    android_api = int(aapi) if aapi.isdigit() else -1
+    android_api = target.split('-')[1]
+
+    if android_api.isdigit():
+        android_api = int(android_api)
+    else:
+        raise ValueError(
+            "failed to extract the Android API level from " +
+            "build.properties. expected int, got: '" +
+            str(android_api) + "'"
+        )
 
     with open('local.properties', 'r') as fileh:
         sdk_dir = fileh.read().strip()


### PR DESCRIPTION
Smaller fix when `android_api` was given as a string but integer is needed and expected.