### PR TITLE
Bump `pyjnius` version to `1.6.1`

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -6,7 +6,7 @@ from os.path import join
 
 
 class PyjniusRecipe(CythonRecipe):
-    version = '1.5.0'
+    version = '1.6.1'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
     depends = [('genericndkbuild', 'sdl2'), 'six']


### PR DESCRIPTION
As our [CI have shown](https://github.com/kivy/python-for-android/actions/runs/6774900670/job/18413008601), `pyjnius==1.5.0` still relies on Java 7, which is old (and now not usable anymore on `macos-latest`, with default Java version)

From `pyjnius>1.6.0`, Java 7 is not required anymore, while building the `pyjnius` Java source code.

