### PR TITLE
Update `pyjnius` version to `1.5.0`

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -6,7 +6,7 @@ from os.path import join
 
 
 class PyjniusRecipe(CythonRecipe):
-    version = '1.4.2'
+    version = '1.5.0'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
     depends = [('genericndkbuild', 'sdl2'), 'six']


### PR DESCRIPTION
Update `pyjnius` to latest available version (`1.5.0`) as it contains a fix needed to correctly handle log on **Kivy 2.2.0** and onwards. 