### PR TITLE
Use Python's touch() rather than shelling out.

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -16,9 +16,11 @@ try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
-from pythonforandroid.logger import (logger, info, warning, debug, shprint, info_main)
-from pythonforandroid.util import (current_directory, ensure_dir,
-                                   BuildInterruptingException, rmdir, move)
+from pythonforandroid.logger import (
+    logger, info, warning, debug, shprint, info_main)
+from pythonforandroid.util import (
+    current_directory, ensure_dir, BuildInterruptingException, rmdir, move,
+    touch)
 from pythonforandroid.util import load_source as import_recipe
 
 
@@ -395,7 +397,7 @@ class Recipe(metaclass=RecipeMeta):
 
                 shprint(sh.rm, '-f', marker_filename)
                 self.download_file(self.versioned_url, filename)
-                shprint(sh.touch, marker_filename)
+                touch(marker_filename)
 
                 if exists(filename) and isfile(filename):
                     for alg, expected_digest in expected_digests.items():
@@ -530,7 +532,7 @@ class Recipe(metaclass=RecipeMeta):
                         patch.format(version=self.version, arch=arch.arch),
                         arch.arch, build_dir=build_dir)
 
-            shprint(sh.touch, join(build_dir, '.patched'))
+            touch(join(build_dir, '.patched'))
 
     def should_build(self, arch):
         '''Should perform any necessary test and return True only if it needs

--- a/pythonforandroid/recipes/protobuf_cpp/__init__.py
+++ b/pythonforandroid/recipes/protobuf_cpp/__init__.py
@@ -1,12 +1,13 @@
+from multiprocessing import cpu_count
+import os
+from os.path import exists, join
+from pythonforandroid.toolchain import info
+import sh
+import sys
+
 from pythonforandroid.recipe import CppCompiledComponentsPythonRecipe
 from pythonforandroid.logger import shprint, info_notify
-from pythonforandroid.util import current_directory
-from os.path import exists, join
-import sh
-from multiprocessing import cpu_count
-from pythonforandroid.toolchain import info
-import sys
-import os
+from pythonforandroid.util import current_directory, touch
 
 
 class ProtobufCppRecipe(CppCompiledComponentsPythonRecipe):
@@ -30,7 +31,7 @@ class ProtobufCppRecipe(CppCompiledComponentsPythonRecipe):
         patch_mark = join(self.get_build_dir(arch.arch), '.protobuf-patched')
         if self.ctx.python_recipe.name == 'python3' and not exists(patch_mark):
             self.apply_patch('fix-python3-compatibility.patch', arch.arch)
-            shprint(sh.touch, patch_mark)
+            touch(patch_mark)
 
         # During building, host needs to transpile .proto files to .py
         # ideally with the same version as protobuf runtime, or with an older one.

--- a/pythonforandroid/recipes/reportlab/__init__.py
+++ b/pythonforandroid/recipes/reportlab/__init__.py
@@ -1,8 +1,9 @@
 import os
 import sh
+
+from pythonforandroid.logger import info
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
-from pythonforandroid.util import (current_directory, ensure_dir)
-from pythonforandroid.logger import (info, shprint)
+from pythonforandroid.util import current_directory, ensure_dir, touch
 
 
 class ReportLabRecipe(CompiledComponentsPythonRecipe):
@@ -28,7 +29,7 @@ class ReportLabRecipe(CompiledComponentsPythonRecipe):
 
             # Apply patches:
             self.apply_patch('patches/fix-setup.patch', arch.arch)
-            shprint(sh.touch, os.path.join(recipe_dir, '.patched'))
+            touch(os.path.join(recipe_dir, '.patched'))
             ft = self.get_recipe('freetype', self.ctx)
             ft_dir = ft.get_build_dir(arch.arch)
             ft_lib_dir = os.environ.get('_FT_LIB_', os.path.join(ft_dir, 'objs', '.libs'))

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -3,6 +3,7 @@ from fnmatch import fnmatch
 import logging
 from os.path import exists, join
 from os import getcwd, chdir, makedirs, walk
+from pathlib import Path
 from platform import uname
 import shutil
 from tempfile import mkdtemp
@@ -123,3 +124,7 @@ def ensure_dir(dn):
 def move(source, destination):
     LOGGER.debug("Moving {} to {}".format(source, destination))
     shutil.move(source, destination)
+
+
+def touch(filename):
+    Path(filename).touch()

--- a/tests/recipes/test_reportlab.py
+++ b/tests/recipes/test_reportlab.py
@@ -30,7 +30,7 @@ class TestReportLabRecipe(RecipeCtx, unittest.TestCase):
         # these sh commands are not relevant for the test and need to be mocked
         with \
                 patch('sh.patch'), \
-                patch('sh.touch'), \
+                patch('pythonforandroid.recipe.touch'), \
                 patch('sh.unzip'), \
                 patch('os.path.isfile'):
             self.recipe.prebuild_arch(self.arch)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -134,7 +134,7 @@ class TestRecipe(unittest.TestCase):
         with (
                 patch_logger_debug()) as m_debug, (
                 mock.patch.object(Recipe, 'download_file')) as m_download_file, (
-                mock.patch('pythonforandroid.recipe.sh.touch')) as m_touch, (
+                mock.patch('pythonforandroid.recipe.touch')) as m_touch, (
                 tempfile.TemporaryDirectory()) as temp_dir:
             recipe.ctx.setup_dirs(temp_dir)
             recipe.download()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -178,3 +178,12 @@ class TestUtil(unittest.TestCase):
             m_logger.debug.assert_called()
             m_logger.error.assert_not_called()
             m_logger.reset_mock()
+
+    def test_touch(self):
+        # Just checking the new file case.
+        # Assume the existing file timestamp case will work if this does.
+        with TemporaryDirectory() as base_dir:
+            new_file_path = Path(base_dir) / "new_file"
+            assert not new_file_path.exists()
+            util.touch(new_file_path)
+            assert new_file_path.exists()


### PR DESCRIPTION
Existing code shells out to run the `touch` Unix command. This can be done faster (and cross-platform) with `pathlib`'s touch method.

* Created a utility to accept string paths or pathlib paths and applies touch.
* Created test for it.
* Update all instances to use it, and updated their tests.
* Where imports were touched, made them PEP8 compliant.