### PR TITLE
Remove `distutils` usage, as is not available anymore on Python `3.12`

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -1,7 +1,7 @@
-from distutils.spawn import find_executable
 from os import environ
 from os.path import join
 from multiprocessing import cpu_count
+import shutil
 
 from pythonforandroid.recipe import Recipe
 from pythonforandroid.util import BuildInterruptingException, build_platform
@@ -172,7 +172,7 @@ class Arch:
 
         # Compiler: `CC` and `CXX` (and make sure that the compiler exists)
         env['PATH'] = self.ctx.env['PATH']
-        cc = find_executable(self.clang_exe, path=env['PATH'])
+        cc = shutil.which(self.clang_exe, path=env['PATH'])
         if cc is None:
             print('Searching path are: {!r}'.format(env['PATH']))
             raise BuildInterruptingException(

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -17,11 +17,10 @@ import tarfile
 import tempfile
 import time
 
-from distutils.version import LooseVersion
 from fnmatch import fnmatch
 import jinja2
 
-from pythonforandroid.util import rmdir, ensure_dir
+from pythonforandroid.util import rmdir, ensure_dir, max_build_tool_version
 
 
 def get_dist_info_for(key, error_if_missing=True):
@@ -512,9 +511,7 @@ main.py that loads it.''')
     # Try to build with the newest available build tools
     ignored = {".DS_Store", ".ds_store"}
     build_tools_versions = [x for x in listdir(join(sdk_dir, 'build-tools')) if x not in ignored]
-    build_tools_versions = sorted(build_tools_versions,
-                                  key=LooseVersion)
-    build_tools_version = build_tools_versions[-1]
+    build_tools_version = max_build_tool_version(build_tools_versions)
 
     # Folder name for launcher (used by SDL2 bootstrap)
     url_scheme = 'kivy'

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -16,6 +16,9 @@ try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
+
+import packaging.version
+
 from pythonforandroid.logger import (
     logger, info, warning, debug, shprint, info_main)
 from pythonforandroid.util import (
@@ -1145,8 +1148,8 @@ class TargetPythonRecipe(Recipe):
 
     @property
     def major_minor_version_string(self):
-        from distutils.version import LooseVersion
-        return '.'.join([str(v) for v in LooseVersion(self.version).version[:2]])
+        parsed_version = packaging.version.parse(self.version)
+        return f"{parsed_version.major}.{parsed_version.minor}"
 
     def create_python_bundle(self, dirn, arch):
         """

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -24,7 +24,7 @@ from sys import platform
 from pythonforandroid.checkdependencies import check
 check()
 
-from packaging.version import Version, InvalidVersion
+from packaging.version import Version
 import sh
 
 from pythonforandroid import __version__
@@ -41,7 +41,12 @@ from pythonforandroid.recipe import Recipe
 from pythonforandroid.recommendations import (
     RECOMMENDED_NDK_API, RECOMMENDED_TARGET_API, print_recommendations)
 from pythonforandroid.util import (
-    current_directory, BuildInterruptingException, load_source, rmdir)
+    current_directory,
+    BuildInterruptingException,
+    load_source,
+    rmdir,
+    max_build_tool_version,
+)
 
 user_dir = dirname(realpath(os.path.curdir))
 toolchain_dir = dirname(__file__)
@@ -1009,18 +1014,7 @@ class ToolchainCL:
             self.hook("before_apk_assemble")
             build_tools_versions = os.listdir(join(ctx.sdk_dir,
                                                    'build-tools'))
-
-            def sort_key(version_text):
-                try:
-                    # Historically, Android build release candidates have had
-                    # spaces in the version number.
-                    return Version(version_text.replace(" ", ""))
-                except InvalidVersion:
-                    # Put badly named versions at worst position.
-                    return Version("0")
-
-            build_tools_versions.sort(key=sort_key)
-            build_tools_version = build_tools_versions[-1]
+            build_tools_version = max_build_tool_version(build_tools_versions)
             info(('Detected highest available build tools '
                   'version to be {}').format(build_tools_version))
 

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -8,6 +8,8 @@ from platform import uname
 import shutil
 from tempfile import mkdtemp
 
+import packaging.version
+
 from pythonforandroid.logger import (logger, Err_Fore, error, info)
 
 LOGGER = logging.getLogger("p4a.util")
@@ -128,3 +130,36 @@ def move(source, destination):
 
 def touch(filename):
     Path(filename).touch()
+
+
+def build_tools_version_sort_key(
+    version_string: str,
+) -> packaging.version.Version:
+    """
+    Returns a packaging.version.Version object for comparison purposes.
+    It includes canonicalization of the version string to allow for
+    comparison of versions with spaces in them (historically, RC candidates)
+
+    If the version string is invalid, it returns a version object with
+    version 0, which will be sorted at worst position.
+    """
+
+    try:
+        # Historically, Android build release candidates have had
+        # spaces in the version number.
+        return packaging.version.Version(version_string.replace(" ", ""))
+    except packaging.version.InvalidVersion:
+        # Put badly named versions at worst position.
+        return packaging.version.Version("0")
+
+
+def max_build_tool_version(
+    build_tools_versions: list,
+) -> str:
+    """
+    Returns the maximum build tools version from a list of build tools
+    versions. It uses the :meth:`build_tools_version_sort_key` function to
+    canonicalize the version strings and then returns the maximum version.
+    """
+
+    return max(build_tools_versions, key=build_tools_version_sort_key)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ data_files = []
 install_reqs = [
     'appdirs', 'colorama>=0.3.3', 'jinja2',
     'sh>=1.10, <2.0; sys_platform!="win32"',
-    'build', 'toml', 'packaging',
+    'build', 'toml', 'packaging', 'setuptools'
 ]
 # (build and toml are used by pythonpackage.py)
 

--- a/testapps/on_device_unit_tests/setup.py
+++ b/testapps/on_device_unit_tests/setup.py
@@ -32,8 +32,8 @@ to build the supported app modes::
 
 import os
 import sys
-from distutils.core import setup
-from setuptools import find_packages
+
+from setuptools import setup, find_packages
 
 # define a basic test app, which can be override passing the proper args to cli
 options = {

--- a/testapps/setup_testapp_python3_sqlite_openssl.py
+++ b/testapps/setup_testapp_python3_sqlite_openssl.py
@@ -1,6 +1,4 @@
-
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import setup, find_packages
 
 options = {'apk': {'requirements': 'requests,peewee,sdl2,pyjnius,kivy,python3',
                    'android-api': 27,

--- a/testapps/setup_vispy.py
+++ b/testapps/setup_vispy.py
@@ -1,6 +1,4 @@
-
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import setup, find_packages
 
 options = {'apk': {'debug': None,
                    'requirements': 'python3,vispy',

--- a/testapps/testlauncher_setup/sdl2.py
+++ b/testapps/testlauncher_setup/sdl2.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import setup
 
 options = {'apk': {'debug': None,
                    'bootstrap': 'sdl2',

--- a/testapps/testlauncherreboot_setup/sdl2.py
+++ b/testapps/testlauncherreboot_setup/sdl2.py
@@ -22,11 +22,10 @@ docker run \
 
 # pylint: disable=import-error,no-name-in-module
 from subprocess import Popen
-from distutils.core import setup
 from os import listdir
 from os.path import join, dirname, abspath, exists
 from pprint import pprint
-from setuptools import find_packages
+from setuptools import setup, find_packages
 
 ROOT = dirname(abspath(__file__))
 LAUNCHER = join(ROOT, 'launcherapp')

--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -35,10 +35,10 @@ class BaseTestForMakeRecipe(RecipeCtx):
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_get_recipe_env(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_check_recipe_choices,
     ):
@@ -46,7 +46,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
         Test that get_recipe_env contains some expected arch flags and that
         some internal methods has been called.
         """
-        mock_find_executable.return_value = self.expected_compiler.format(
+        mock_shutil_which.return_value = self.expected_compiler.format(
                 android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
         mock_check_recipe_choices.return_value = sorted(
@@ -67,19 +67,19 @@ class BaseTestForMakeRecipe(RecipeCtx):
 
         # make sure that the mocked methods are actually called
         mock_ensure_dir.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()
         mock_check_recipe_choices.assert_called()
 
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
     ):
-        mock_find_executable.return_value = self.expected_compiler.format(
+        mock_shutil_which.return_value = self.expected_compiler.format(
                 android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
 
@@ -101,7 +101,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
         mock_make.assert_called()
         mock_ensure_dir.assert_called()
         mock_current_directory.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()
 
 
 class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
@@ -116,14 +116,14 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
 
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
     ):
-        mock_find_executable.return_value = self.expected_compiler.format(
+        mock_shutil_which.return_value = self.expected_compiler.format(
                 android_ndk=self.ctx._ndk_dir, system=system().lower()
         )
 
@@ -141,4 +141,4 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
         mock_make.assert_called()
         mock_ensure_dir.assert_called()
         mock_current_directory.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()

--- a/tests/recipes/test_icu.py
+++ b/tests/recipes/test_icu.py
@@ -33,17 +33,17 @@ class TestIcuRecipe(RecipeCtx, unittest.TestCase):
     @mock.patch("pythonforandroid.bootstrap.sh.Command")
     @mock.patch("pythonforandroid.recipes.icu.sh.make")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_sh_make,
         mock_sh_command,
         mock_chdir,
         mock_makedirs,
     ):
-        mock_find_executable.return_value = os.path.join(
+        mock_shutil_which.return_value = os.path.join(
             self.ctx._ndk_dir,
             f"toolchains/llvm/prebuilt/{self.ctx.ndk.host_tag}/bin/clang",
         )
@@ -89,10 +89,10 @@ class TestIcuRecipe(RecipeCtx, unittest.TestCase):
                 )
         mock_makedirs.assert_called()
 
-        mock_find_executable.assert_called_once()
+        mock_shutil_which.assert_called_once()
         self.assertEqual(
-            mock_find_executable.call_args[0][0],
-            mock_find_executable.return_value,
+            mock_shutil_which.call_args[0][0],
+            mock_shutil_which.return_value,
         )
 
     @mock.patch("pythonforandroid.recipes.icu.sh.cp")

--- a/tests/recipes/test_libgeos.py
+++ b/tests/recipes/test_libgeos.py
@@ -12,10 +12,10 @@ class TestLibgeosRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.util.makedirs")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_makedirs,

--- a/tests/recipes/test_libmysqlclient.py
+++ b/tests/recipes/test_libmysqlclient.py
@@ -13,10 +13,10 @@ class TestLibmysqlclientRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.libmysqlclient.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_cp,

--- a/tests/recipes/test_libpq.py
+++ b/tests/recipes/test_libpq.py
@@ -13,10 +13,10 @@ class TestLibpqRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.libpq.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_cp,

--- a/tests/recipes/test_libvorbis.py
+++ b/tests/recipes/test_libvorbis.py
@@ -14,10 +14,10 @@ class TestLibvorbisRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.libvorbis.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_cp,

--- a/tests/recipes/test_openal.py
+++ b/tests/recipes/test_openal.py
@@ -14,17 +14,17 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.openal.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_prebuild_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_cp,
         mock_sh_make,
         mock_sh_cmake,
     ):
-        mock_find_executable.return_value = (
+        mock_shutil_which.return_value = (
             "/opt/android/android-ndk/toolchains/"
             "llvm/prebuilt/linux-x86_64/bin/clang"
         )
@@ -33,7 +33,7 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
         # make sure that the mocked methods are actually called
         mock_ensure_dir.assert_called()
         mock_current_directory.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()
         mock_sh_cp.assert_called()
         mock_sh_make.assert_called()
         mock_sh_cmake.assert_called()
@@ -41,10 +41,10 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.openal.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_cp,

--- a/tests/recipes/test_openssl.py
+++ b/tests/recipes/test_openssl.py
@@ -14,10 +14,10 @@ class TestOpensslRecipe(BaseTestForMakeRecipe, unittest.TestCase):
     @mock.patch("pythonforandroid.recipes.openssl.sh.patch")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_current_directory,
         mock_sh_patch,

--- a/tests/recipes/test_pandas.py
+++ b/tests/recipes/test_pandas.py
@@ -14,10 +14,10 @@ class TestPandasRecipe(RecipeCtx, unittest.TestCase):
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_get_recipe_env(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_check_recipe_choices,
     ):
@@ -27,7 +27,7 @@ class TestPandasRecipe(RecipeCtx, unittest.TestCase):
         returns the expected flags
         """
 
-        mock_find_executable.return_value = (
+        mock_shutil_which.return_value = (
             "/opt/android/android-ndk/toolchains/"
             "llvm/prebuilt/linux-x86_64/bin/clang"
         )
@@ -43,5 +43,5 @@ class TestPandasRecipe(RecipeCtx, unittest.TestCase):
 
         # make sure that the mocked methods are actually called
         mock_ensure_dir.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()
         mock_check_recipe_choices.assert_called()

--- a/tests/recipes/test_pyicu.py
+++ b/tests/recipes/test_pyicu.py
@@ -12,10 +12,10 @@ class TestPyIcuRecipe(RecipeCtx, unittest.TestCase):
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_get_recipe_env(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_check_recipe_choices,
     ):
@@ -26,7 +26,7 @@ class TestPyIcuRecipe(RecipeCtx, unittest.TestCase):
         """
         icu_recipe = Recipe.get_recipe("icu", self.ctx)
 
-        mock_find_executable.return_value = (
+        mock_shutil_which.return_value = (
             "/opt/android/android-ndk/toolchains/"
             "llvm/prebuilt/linux-x86_64/bin/clang"
         )
@@ -44,5 +44,5 @@ class TestPyIcuRecipe(RecipeCtx, unittest.TestCase):
 
         # make sure that the mocked methods are actually called
         mock_ensure_dir.assert_called()
-        mock_find_executable.assert_called()
+        mock_shutil_which.assert_called()
         mock_check_recipe_choices.assert_called()

--- a/tests/recipes/test_python3.py
+++ b/tests/recipes/test_python3.py
@@ -60,10 +60,10 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
         )
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_get_recipe_env(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_check_recipe_choices,
     ):
         """
@@ -71,7 +71,7 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
         :meth:`~pythonforandroid.recipes.python3.Python3Recipe.get_recipe_env`
         returns the expected flags
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_check_recipe_choices.return_value = sorted(
             self.ctx.recipe_build_order
         )
@@ -91,13 +91,13 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
     # and `set_libs_flags`, since these calls are tested separately
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.util.makedirs")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_build_arch(
             self,
-            mock_find_executable,
+            mock_shutil_which,
             mock_makedirs,
             mock_chdir):
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
 
         # specific `build_arch` mocks
         with mock.patch(

--- a/tests/test_archs.py
+++ b/tests/test_archs.py
@@ -92,9 +92,9 @@ class TestArchARM(ArchSetUpBaseClass, unittest.TestCase):
     will be used to perform tests for :class:`~pythonforandroid.archs.ArchARM`.
     """
 
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    def test_arch_arm(self, mock_ensure_dir, mock_find_executable):
+    def test_arch_arm(self, mock_ensure_dir, mock_shutil_which):
         """
         Test that class :class:`~pythonforandroid.archs.ArchARM` returns some
         expected attributes and environment variables.
@@ -103,13 +103,13 @@ class TestArchARM(ArchSetUpBaseClass, unittest.TestCase):
             Here we mock two methods:
 
                 - `ensure_dir` because we don't want to create any directory
-                - `find_executable` because otherwise we will
+                - `shutil.which` because otherwise we will
                   get an error when trying to find the compiler (we are setting
                   some fake paths for our android sdk and ndk so probably will
                   not exist)
 
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_ensure_dir.return_value = True
 
         arch = ArchARM(self.ctx)
@@ -126,8 +126,8 @@ class TestArchARM(ArchSetUpBaseClass, unittest.TestCase):
             expected_env_gcc_keys, set(env.keys()) & expected_env_gcc_keys
         )
 
-        # check find_executable calls
-        mock_find_executable.assert_called_once_with(
+        # check shutil.which calls
+        mock_shutil_which.assert_called_once_with(
             self.expected_compiler, path=environ["PATH"]
         )
 
@@ -163,7 +163,7 @@ class TestArchARM(ArchSetUpBaseClass, unittest.TestCase):
         self.assertEqual(env["NDK_CCACHE"], "/usr/bin/ccache")
 
         # Check exception in case that CC is not found
-        mock_find_executable.return_value = None
+        mock_shutil_which.return_value = None
         with self.assertRaises(BuildInterruptingException) as e:
             arch.get_env()
         self.assertEqual(
@@ -182,10 +182,10 @@ class TestArchARMv7a(ArchSetUpBaseClass, unittest.TestCase):
     :class:`~pythonforandroid.archs.ArchARMv7_a`.
     """
 
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     @mock.patch("pythonforandroid.build.ensure_dir")
     def test_arch_armv7a(
-        self, mock_ensure_dir, mock_find_executable
+        self, mock_ensure_dir, mock_shutil_which
     ):
         """
         Test that class :class:`~pythonforandroid.archs.ArchARMv7_a` returns
@@ -197,7 +197,7 @@ class TestArchARMv7a(ArchSetUpBaseClass, unittest.TestCase):
             This has to be done because here we tests the `get_env` with clang
 
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_ensure_dir.return_value = True
 
         arch = ArchARMv7_a(self.ctx)
@@ -207,8 +207,8 @@ class TestArchARMv7a(ArchSetUpBaseClass, unittest.TestCase):
         self.assertEqual(arch.target, "armv7a-linux-androideabi21")
 
         env = arch.get_env()
-        # check find_executable calls
-        mock_find_executable.assert_called_once_with(
+        # check shutil.which calls
+        mock_shutil_which.assert_called_once_with(
             self.expected_compiler, path=environ["PATH"]
         )
 
@@ -241,9 +241,9 @@ class TestArchX86(ArchSetUpBaseClass, unittest.TestCase):
     will be used to perform tests for :class:`~pythonforandroid.archs.Archx86`.
     """
 
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    def test_arch_x86(self, mock_ensure_dir, mock_find_executable):
+    def test_arch_x86(self, mock_ensure_dir, mock_shutil_which):
         """
         Test that class :class:`~pythonforandroid.archs.Archx86` returns
         some expected attributes and environment variables.
@@ -255,7 +255,7 @@ class TestArchX86(ArchSetUpBaseClass, unittest.TestCase):
             which is probably the case. This has to be done because here we
             tests the `get_env` with clang
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_ensure_dir.return_value = True
 
         arch = Archx86(self.ctx)
@@ -265,8 +265,8 @@ class TestArchX86(ArchSetUpBaseClass, unittest.TestCase):
         self.assertEqual(arch.target, "i686-linux-android21")
 
         env = arch.get_env()
-        # check find_executable calls
-        mock_find_executable.assert_called_once_with(
+        # check shutil.which calls
+        mock_shutil_which.assert_called_once_with(
             self.expected_compiler, path=environ["PATH"]
         )
 
@@ -284,10 +284,10 @@ class TestArchX86_64(ArchSetUpBaseClass, unittest.TestCase):
     :class:`~pythonforandroid.archs.Archx86_64`.
     """
 
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     @mock.patch("pythonforandroid.build.ensure_dir")
     def test_arch_x86_64(
-        self, mock_ensure_dir, mock_find_executable
+        self, mock_ensure_dir, mock_shutil_which
     ):
         """
         Test that class :class:`~pythonforandroid.archs.Archx86_64` returns
@@ -300,7 +300,7 @@ class TestArchX86_64(ArchSetUpBaseClass, unittest.TestCase):
             which is probably the case. This has to be done because here we
             tests the `get_env` with clang
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_ensure_dir.return_value = True
 
         arch = Archx86_64(self.ctx)
@@ -310,13 +310,13 @@ class TestArchX86_64(ArchSetUpBaseClass, unittest.TestCase):
         self.assertEqual(arch.target, "x86_64-linux-android21")
 
         env = arch.get_env()
-        # check find_executable calls
-        mock_find_executable.assert_called_once_with(
+        # check shutil.which calls
+        mock_shutil_which.assert_called_once_with(
             self.expected_compiler, path=environ["PATH"]
         )
 
         # For x86_64 we expect some extra cflags in our `environment`
-        mock_find_executable.assert_called_once()
+        mock_shutil_which.assert_called_once()
         self.assertIn(
             " -march=x86-64 -msse4.2 -mpopcnt -m64", env["CFLAGS"]
         )
@@ -329,10 +329,10 @@ class TestArchAArch64(ArchSetUpBaseClass, unittest.TestCase):
     :class:`~pythonforandroid.archs.ArchAarch_64`.
     """
 
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     @mock.patch("pythonforandroid.build.ensure_dir")
     def test_arch_aarch_64(
-        self, mock_ensure_dir, mock_find_executable
+        self, mock_ensure_dir, mock_shutil_which
     ):
         """
         Test that class :class:`~pythonforandroid.archs.ArchAarch_64` returns
@@ -345,7 +345,7 @@ class TestArchAArch64(ArchSetUpBaseClass, unittest.TestCase):
             which is probably the case. This has to be done because here we
             tests the `get_env` with clang
         """
-        mock_find_executable.return_value = self.expected_compiler
+        mock_shutil_which.return_value = self.expected_compiler
         mock_ensure_dir.return_value = True
 
         arch = ArchAarch_64(self.ctx)
@@ -355,8 +355,8 @@ class TestArchAArch64(ArchSetUpBaseClass, unittest.TestCase):
         self.assertEqual(arch.target, "aarch64-linux-android21")
 
         env = arch.get_env()
-        # check find_executable calls
-        mock_find_executable.assert_called_once_with(
+        # check shutil.which calls
+        mock_shutil_which.assert_called_once_with(
             self.expected_compiler, path=environ["PATH"]
         )
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -523,15 +523,15 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
     @mock.patch("pythonforandroid.bootstrap.shprint")
     @mock.patch("pythonforandroid.bootstrap.sh.Command")
     @mock.patch("pythonforandroid.build.ensure_dir")
-    @mock.patch("pythonforandroid.archs.find_executable")
+    @mock.patch("shutil.which")
     def test_bootstrap_strip(
         self,
-        mock_find_executable,
+        mock_shutil_which,
         mock_ensure_dir,
         mock_sh_command,
         mock_sh_print,
     ):
-        mock_find_executable.return_value = os.path.join(
+        mock_shutil_which.return_value = os.path.join(
             self.ctx._ndk_dir,
             f"toolchains/llvm/prebuilt/{self.ctx.ndk.host_tag}/bin/clang",
         )
@@ -544,10 +544,9 @@ class GenericBootstrapTest(BaseClassSetupBootstrap):
         # test that strip_libraries runs with a fake distribution
         bs.strip_libraries(arch)
 
-        mock_find_executable.assert_called_once()
         self.assertEqual(
-            mock_find_executable.call_args[0][0],
-            mock_find_executable.return_value,
+            mock_shutil_which.call_args[0][0],
+            mock_shutil_which.return_value,
         )
         mock_sh_command.assert_called_once_with(
             os.path.join(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -28,7 +28,7 @@ class TestBuildBasic(unittest.TestCase):
 
     def test_strip_if_with_debug_symbols(self):
         ctx = mock.Mock()
-        ctx.python_recipe.major_minor_version_string = "python3.6"
+        ctx.python_recipe.major_minor_version_string = "3.6"
         ctx.get_site_packages_dir.return_value = "test-doesntexist"
         ctx.build_dir = "nonexistant_directory"
         ctx.archs = ["arm64"]

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -2,6 +2,7 @@ import unittest
 from os.path import join
 from sys import version as py_version
 
+import packaging.version
 from unittest import mock
 from pythonforandroid.recommendations import (
     check_ndk_api,
@@ -53,7 +54,8 @@ class TestRecommendations(unittest.TestCase):
     @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     @mock.patch("pythonforandroid.recommendations.read_ndk_version")
     def test_check_ndk_version_greater_than_recommended(self, mock_read_ndk):
-        mock_read_ndk.return_value.version = [MAX_NDK_VERSION + 1, 0, 5232133]
+        _version_string = f"{MIN_NDK_VERSION + 1}.0.5232133"
+        mock_read_ndk.return_value = packaging.version.Version(_version_string)
         with self.assertLogs(level="INFO") as cm:
             check_ndk_version(self.ndk_dir)
         mock_read_ndk.assert_called_once_with(self.ndk_dir)
@@ -76,7 +78,8 @@ class TestRecommendations(unittest.TestCase):
 
     @mock.patch("pythonforandroid.recommendations.read_ndk_version")
     def test_check_ndk_version_lower_than_recommended(self, mock_read_ndk):
-        mock_read_ndk.return_value.version = [MIN_NDK_VERSION - 1, 0, 5232133]
+        _version_string = f"{MIN_NDK_VERSION - 1}.0.5232133"
+        mock_read_ndk.return_value = packaging.version.Version(_version_string)
         with self.assertRaises(BuildInterruptingException) as e:
             check_ndk_version(self.ndk_dir)
         self.assertEqual(
@@ -124,7 +127,9 @@ class TestRecommendations(unittest.TestCase):
         mock_open_src_prop.assert_called_once_with(
             join(self.ndk_dir, "source.properties")
         )
-        assert version == "17.2.4988734"
+        assert version.major == 17
+        assert version.minor == 2
+        assert version.micro == 4988734
 
     @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     @mock.patch("pythonforandroid.recommendations.open")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -187,3 +187,46 @@ class TestUtil(unittest.TestCase):
             assert not new_file_path.exists()
             util.touch(new_file_path)
             assert new_file_path.exists()
+
+    def test_build_tools_version_sort_key(self):
+
+        build_tools_versions = [
+            "26.0.1",
+            "26.0.0",
+            "26.0.2",
+            "32.0.0 rc1",
+            "31.0.0",
+            "999something",
+        ]
+
+        expected_result = [
+            "999something",  # invalid version
+            "26.0.0",
+            "26.0.1",
+            "26.0.2",
+            "31.0.0",
+            "32.0.0 rc1",
+        ]
+
+        result = sorted(
+            build_tools_versions, key=util.build_tools_version_sort_key
+        )
+
+        self.assertEqual(result, expected_result)
+
+    def test_max_build_tool_version(self):
+
+        build_tools_versions = [
+            "26.0.1",
+            "26.0.0",
+            "26.0.2",
+            "32.0.0 rc1",
+            "31.0.0",
+            "999something",
+        ]
+
+        expected_result = "32.0.0 rc1"
+
+        result = util.max_build_tool_version(build_tools_versions)
+
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
Recently, our CI pipeline began failing due to the default Python version provided by `actions/setup-python` being set to `3.12`. This issue stems from the removal of `distutils` in Python `3.12`.

**Changes:**

To address the Python 3.12 compatibility issue, this pull request introduces the following changes:

- Replaced `distutils.spawn.find_executable` with `shutil.which` for locating executables.
- Replaced the use of `distutils.version.LooseVersion` with `packaging.version.version` for version comparisons.
- Introduced two new methods, `build_tools_version_sort_key` and `max_build_tool_version`, in the `pythonforandroid.utils` module. These additions not only resolve DRY (Don't Repeat Yourself) violations but also enhance testability.
- Updates the testapps to use `setuptools` instead of `distutils`.
- Adds a `setuptools` dependency

These changes ensure that our codebase remains compatible with Python 3.12 and eliminates any reliance on deprecated `distutils` functionality.