### PR TITLE
:rotating_light: linter fixes

### DIFF
--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -70,7 +70,6 @@ class Bootstrap:
     '''An Android project template, containing recipe stuff for
     compilation and templated fields for APK info.
     '''
-    name = ''
     jni_subdir = '/jni'
     ctx = None
 

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -77,11 +77,6 @@ class Context:
     # the Android project folder where everything ends up
     dist_dir = None
 
-    # where Android libs are cached after build
-    # but before being placed in dists
-    libs_dir = None
-    aars_dir = None
-
     # Whether setup.py or similar should be used if present:
     use_setup_py = False
 
@@ -109,6 +104,10 @@ class Context:
 
     @property
     def libs_dir(self):
+        """
+        where Android libs are cached after build
+        but before being placed in dists
+        """
         # Was previously hardcoded as self.build_dir/libs
         directory = join(self.build_dir, 'libs_collections',
                          self.bootstrap.distribution.name)

--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -45,7 +45,7 @@ def get_dependency_tuple_list_for_recipe(recipe, blacklist=None):
     """
     if blacklist is None:
         blacklist = set()
-    assert type(blacklist) == set
+    assert type(blacklist) is set
     if recipe.depends is None:
         dependencies = []
     else:
@@ -160,7 +160,7 @@ def obvious_conflict_checker(ctx, name_tuples, blacklist=None):
         current_to_be_added = list(to_be_added)
         to_be_added = []
         for (added_tuple, adding_recipe) in current_to_be_added:
-            assert type(added_tuple) == tuple
+            assert type(added_tuple) is tuple
             if len(added_tuple) > 1:
                 # No obvious commitment in what to add, don't check it itself
                 # but throw it into deps for later comparing against

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -36,10 +36,10 @@ class TestBuildBasic(unittest.TestCase):
         modules = ["mymodule"]
         project_dir = None
         with mock.patch('pythonforandroid.build.info'), \
-                mock.patch('sh.Command'),\
-                mock.patch('pythonforandroid.build.open'),\
-                mock.patch('pythonforandroid.build.shprint'),\
-                mock.patch('pythonforandroid.build.current_directory'),\
+                mock.patch('sh.Command'), \
+                mock.patch('pythonforandroid.build.open'), \
+                mock.patch('pythonforandroid.build.shprint'), \
+                mock.patch('pythonforandroid.build.current_directory'), \
                 mock.patch('pythonforandroid.build.CythonRecipe') as m_CythonRecipe, \
                 mock.patch('pythonforandroid.build.project_has_setup_py') as m_project_has_setup_py, \
                 mock.patch('pythonforandroid.build.run_setuppy_install'):


### PR DESCRIPTION
The errors were:
```
pythonforandroid/bootstrap.py:136:5: F811 redefinition of unused 'name' from line 73
pythonforandroid/build.py:111:5: F811 redefinition of unused 'libs_dir' from line 82
pythonforandroid/build.py:127:5: F811 redefinition of unused 'aars_dir' from line 83
pythonforandroid/graph.py:48:12: E721 do not compare types, for exact checks use `is`
pythonforandroid/graph.py:163:20: E721 do not compare types, for exact checks use `is`
tests/test_build.py:39:41: E231 missing whitespace after ','
tests/test_build.py:40:58: E231 missing whitespace after ','
tests/test_build.py:41:61: E231 missing whitespace after ','
tests/test_build.py:42:71: E231 missing whitespace after ','
```