### PR TITLE
Use a pinned version of `Cython` for now, as most of the recipes are incompatible with `Cython==3.x.x`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: virtualenv
 
 $(VIRTUAL_ENV):
 	python3 -m venv $(VIRTUAL_ENV)
-	$(PIP) install Cython
+	$(PIP) install Cython==0.29.36
 	$(PIP) install -e .
 
 virtualenv: $(VIRTUAL_ENV)


### PR DESCRIPTION
`Cython>=3.0.0` broke our CI pipeline.

But it's not `Cython` fault, instead, we urge to change our `python-for-android` and `kivy-ios` logic to not rely on a single specific `Cython` version for all the packages, as every package should be able to decide the `Cython` (and other build-time-only packages to use).

Meanwhile, to keep the development up and running, that seems the faster solution.

(See https://github.com/kivy/buildozer/pull/1637)