### PR TITLE
Remove deprecated FlatDir in Gradle template

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -16,9 +16,6 @@ allprojects {
         {%- for repo in args.gradle_repositories %}
         {{repo}}
         {%- endfor %}
-        flatDir {
-            dirs 'libs'
-        }
     }
 }
 


### PR DESCRIPTION
When running Gradle, a warning is issued:

> [DEBUG]:   	**> Configure project :**
> [DEBUG]:   	WARNING:Using flatDir should be avoided because it doesn't support any meta-data formats.

I went to [Stack Overflow](https://stackoverflow.com/questions/68215302/using-flatdirs-should-be-avoided-because-it-doesnt-support-any-meta-data-format) to learn what the appropriate action was, and while the answers varied, they generally recommended removing the `flatDir` entry and adding a `jniLibs.srcDir[s]` entry to under `sourceSets`.

Examining the Gradle template, the `sourceSets` were already configured, so I simply removed the `flatDir` entry.

Confirmed that `flatDir` warnings are no longer logged, and builds are proceeding fine.