### PR TITLE
Update Kivy recipe for 2.2.0

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -22,7 +22,7 @@ def is_kivy_affected_by_deadlock_issue(recipe=None, arch=None):
 
 
 class KivyRecipe(CythonRecipe):
-    version = '2.2.0rc1'
+    version = '2.2.0'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 

--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -22,12 +22,12 @@ def is_kivy_affected_by_deadlock_issue(recipe=None, arch=None):
 
 
 class KivyRecipe(CythonRecipe):
-    version = '2.1.0'
+    version = '2.2.0rc1'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 
     depends = ['sdl2', 'pyjnius', 'setuptools']
-    python_depends = ['certifi']
+    python_depends = ['certifi', 'chardet', 'idna', 'requests', 'urllib3']
 
     # sdl-gl-swapwindow-nogil.patch is needed to avoid a deadlock.
     # See: https://github.com/kivy/kivy/pull/8025


### PR DESCRIPTION
~~⚠️ WIP - DO NOT MERGE
⚠️ Currently uses the pre-release version (2.2.0rc1) for testing~~

Updates the Kivy recipe, and adds the proper (new) dependencies. 

`chardet` is used as a replacement for `charset-normalizer>=3.x`, which requires a recipe (or, as an alternative, and it will likely land on `python-for-android` soon, the proper flags during `pip install`, to select a non-platform specific wheel).