### PR TITLE
Update Lottie player version

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -125,7 +125,7 @@ dependencies {
     {%- endfor %}
     {%- endif %}
     {% if args.presplash_lottie %}
-    implementation 'com.airbnb.android:lottie:3.4.0'
+    implementation 'com.airbnb.android:lottie:6.1.0'
     {%- endif %}
 }
 


### PR DESCRIPTION
### Description

Updates the Lottie player version to [the latest 6.1.0](https://github.com/airbnb/lottie-android/releases).

The current version in use (3.4.0) is from 2020, and among the many issues that have already have been fixed since then, it does not allow for color updates in keyframes[0], which is a very common operation when changing Lotties that already exist out there in the public domain.

[0] https://stackoverflow.com/questions/74912770/lottie-animation-error-after-change-color-of-animation
