### PR TITLE
Use build rather than pep517 for building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ data_files = []
 install_reqs = [
     'appdirs', 'colorama>=0.3.3', 'jinja2',
     'sh>=1.10, <2.0; sys_platform!="nt"',
-    'pep517', 'toml', 'packaging',
+    'build', 'toml', 'packaging',
 ]
-# (pep517 and toml are used by pythonpackage.py)
+# (build and toml are used by pythonpackage.py)
 
 
 # By specifying every file manually, package_data will be able to

--- a/tests/test_pythonpackage.py
+++ b/tests/test_pythonpackage.py
@@ -42,7 +42,7 @@ def test_get_package_dependencies():
         if "MarkupSafe" in dep
     ]
     # Check setuptools not being in non-recursive deps:
-    # (It will be in recursive ones due to p4a's pep517 dependency)
+    # (It will be in recursive ones due to p4a's build dependency)
     assert "setuptools" not in deps_nonrecursive
     # Check setuptools is present in non-recursive deps,
     # if we also add build requirements:

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -236,7 +236,7 @@ class TestGetSystemPythonExecutable():
             pybin,
             "-c",
             "import importlib\n"
-            "import json\n"
+            "import build.util\n"
             "import os\n"
             "import sys\n"
             "sys.path = [os.path.dirname(sys.argv[1])] + sys.path\n"
@@ -273,8 +273,8 @@ class TestGetSystemPythonExecutable():
             # Some deps may not be installed, so we just avoid to raise
             # an exception here, as a missing dep should not make the test
             # fail.
-            if "pep517" in str(e.args):
-                # System python probably doesn't have pep517 available!
+            if "build" in str(e.args):
+                # System python probably doesn't have build available!
                 pass
             elif "toml" in str(e.args):
                 # System python probably doesn't have toml available!
@@ -304,11 +304,8 @@ class TestGetSystemPythonExecutable():
             ])
             subprocess.check_output([
                 os.path.join(test_dir, "venv", "bin", "pip"),
-                "install", "-U", "pep517"
-            ])
-            subprocess.check_output([
-                os.path.join(test_dir, "venv", "bin", "pip"),
-                "install", "-U", "toml"
+                "install", "-U", "build", "toml", "sh<2.0", "colorama",
+                "appdirs", "jinja2", "packaging"
             ])
             sys_python_path = self.run__get_system_python_executable(
                 os.path.join(test_dir, "venv", "bin", "python")


### PR DESCRIPTION
pep517 has been renamed to pyproject-hooks, and as a consequence all of the deprecated functionality has been removed. build now provides the functionality required, and since we are only interested in the metadata, we can leverage a helper function for that. I've also removed all of the subprocess machinery for calling the wrapping function, since it appears to not be as noisy as pep517.