### PR TITLE
Automatically generate required pre-requisites

### DIFF
--- a/pythonforandroid/prerequisites.py
+++ b/pythonforandroid/prerequisites.py
@@ -370,22 +370,19 @@ class CmakePrerequisite(Prerequisite):
 
 
 def get_required_prerequisites(platform="linux"):
-    DEFAULT_PREREQUISITES = dict(
-        darwin=[
-            HomebrewPrerequisite(),
-            AutoconfPrerequisite(),
-            AutomakePrerequisite(),
-            LibtoolPrerequisite(),
-            PkgConfigPrerequisite(),
-            CmakePrerequisite(),
-            OpenSSLPrerequisite(),
-            JDKPrerequisite(),
-        ],
-        linux=[],
-        all_platforms=[],
-    )
-
-    return DEFAULT_PREREQUISITES["all_platforms"] + DEFAULT_PREREQUISITES[platform]
+    return [
+        prerequisite_cls()
+        for prerequisite_cls in [
+            HomebrewPrerequisite,
+            AutoconfPrerequisite,
+            AutomakePrerequisite,
+            LibtoolPrerequisite,
+            PkgConfigPrerequisite,
+            CmakePrerequisite,
+            OpenSSLPrerequisite,
+            JDKPrerequisite,
+        ] if prerequisite_cls.mandatory.get(platform, False)
+    ]
 
 
 def check_and_install_default_prerequisites():


### PR DESCRIPTION
`get_required_prerequisites()` maintains a list of Prerequisites required by each platform.

But that same information is already stored in each Prerequisite class.

Rather than maintaining two lists which might become inconsistent, auto-generate one.

[Note: Unit tests fail, but I don't think it is a result of this change,]