### PR TITLE
`build_platform` should be all-lowercase

### DIFF
--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -8,8 +8,9 @@ from tempfile import mkdtemp
 from pythonforandroid.logger import (logger, Err_Fore, error, info)
 
 
-build_platform = '{system}-{machine}'.format(
-    system=uname().system, machine=uname().machine.lower())
+build_platform = "{system}-{machine}".format(
+    system=uname().system, machine=uname().machine
+).lower()
 """the build platform in the format `system-machine`. We use
 this string to define the right build system when compiling some recipes or
 to get the right path for clang compiler"""


### PR DESCRIPTION
`build_platform` should be all-lowercase. 

FYI: @Julian-O , the issue has been introduced via #2857 (CI wasn't working as expected, and was hard to see)

Now that CI is working as expected, see: https://github.com/kivy/python-for-android/actions/runs/5630635544/job/15256832012?pr=2863