### PR TITLE
Standardise ensure_dir and rmdir

### DIFF
--- a/ci/constants.py
+++ b/ci/constants.py
@@ -33,6 +33,8 @@ BROKEN_RECIPES_PYTHON3 = set([
     'twisted',
     # genericndkbuild is incompatible with sdl2 (which is build by default when targeting sdl2 bootstrap)
     'genericndkbuild',
+    # libmysqlclient gives a linker failure (See issue #2808)
+    'libmysqlclient',
 ])
 
 BROKEN_RECIPES = {

--- a/ci/constants.py
+++ b/ci/constants.py
@@ -35,6 +35,7 @@ BROKEN_RECIPES_PYTHON3 = set([
     'genericndkbuild',
     # libmysqlclient gives a linker failure (See issue #2808)
     'libmysqlclient',
+    # libtorrent gives an undeclared identified (See issue #2809)
 ])
 
 BROKEN_RECIPES = {

--- a/ci/constants.py
+++ b/ci/constants.py
@@ -35,7 +35,11 @@ BROKEN_RECIPES_PYTHON3 = set([
     'genericndkbuild',
     # libmysqlclient gives a linker failure (See issue #2808)
     'libmysqlclient',
-    # libtorrent gives an undeclared identified (See issue #2809)
+    # boost gives errors (requires numpy? syntax error in .jam?)
+    'boost',
+    # libtorrent gives errors (requires boost. Also, see issue #2809, to start with)
+    'libtorrent',
+
 ])
 
 BROKEN_RECIPES = {

--- a/pythonforandroid/bdistapk.py
+++ b/pythonforandroid/bdistapk.py
@@ -1,10 +1,10 @@
-from setuptools import Command
-
-import sys
-from os.path import realpath, join, exists, dirname, curdir, basename, split
-from os import makedirs
 from glob import glob
-from shutil import rmtree, copyfile
+from os.path import realpath, join, dirname, curdir, basename, split
+from setuptools import Command
+from shutil import copyfile
+import sys
+
+from pythonforandroid.util import rmdir, ensure_dir
 
 
 def argv_contains(t):
@@ -90,9 +90,8 @@ class Bdist(Command):
                   'that.')
 
         bdist_dir = 'build/bdist.android-{}'.format(self.arch)
-        if exists(bdist_dir):
-            rmtree(bdist_dir)
-        makedirs(bdist_dir)
+        rmdir(bdist_dir)
+        ensure_dir(bdist_dir)
 
         globs = []
         for directory, patterns in self.distribution.package_data.items():
@@ -107,8 +106,7 @@ class Bdist(Command):
         if not argv_contains('--launcher'):
             for filen in filens:
                 new_dir = join(bdist_dir, dirname(filen))
-                if not exists(new_dir):
-                    makedirs(new_dir)
+                ensure_dir(new_dir)
                 print('Including {}'.format(filen))
                 copyfile(filen, join(bdist_dir, filen))
                 if basename(filen) in ('main.py', 'main.pyc'):

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -10,7 +10,8 @@ import shutil
 
 from pythonforandroid.logger import (shprint, info, logger, debug)
 from pythonforandroid.util import (
-    current_directory, ensure_dir, temp_directory, BuildInterruptingException)
+    current_directory, ensure_dir, temp_directory, BuildInterruptingException,
+    rmdir)
 from pythonforandroid.recipe import Recipe
 
 
@@ -70,7 +71,6 @@ class Bootstrap:
     '''An Android project template, containing recipe stuff for
     compilation and templated fields for APK info.
     '''
-    name = ''
     jni_subdir = '/jni'
     ctx = None
 
@@ -397,7 +397,7 @@ class Bootstrap:
                 files = [join(rd, f) for f in listdir(rd) if f != 'EGG-INFO']
                 if files:
                     shprint(sh.mv, '-t', sitepackages, *files)
-                shprint(sh.rm, '-rf', d)
+                rmdir(d)
 
 
 def expand_dependencies(recipes, ctx):

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -21,6 +21,8 @@ from distutils.version import LooseVersion
 from fnmatch import fnmatch
 import jinja2
 
+from pythonforandroid.util import rmdir, ensure_dir
+
 
 def get_dist_info_for(key, error_if_missing=True):
     try:
@@ -91,11 +93,6 @@ environment = jinja2.Environment(loader=jinja2.FileSystemLoader(
 
 DEFAULT_PYTHON_ACTIVITY_JAVA_CLASS = 'org.kivy.android.PythonActivity'
 DEFAULT_PYTHON_SERVICE_JAVA_CLASS = 'org.kivy.android.PythonService'
-
-
-def ensure_dir(path):
-    if not exists(path):
-        makedirs(path)
 
 
 def render(template, dest, **kwargs):
@@ -241,7 +238,7 @@ main.py that loads it.''')
     assets_dir = "src/main/assets"
 
     # Delete the old assets.
-    shutil.rmtree(assets_dir, ignore_errors=True)
+    rmdir(assets_dir, ignore_errors=True)
     ensure_dir(assets_dir)
 
     # Add extra environment variable file into tar-able directory:
@@ -290,7 +287,7 @@ main.py that loads it.''')
                                     not exists(
                                         join(main_py_only_dir, dir_path)
                                     )):
-                                os.mkdir(join(main_py_only_dir, dir_path))
+                                ensure_dir(join(main_py_only_dir, dir_path))
                             # Copy actual file:
                             shutil.copyfile(
                                 join(args.private, variant),
@@ -328,17 +325,17 @@ main.py that loads it.''')
             )
     finally:
         for directory in _temp_dirs_to_clean:
-            shutil.rmtree(directory)
+            rmdir(directory)
 
     # Remove extra env vars tar-able directory:
-    shutil.rmtree(env_vars_tarpath)
+    rmdir(env_vars_tarpath)
 
     # Prepare some variables for templating process
     res_dir = "src/main/res"
     res_dir_initial = "src/res_initial"
     # make res_dir stateless
     if exists(res_dir_initial):
-        shutil.rmtree(res_dir, ignore_errors=True)
+        rmdir(res_dir, ignore_errors=True)
         shutil.copytree(res_dir_initial, res_dir)
     else:
         shutil.copytree(res_dir, res_dir_initial)

--- a/pythonforandroid/bootstraps/sdl2/__init__.py
+++ b/pythonforandroid/bootstraps/sdl2/__init__.py
@@ -1,8 +1,10 @@
+from os.path import join
+
+import sh
+
 from pythonforandroid.toolchain import (
     Bootstrap, shprint, current_directory, info, info_main)
-from pythonforandroid.util import ensure_dir
-from os.path import join
-import sh
+from pythonforandroid.util import ensure_dir, rmdir
 
 
 class SDL2GradleBootstrap(Bootstrap):
@@ -15,8 +17,8 @@ class SDL2GradleBootstrap(Bootstrap):
     def assemble_distribution(self):
         info_main("# Creating Android project ({})".format(self.name))
 
+        rmdir(self.dist_dir)
         info("Copying SDL2/gradle build")
-        shprint(sh.rm, "-rf", self.dist_dir)
         shprint(sh.cp, "-r", self.build_dir, self.dist_dir)
 
         # either the build use environment variable (ANDROID_HOME)

--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -2,7 +2,7 @@ import sh
 from os.path import join
 from pythonforandroid.toolchain import (
     Bootstrap, current_directory, info, info_main, shprint)
-from pythonforandroid.util import ensure_dir
+from pythonforandroid.util import ensure_dir, rmdir
 
 
 class ServiceOnlyBootstrap(Bootstrap):
@@ -18,7 +18,7 @@ class ServiceOnlyBootstrap(Bootstrap):
             self.name))
 
         info('This currently just copies the build stuff straight from the build dir.')
-        shprint(sh.rm, '-rf', self.dist_dir)
+        rmdir(self.dist_dir)
         shprint(sh.cp, '-r', self.build_dir, self.dist_dir)
         with current_directory(self.dist_dir):
             with open('local.properties', 'w') as fileh:

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -1,7 +1,9 @@
-from pythonforandroid.toolchain import Bootstrap, current_directory, info, info_main, shprint
-from pythonforandroid.util import ensure_dir
 from os.path import join
+
 import sh
+
+from pythonforandroid.toolchain import Bootstrap, current_directory, info, info_main, shprint
+from pythonforandroid.util import ensure_dir, rmdir
 
 
 class WebViewBootstrap(Bootstrap):
@@ -15,7 +17,7 @@ class WebViewBootstrap(Bootstrap):
         info_main('# Creating Android project from build and {} bootstrap'.format(
             self.name))
 
-        shprint(sh.rm, '-rf', self.dist_dir)
+        rmdir(self.dist_dir)
         shprint(sh.cp, '-r', self.build_dir, self.dist_dir)
         with current_directory(self.dist_dir):
             with open('local.properties', 'w') as fileh:

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -1,28 +1,29 @@
+from contextlib import suppress
+import copy
+import glob
+import os
+from os import environ
 from os.path import (
     abspath, join, realpath, dirname, expanduser, exists
 )
-from os import environ
-import copy
-import os
-import glob
 import re
-import sh
 import shutil
 import subprocess
-from contextlib import suppress
 
-from pythonforandroid.util import (
-    current_directory, ensure_dir,
-    BuildInterruptingException,
-)
-from pythonforandroid.logger import (info, warning, info_notify, info_main, shprint)
+import sh
+
+from pythonforandroid.androidndk import AndroidNDK
 from pythonforandroid.archs import ArchARM, ArchARMv7_a, ArchAarch_64, Archx86, Archx86_64
+from pythonforandroid.logger import (info, warning, info_notify, info_main, shprint)
 from pythonforandroid.pythonpackage import get_package_name
 from pythonforandroid.recipe import CythonRecipe, Recipe
 from pythonforandroid.recommendations import (
     check_ndk_version, check_target_api, check_ndk_api,
     RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API)
-from pythonforandroid.androidndk import AndroidNDK
+from pythonforandroid.util import (
+    current_directory, ensure_dir,
+    BuildInterruptingException, rmdir
+)
 
 
 def get_targets(sdk_dir):
@@ -76,11 +77,6 @@ class Context:
 
     # the Android project folder where everything ends up
     dist_dir = None
-
-    # where Android libs are cached after build
-    # but before being placed in dists
-    libs_dir = None
-    aars_dir = None
 
     # Whether setup.py or similar should be used if present:
     use_setup_py = False
@@ -642,7 +638,7 @@ def run_setuppy_install(ctx, project_dir, env=None, arch=None):
             for f in set(copied_over_contents + new_venv_additions):
                 full_path = os.path.join(venv_site_packages_dir, f)
                 if os.path.isdir(full_path):
-                    shutil.rmtree(full_path)
+                    rmdir(full_path)
                 else:
                     os.remove(full_path)
         finally:

--- a/pythonforandroid/distribution.py
+++ b/pythonforandroid/distribution.py
@@ -1,10 +1,11 @@
-from os.path import exists, join
-import glob
 import json
+import glob
+from os.path import exists, join
 
-from pythonforandroid.logger import (debug, info, info_notify, warning, Err_Style, Err_Fore)
-from pythonforandroid.util import current_directory, BuildInterruptingException
-from shutil import rmtree
+from pythonforandroid.logger import (
+    debug, info, info_notify, warning, Err_Style, Err_Fore)
+from pythonforandroid.util import (
+    current_directory, BuildInterruptingException, rmdir)
 
 
 class Distribution:
@@ -201,7 +202,7 @@ class Distribution:
         return exists(self.dist_dir)
 
     def delete(self):
-        rmtree(self.dist_dir)
+        rmdir(self.dist_dir)
 
     @classmethod
     def get_distributions(cls, ctx, extra_dist_dirs=[]):

--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -45,7 +45,7 @@ def get_dependency_tuple_list_for_recipe(recipe, blacklist=None):
     """
     if blacklist is None:
         blacklist = set()
-    assert type(blacklist) == set
+    assert type(blacklist) is set
     if recipe.depends is None:
         dependencies = []
     else:
@@ -160,7 +160,7 @@ def obvious_conflict_checker(ctx, name_tuples, blacklist=None):
         current_to_be_added = list(to_be_added)
         to_be_added = []
         for (added_tuple, adding_recipe) in current_to_be_added:
-            assert type(added_tuple) == tuple
+            assert type(added_tuple) is tuple
             if len(added_tuple) > 1:
                 # No obvious commitment in what to add, don't check it itself
                 # but throw it into deps for later comparing against

--- a/pythonforandroid/prerequisites.py
+++ b/pythonforandroid/prerequisites.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-import sys
-import platform
 import os
-import subprocess
+import platform
 import shutil
+import subprocess
+import sys
+
 from pythonforandroid.logger import info, warning, error
+from pythonforandroid.util import ensure_dir
 
 
 class Prerequisite(object):
@@ -247,13 +249,7 @@ class JDKPrerequisite(Prerequisite):
                 "~/Library/Java/JavaVirtualMachines"
             )
             info(f"Extracting {filename} to {user_library_java_path}")
-            subprocess.check_output(
-                [
-                    "mkdir",
-                    "-p",
-                    user_library_java_path,
-                ],
-            )
+            ensure_dir(user_library_java_path)
             subprocess.check_output(
                 ["tar", "xzf", f"/tmp/{filename}", "-C", user_library_java_path],
             )

--- a/pythonforandroid/pythonpackage.py
+++ b/pythonforandroid/pythonpackage.py
@@ -34,6 +34,7 @@
 
 
 import functools
+from io import open  # needed for python 2
 import os
 import shutil
 import subprocess
@@ -41,13 +42,14 @@ import sys
 import tarfile
 import tempfile
 import time
-import zipfile
-from io import open  # needed for python 2
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urlparse
+import zipfile
 
 import toml
 import build.util
+
+from pythonforandroid.util import rmdir, ensure_dir
 
 
 def transform_dep_for_pip(dependency):
@@ -113,7 +115,7 @@ def extract_metainfo_files_from_package(
 
         _extract_metainfo_files_from_package_unsafe(package, output_folder)
     finally:
-        shutil.rmtree(temp_folder)
+        rmdir(temp_folder)
 
 
 def _get_system_python_executable():
@@ -314,7 +316,7 @@ def get_package_as_folder(dependency):
             )
 
         # Create download subfolder:
-        os.mkdir(os.path.join(venv_path, "download"))
+        ensure_dir(os.path.join(venv_path, "download"))
 
         # Write a requirements.txt with our package and download:
         with open(os.path.join(venv_path, "requirements.txt"),
@@ -394,11 +396,11 @@ def get_package_as_folder(dependency):
         # Copy result to new dedicated folder so we can throw away
         # our entire virtualenv nonsense after returning:
         result_path = tempfile.mkdtemp()
-        shutil.rmtree(result_path)
+        rmdir(result_path)
         shutil.copytree(result_folder_or_file, result_path)
         return (dl_type, result_path)
     finally:
-        shutil.rmtree(venv_parent)
+        rmdir(venv_parent)
 
 
 def _extract_metainfo_files_from_package_unsafe(
@@ -458,7 +460,7 @@ def _extract_metainfo_files_from_package_unsafe(
         shutil.copyfile(metadata_path, os.path.join(output_path, "METADATA"))
     finally:
         if clean_up_path:
-            shutil.rmtree(path)
+            rmdir(path)
 
 
 def is_filesystem_path(dep):
@@ -576,7 +578,7 @@ def _extract_info_from_package(dependency,
 
             return list(set(requirements))  # remove duplicates
     finally:
-        shutil.rmtree(output_folder)
+        rmdir(output_folder)
 
 
 package_name_cache = dict()

--- a/pythonforandroid/recipes/ifaddrs/__init__.py
+++ b/pythonforandroid/recipes/ifaddrs/__init__.py
@@ -1,10 +1,13 @@
 """ ifaddrs for Android
 """
-from os.path import join, exists
+from os.path import join
+
 import sh
-from pythonforandroid.logger import info, shprint
+
+from pythonforandroid.logger import shprint
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 from pythonforandroid.toolchain import current_directory
+from pythonforandroid.util import ensure_dir
 
 
 class IFAddrRecipe(CompiledComponentsPythonRecipe):
@@ -19,9 +22,7 @@ class IFAddrRecipe(CompiledComponentsPythonRecipe):
     def prebuild_arch(self, arch):
         """Make the build and target directories"""
         path = self.get_build_dir(arch.arch)
-        if not exists(path):
-            info("creating {}".format(path))
-            shprint(sh.mkdir, '-p', path)
+        ensure_dir(path)
 
     def build_arch(self, arch):
         """simple shared compile"""
@@ -30,9 +31,7 @@ class IFAddrRecipe(CompiledComponentsPythonRecipe):
                 self.get_build_dir(arch.arch),
                 join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Lib'),
                 join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include')):
-            if not exists(path):
-                info("creating {}".format(path))
-                shprint(sh.mkdir, '-p', path)
+            ensure_dir(path)
         cli = env['CC'].split()[0]
         # makes sure first CC command is the compiler rather than ccache, refs:
         # https://github.com/kivy/python-for-android/issues/1398

--- a/pythonforandroid/recipes/lapack/__init__.py
+++ b/pythonforandroid/recipes/lapack/__init__.py
@@ -11,7 +11,7 @@ from os.path import join
 import sh
 import shutil
 from os import environ
-from pythonforandroid.util import build_platform
+from pythonforandroid.util import build_platform, rmdir
 
 arch_to_sysroot = {'armeabi': 'arm', 'armeabi-v7a': 'arm', 'arm64-v8a': 'arm64'}
 
@@ -57,7 +57,8 @@ class LapackRecipe(Recipe):
         with current_directory(build_target):
             env = self.get_recipe_env(arch)
             ndk_dir = environ["LEGACY_NDK"]
-            shprint(sh.rm, '-rf', 'CMakeFiles/', 'CMakeCache.txt', _env=env)
+            rmdir('CMakeFiles')
+            shprint(sh.rm, '-f', 'CMakeCache.txt', _env=env)
             opts = [
                     '-DCMAKE_SYSTEM_NAME=Android',
                     '-DCMAKE_POSITION_INDEPENDENT_CODE=1',

--- a/pythonforandroid/recipes/libglob/__init__.py
+++ b/pythonforandroid/recipes/libglob/__init__.py
@@ -2,11 +2,14 @@
     android libglob
     available via '-lglob' LDFLAG
 """
-from os.path import exists, join
+from os.path import join
+
+import sh
+
+from pythonforandroid.logger import shprint
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.toolchain import current_directory
-from pythonforandroid.logger import info, shprint
-import sh
+from pythonforandroid.util import ensure_dir
 
 
 class LibGlobRecipe(Recipe):
@@ -32,9 +35,7 @@ class LibGlobRecipe(Recipe):
     def prebuild_arch(self, arch):
         """Make the build and target directories"""
         path = self.get_build_dir(arch.arch)
-        if not exists(path):
-            info("creating {}".format(path))
-            shprint(sh.mkdir, '-p', path)
+        ensure_dir(path)
 
     def build_arch(self, arch):
         """simple shared compile"""
@@ -43,9 +44,7 @@ class LibGlobRecipe(Recipe):
                 self.get_build_dir(arch.arch),
                 join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Lib'),
                 join(self.ctx.python_recipe.get_build_dir(arch.arch), 'Include')):
-            if not exists(path):
-                info("creating {}".format(path))
-                shprint(sh.mkdir, '-p', path)
+            ensure_dir(path)
         cli = env['CC'].split()[0]
         # makes sure first CC command is the compiler rather than ccache, refs:
         # https://github.com/kivy/python-for-android/issues/1399

--- a/pythonforandroid/recipes/libmysqlclient/__init__.py
+++ b/pythonforandroid/recipes/libmysqlclient/__init__.py
@@ -26,7 +26,7 @@ class LibmysqlclientRecipe(Recipe):
         env = self.get_recipe_env(arch)
         with current_directory(join(self.get_build_dir(arch.arch), 'libmysqlclient')):
             shprint(sh.cp, '-t', '.', join(self.get_recipe_dir(), 'p4a.cmake'))
-            # shprint(sh.mkdir, 'Platform')
+            # ensure_dir('Platform')
             # shprint(sh.cp, '-t', 'Platform', join(self.get_recipe_dir(), 'Linux.cmake'))
             shprint(sh.rm, '-f', 'CMakeCache.txt')
             shprint(sh.cmake, '-G', 'Unix Makefiles',

--- a/pythonforandroid/recipes/libtorrent/__init__.py
+++ b/pythonforandroid/recipes/libtorrent/__init__.py
@@ -1,8 +1,11 @@
-from pythonforandroid.toolchain import Recipe, shprint, shutil, current_directory
 from multiprocessing import cpu_count
-from os.path import join, basename
 from os import listdir, walk
+from os.path import join, basename
+import shutil
+
 import sh
+
+from pythonforandroid.toolchain import Recipe, shprint, current_directory
 
 # This recipe builds libtorrent with Python bindings
 # It depends on Boost.Build and the source of several Boost libraries present

--- a/pythonforandroid/recipes/opencv/__init__.py
+++ b/pythonforandroid/recipes/opencv/__init__.py
@@ -1,9 +1,11 @@
-from os.path import join
-import sh
-from pythonforandroid.recipe import NDKRecipe
-from pythonforandroid.util import current_directory
-from pythonforandroid.logger import shprint
 from multiprocessing import cpu_count
+from os.path import join
+
+import sh
+
+from pythonforandroid.logger import shprint
+from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.util import current_directory, ensure_dir
 
 
 class OpenCVRecipe(NDKRecipe):
@@ -45,7 +47,7 @@ class OpenCVRecipe(NDKRecipe):
 
     def build_arch(self, arch):
         build_dir = join(self.get_build_dir(arch.arch), 'build')
-        shprint(sh.mkdir, '-p', build_dir)
+        ensure_dir(build_dir)
 
         opencv_extras = []
         if 'opencv_extras' in self.ctx.recipe_build_order:

--- a/pythonforandroid/recipes/sqlite3/__init__.py
+++ b/pythonforandroid/recipes/sqlite3/__init__.py
@@ -1,7 +1,8 @@
-from pythonforandroid.recipe import NDKRecipe
-from pythonforandroid.toolchain import shutil
 from os.path import join
-import sh
+import shutil
+
+from pythonforandroid.recipe import NDKRecipe
+from pythonforandroid.util import ensure_dir
 
 
 class Sqlite3Recipe(NDKRecipe):
@@ -16,7 +17,7 @@ class Sqlite3Recipe(NDKRecipe):
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)
         # Copy the Android make file
-        sh.mkdir('-p', join(self.get_build_dir(arch.arch), 'jni'))
+        ensure_dir(join(self.get_build_dir(arch.arch), 'jni'))
         shutil.copyfile(join(self.get_recipe_dir(), 'Android.mk'),
                         join(self.get_build_dir(arch.arch), 'jni/Android.mk'))
 

--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -1,7 +1,7 @@
 import os
-import shutil
 
 from pythonforandroid.recipe import CythonRecipe
+from pythonforandroid.util import rmdir
 
 
 class TwistedRecipe(CythonRecipe):
@@ -23,7 +23,7 @@ class TwistedRecipe(CythonRecipe):
         for item in os.walk(source_dir):
             if os.path.basename(item[0]) == 'test':
                 full_path = os.path.join(source_dir, item[0])
-                shutil.rmtree(full_path, ignore_errors=True)
+                rmdir(full_path, ignore_errors=True)
 
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)

--- a/pythonforandroid/recipes/zope_interface/__init__.py
+++ b/pythonforandroid/recipes/zope_interface/__init__.py
@@ -1,7 +1,8 @@
+from os.path import join
+
 from pythonforandroid.recipe import PythonRecipe
 from pythonforandroid.toolchain import current_directory
-from os.path import join
-import sh
+from pythonforandroid.util import rmdir
 
 
 class ZopeInterfaceRecipe(PythonRecipe):
@@ -25,11 +26,8 @@ class ZopeInterfaceRecipe(PythonRecipe):
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)
         with current_directory(self.get_build_dir(arch.arch)):
-            sh.rm(
-                '-rf',
-                'src/zope/interface/tests',
-                'src/zope/interface/common/tests',
-            )
+            rmdir('src/zope/interface/tests')
+            rmdir('src/zope/interface/common/tests')
 
 
 recipe = ZopeInterfaceRecipe()

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -16,7 +16,6 @@ from os import environ
 from os.path import (join, dirname, realpath, exists, expanduser, basename)
 import re
 import shlex
-import shutil
 import sys
 from sys import platform
 
@@ -42,7 +41,7 @@ from pythonforandroid.recipe import Recipe
 from pythonforandroid.recommendations import (
     RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API, print_recommendations)
 from pythonforandroid.util import (
-    current_directory, BuildInterruptingException, load_source)
+    current_directory, BuildInterruptingException, load_source, rmdir)
 
 user_dir = dirname(realpath(os.path.curdir))
 toolchain_dir = dirname(__file__)
@@ -831,18 +830,16 @@ class ToolchainCL:
         """Delete all compiled distributions in the internal distribution
         directory."""
         ctx = self.ctx
-        if exists(ctx.dist_dir):
-            shutil.rmtree(ctx.dist_dir)
+        rmdir(ctx.dist_dir)
 
     def clean_bootstrap_builds(self, _args):
         """Delete all the bootstrap builds."""
-        if exists(join(self.ctx.build_dir, 'bootstrap_builds')):
-            shutil.rmtree(join(self.ctx.build_dir, 'bootstrap_builds'))
+        rmdir(join(self.ctx.build_dir, 'bootstrap_builds'))
         # for bs in Bootstrap.all_bootstraps():
         #     bs = Bootstrap.get_bootstrap(bs, self.ctx)
         #     if bs.build_dir and exists(bs.build_dir):
         #         info('Cleaning build for {} bootstrap.'.format(bs.name))
-        #         shutil.rmtree(bs.build_dir)
+        #         rmdir(bs.build_dir)
 
     def clean_builds(self, _args):
         """Delete all build caches for each recipe, python-install, java code
@@ -853,13 +850,10 @@ class ToolchainCL:
         of a specific recipe.
         """
         ctx = self.ctx
-        if exists(ctx.build_dir):
-            shutil.rmtree(ctx.build_dir)
-        if exists(ctx.python_installs_dir):
-            shutil.rmtree(ctx.python_installs_dir)
+        rmdir(ctx.build_dir)
+        rmdir(ctx.python_installs_dir)
         libs_dir = join(self.ctx.build_dir, 'libs_collections')
-        if exists(libs_dir):
-            shutil.rmtree(libs_dir)
+        rmdir(libs_dir)
 
     def clean_recipe_build(self, args):
         """Deletes the build files of the given recipe.
@@ -889,14 +883,14 @@ class ToolchainCL:
             for package in args.recipes:
                 remove_path = join(ctx.packages_path, package)
                 if exists(remove_path):
-                    shutil.rmtree(remove_path)
+                    rmdir(remove_path)
                     info('Download cache removed for: "{}"'.format(package))
                 else:
                     warning('No download cache found for "{}", skipping'.format(
                         package))
         else:
             if exists(ctx.packages_path):
-                shutil.rmtree(ctx.packages_path)
+                rmdir(ctx.packages_path)
                 info('Download cache removed.')
             else:
                 print('No cache found at "{}"'.format(ctx.packages_path))

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -1,12 +1,15 @@
 import contextlib
+from fnmatch import fnmatch
+import logging
 from os.path import exists, join
 from os import getcwd, chdir, makedirs, walk
 from platform import uname
-import shutil
-from fnmatch import fnmatch
+from shutil import rmtree
 from tempfile import mkdtemp
+
 from pythonforandroid.logger import (logger, Err_Fore, error, info)
 
+LOGGER = logging.getLogger("p4a.util")
 
 build_platform = "{system}-{machine}".format(
     system=uname().system, machine=uname().machine
@@ -36,14 +39,9 @@ def temp_directory():
                               temp_dir, Err_Fore.RESET)))
         yield temp_dir
     finally:
-        shutil.rmtree(temp_dir)
+        rmtree(temp_dir)
         logger.debug(''.join((Err_Fore.CYAN, ' - temp directory deleted ',
                               temp_dir, Err_Fore.RESET)))
-
-
-def ensure_dir(filename):
-    if not exists(filename):
-        makedirs(filename)
 
 
 def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns):
@@ -106,3 +104,17 @@ def handle_build_exception(exception):
     if exception.instructions is not None:
         info('Instructions: {}'.format(exception.instructions))
     exit(1)
+
+
+def rmdir(dn, ignore_errors=False):
+    if not exists(dn):
+        return
+    LOGGER.debug("Remove directory and subdirectory {}".format(dn))
+    rmtree(dn, ignore_errors)
+
+
+def ensure_dir(dn):
+    if exists(dn):
+        return
+    LOGGER.debug("Create directory {0}".format(dn))
+    makedirs(dn)

--- a/tests/recipes/test_libmysqlclient.py
+++ b/tests/recipes/test_libmysqlclient.py
@@ -23,7 +23,7 @@ class TestLibmysqlclientRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
         mock_sh_rm,
     ):
         # We overwrite the base test method because we need
-        # to mock a little more (`sh.cp` and `sh.rm`)
+        # to mock a little more (`sh.cp` and rmdir)
         super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()

--- a/tests/recipes/test_openal.py
+++ b/tests/recipes/test_openal.py
@@ -50,7 +50,7 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
         mock_sh_cp,
     ):
         # We overwrite the base test method because we need to mock a little
-        # more with this recipe (`sh.cp` and `sh.rm`)
+        # more with this recipe.
         super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_cp.assert_called()

--- a/tests/recipes/test_openssl.py
+++ b/tests/recipes/test_openssl.py
@@ -23,7 +23,7 @@ class TestOpensslRecipe(BaseTestForMakeRecipe, unittest.TestCase):
         mock_sh_patch,
     ):
         # We overwrite the base test method because we need to mock a little
-        # more with this recipe (`sh.cp` and `sh.rm`)
+        # more with this recipe.
         super().test_build_arch()
         # make sure that the mocked methods are actually called
         mock_sh_patch.assert_called()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -352,12 +352,16 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
     @mock.patch("pythonforandroid.util.exists")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.bootstrap.listdir")
-    @mock.patch("pythonforandroid.bootstrap.sh.rm")
+    @mock.patch("pythonforandroid.bootstraps.sdl2.rmdir")
+    @mock.patch("pythonforandroid.bootstraps.service_only.rmdir")
+    @mock.patch("pythonforandroid.bootstraps.webview.rmdir")
     @mock.patch("pythonforandroid.bootstrap.sh.cp")
     def test_assemble_distribution(
         self,
         mock_sh_cp,
-        mock_sh_rm,
+        mock_rmdir1,
+        mock_rmdir2,
+        mock_rmdir3,
         mock_listdir,
         mock_chdir,
         mock_ensure_dir,
@@ -433,7 +437,6 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
             )
 
         # check that the other mocks we made are actually called
-        mock_sh_rm.assert_called()
         mock_sh_cp.assert_called()
         mock_chdir.assert_called()
         mock_listdir.assert_called()
@@ -558,11 +561,11 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
         mock_sh_print.assert_called()
 
     @mock.patch("pythonforandroid.bootstrap.listdir")
-    @mock.patch("pythonforandroid.bootstrap.sh.rm")
+    @mock.patch("pythonforandroid.bootstrap.rmdir")
     @mock.patch("pythonforandroid.bootstrap.sh.mv")
     @mock.patch("pythonforandroid.bootstrap.isdir")
     def test_bootstrap_fry_eggs(
-        self, mock_isdir, mock_sh_mv, mock_sh_rm, mock_listdir
+        self, mock_isdir, mock_sh_mv, mock_rmdir, mock_listdir
     ):
         mock_listdir.return_value = [
             "jnius",
@@ -590,7 +593,7 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
             ]
         )
         self.assertEqual(
-            mock_sh_rm.call_args[0][1], "pyjnius-1.2.1.dev0-py3.7.egg"
+            mock_rmdir.call_args[0][0], "pyjnius-1.2.1.dev0-py3.7.egg"
         )
         # check that the other mocks we made are actually called
         mock_isdir.assert_called()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -36,10 +36,10 @@ class TestBuildBasic(unittest.TestCase):
         modules = ["mymodule"]
         project_dir = None
         with mock.patch('pythonforandroid.build.info'), \
-                mock.patch('sh.Command'),\
-                mock.patch('pythonforandroid.build.open'),\
-                mock.patch('pythonforandroid.build.shprint'),\
-                mock.patch('pythonforandroid.build.current_directory'),\
+                mock.patch('sh.Command'), \
+                mock.patch('pythonforandroid.build.open'), \
+                mock.patch('pythonforandroid.build.shprint'), \
+                mock.patch('pythonforandroid.build.current_directory'), \
                 mock.patch('pythonforandroid.build.CythonRecipe') as m_CythonRecipe, \
                 mock.patch('pythonforandroid.build.project_has_setup_py') as m_project_has_setup_py, \
                 mock.patch('pythonforandroid.build.run_setuppy_install'):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -91,8 +91,8 @@ class TestDistribution(unittest.TestCase):
             self.ctx.bootstrap.distribution.dist_dir
         )
 
-    @mock.patch("pythonforandroid.distribution.rmtree")
-    def test_delete(self, mock_rmtree):
+    @mock.patch("pythonforandroid.distribution.rmdir")
+    def test_delete(self, mock_rmdir):
         """Test that method
         :meth:`~pythonforandroid.distribution.Distribution.delete` is
         called once with the proper arguments."""
@@ -100,7 +100,7 @@ class TestDistribution(unittest.TestCase):
             Bootstrap().get_bootstrap("sdl2", self.ctx)
         )
         self.ctx.bootstrap.distribution.delete()
-        mock_rmtree.assert_called_once_with(
+        mock_rmdir.assert_called_once_with(
             self.ctx.bootstrap.distribution.dist_dir
         )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,20 +21,20 @@ class TestUtil(unittest.TestCase):
         util.ensure_dir("fake_directory")
         mock_makedirs.assert_called_once_with("fake_directory")
 
-    @mock.patch("shutil.rmtree")
+    @mock.patch("pythonforandroid.util.rmtree")
     @mock.patch("pythonforandroid.util.mkdtemp")
-    def test_temp_directory(self, mock_mkdtemp, mock_shutil_rmtree):
+    def test_temp_directory(self, mock_mkdtemp, mock_rmtree):
         """
         Basic test for method :meth:`~pythonforandroid.util.temp_directory`. We
         perform this test by `mocking` the command `mkdtemp` and
-        `shutil.rmtree` and we make sure that those functions are called in the
+        `rmdir` and we make sure that those functions are called in the
         proper place.
         """
         mock_mkdtemp.return_value = "/temp/any_directory"
         with util.temp_directory():
             mock_mkdtemp.assert_called_once()
-            mock_shutil_rmtree.assert_not_called()
-        mock_shutil_rmtree.assert_called_once_with("/temp/any_directory")
+            mock_rmtree.assert_not_called()
+        mock_rmtree.assert_called_once_with("/temp/any_directory")
 
     @mock.patch("pythonforandroid.util.chdir")
     def test_current_directory(self, moch_chdir):


### PR DESCRIPTION
1) A new version of Flake8 dropped while I was submitting this PR. There are several inconsequential edits to unrelated files, because Flake8 held my tests at gunpoint until I did it.

2) When p4a wanted to create a directory, it used any of several different techniques:
	* it called os.mkdirs()
	* it called shutil.mkdir()
	* it called util.ensure_dir()
	* it called bootstraps.common.build.build.ensure_dir()
	* it called sh.mkdir()
	
The latter has terrible performance and isn't cross-platform.

* I modified util.ensure_dir() to log if and only if it made a change.
* I modified all directory creations to use util.ensure_dir().
* I removed any now unnecessary logs and existence checks from the code, so the clients are now simpler.

3) When p4a wants to remove a directory, it used any of several different techniques:
	* it called shutil.rmtree
	* it called sh.rm("-r")
	* it called subprocess.check_output(["mkdir"..])

The latter two have terrible performance and aren't cross-platform.
	
* I created util.rmdir(). It logs if and only if it makes a change.
* I modified all directory deletions (outside of test code) to use util.rmdir().
* I removed any now unnecessary logs and existence checks from the code, so the clients are now simpler.
* recipe.py had some weird code to delete then create then delete a folder. I simplified it to delete.

4) Whenever I had to touch the imports, I sorted them to make them PEP8 compliant.

5) A couple of the receipes (e.g. sqlite3) weirdly imported shutil indirectly, via toolchain, which caused a problem when toolchain stopped importing it (no longer required). Changed the recipe code to import shutil directly.

Note I only tackled two system calls; I didn't even look at removing single files. There are more to come, but I want to keep each review simple, and this one is already too complex.
