### PR TITLE
Correct check for --sdk option

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -1006,7 +1006,7 @@ def parse_args_and_make_package(args=None):
         print('Billing not yet supported!')
         sys.exit(1)
 
-    if args.sdk_version == -1:
+    if args.sdk_version != -1:
         print('WARNING: Received a --sdk argument, but this argument is '
               'deprecated and does nothing.')
         args.sdk_version = -1  # ensure it is not used


### PR DESCRIPTION
The message "WARNING: Received a --sdk argument, but this argument is deprecated and does nothing." was displayed even if no --sdk option was passed.

This appears to be the history:

* Originally, --sdk option was accepted.
* Sep 2017: --sdk option was removed/rejected..
* Oct 2017, --sdk was ignored, with a warning.
* Dec 2018, --sdk was accidentally enforced, with a warning.

The default value of the argument is -1, so we should issue a warning only if the value has been changed (i.e. by supplying a value) and then we should set the value to -1 to make sure it isn't used.

[Alternatively, accept that no-one is still using this option, and delete the check.]