### PR TITLE
Use platform.uname instead of os.uname

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to install and begin creating APKs and AABs.
 
 (for the develop branch: `pip install git+https://github.com/kivy/python-for-android.git`)
 
-Test that the install works with:
+Test that theinstall works with:
 
     p4a --version
 

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -1,6 +1,7 @@
 import contextlib
 from os.path import exists, join
-from os import getcwd, chdir, makedirs, walk, uname
+from os import getcwd, chdir, makedirs, walk
+from platform import uname
 import shutil
 from fnmatch import fnmatch
 from tempfile import mkdtemp
@@ -8,7 +9,7 @@ from pythonforandroid.logger import (logger, Err_Fore, error, info)
 
 
 build_platform = '{system}-{machine}'.format(
-    system=uname()[0], machine=uname()[-1]).lower()
+    system=uname().system, machine=uname().machine.lower())
 """the build platform in the format `system-machine`. We use
 this string to define the right build system when compiling some recipes or
 to get the right path for clang compiler"""


### PR DESCRIPTION
Advantages:

- Works cross platform, not just Unix.
- Is a namedtuple, so can use meaningful  fieldnames.

Also snuck in correction to typo in Readme which doesn't warrant its own review.

[Note: Unit-tests failed, but I don't *think* it had anything to do with this.]