### PR TITLE
fix tools/liblink: syntax error

### DIFF
--- a/pythonforandroid/tools/liblink
+++ b/pythonforandroid/tools/liblink
@@ -35,6 +35,7 @@ while i < len(sys.argv):
 
     if opt.startswith(
             ("-I", "-isystem", "-m", "-f", "-O", "-g", "-D", "-R")):
+        continue
 
     if opt.startswith("-"):
         print(sys.argv)


### PR DESCRIPTION
Looks like a regression from 22b7dfee1ddc5f435f8bf016cbf83980a45b4374

To be honest I am not sure how this file is used. Maybe it could be removed altogether seeing as no one complained for three years.