### PR TITLE
Python versions: Update documentation & CI testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macOs-latest]
     steps:
     - name: Checkout python-for-android

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -8,8 +8,8 @@ This page contains instructions for using different build options.
 Python versions
 ---------------
 
-python-for-android supports using Python 3.7 or higher. To explicitly select a Python
-version in your requirements, use e.g. ``--requirements=python3==3.7.1,hostpython3==3.7.1``.
+python-for-android supports using Python 3.8 or higher. To explicitly select a Python
+version in your requirements, use e.g. ``--requirements=python3==3.10.11,hostpython3==3.10.11``.
 
 The last python-for-android version supporting Python2 was `v2019.10.06 <https://github.com/kivy/python-for-android/archive/v2019.10.06.zip>`__
 


### PR DESCRIPTION
Python 3.11 was released October 2022.
Python 3.7 went end-of-life June 2023