### PR TITLE
Update `python-for-android` prerequisites (`Dockerfile`, `prerequisites.py`, docs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # If platform is not specified, by default the target platform of the build request is used.
 # This is not what we want, as Google doesn't provide a linux/arm64 compatible NDK.
 # See: https://docs.docker.com/engine/reference/builder/#from
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 # configure locale
 RUN apt -y update -qq > /dev/null \
@@ -48,43 +48,37 @@ ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/app" \
     PATH="${HOME_DIR}/.local/bin:${PATH}" \
     ANDROID_HOME="${HOME_DIR}/.android" \
-    JAVA_HOME="/usr/lib/jvm/java-13-openjdk-amd64"
+    JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
 
 
 # install system dependencies
-RUN dpkg --add-architecture i386 \
-    && ${RETRY} apt -y update -qq > /dev/null \
+RUN ${RETRY} apt -y update -qq > /dev/null \
     && ${RETRY} DEBIAN_FRONTEND=noninteractive apt install -qq --yes --no-install-recommends \
-    autoconf \
-    automake \
-    autopoint \
-    build-essential \
-    ccache \
-    cmake \
-    gettext \
-    git \
-    lbzip2 \
-    libffi-dev \
-    libgtk2.0-0:i386 \
-    libidn11:i386 \
-    libltdl-dev \
-    libncurses5:i386 \
-    libssl-dev \
-    libstdc++6:i386 \
-    libtool \
-    openjdk-13-jdk \
-    patch \
-    pkg-config \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    sudo \
-    unzip \
-    wget \
-    zip \
-    zlib1g-dev \
-    zlib1g:i386 \
+        ant \
+        autoconf \
+        automake \
+        ccache \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        lbzip2 \
+        libffi-dev \
+        libltdl-dev \
+        libtool \
+        libssl-dev \
+        openjdk-17-jdk \
+        patch \
+        unzip \
+        zip \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        make \
+        sudo \
+        wget \
     && apt -y autoremove \
     && apt -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,18 +67,18 @@ RUN ${RETRY} apt -y update -qq > /dev/null \
         libltdl-dev \
         libtool \
         libssl-dev \
+        make \
         openjdk-17-jdk \
         patch \
-        unzip \
-        zip \
         pkg-config \
         python3 \
         python3-dev \
         python3-pip \
         python3-venv \
-        make \
         sudo \
+        unzip \
         wget \
+        zip \
     && apt -y autoremove \
     && apt -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -56,48 +56,45 @@ You can also test the master branch from Github using::
 
     pip install git+https://github.com/kivy/python-for-android.git
 
-Installing Dependencies
+Installing Prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-p4a has several dependencies that must be installed:
+p4a requires a few dependencies to be installed on your system to work
+properly. While we're working on a way to automate pre-requisites checks,
+suggestions and installation on all platforms (macOS is already supported),
+on Linux distros you'll need to install them manually.
 
-- ant
-- autoconf (for libffi and other recipes)
-- automake
-- ccache (optional)
-- cmake (required for some native code recipes like jpeg's recipe)
-- cython (can be installed via pip)
-- gcc
-- git
-- libncurses (including 32 bit)
-- libtool (for libffi and recipes)
-- libssl-dev (for TLS/SSL support on hostpython3 and recipe)
-- openjdk-8
-- patch
-- python3
-- unzip
-- virtualenv (can be installed via pip)
-- zlib (including 32 bit)
-- zip
+On recent versions of Ubuntu and its derivatives you can easily install them via
+the following command (re-adapted from the `Dockerfile` we use to perform CI builds)::
 
-On recent versions of Ubuntu and its derivatives you may be able to
-install most of these with::
-
-    sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install -y build-essential ccache git zlib1g-dev python3 python3-dev libncurses5:i386 libstdc++6:i386 zlib1g:i386 openjdk-8-jdk unzip ant ccache autoconf libtool libssl-dev
+    sudo apt-get install -y \
+        ant \
+        autoconf \
+        automake \
+        ccache \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        lbzip2 \
+        libffi-dev \
+        libltdl-dev \
+        libtool \
+        libssl-dev \
+        openjdk-17-jdk \
+        patch \
+        unzip \
+        zip \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        make \
+        sudo \
+        wget
 
-On Arch Linux you should be able to run the following to
-install most of the dependencies (note: this list may not be
-complete)::
-
-    sudo pacman -S core/autoconf core/automake core/gcc core/make core/patch core/pkgconf extra/cmake extra/jdk8-openjdk extra/python-pip extra/unzip extra/zip
-
-On macOS::
-
-    brew install autoconf automake libtool openssl pkg-config
-    brew tap homebrew/cask-versions
-    brew install --cask homebrew/cask-versions/adoptopenjdk8
 
 Installing Android SDK
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -82,18 +82,18 @@ the following command (re-adapted from the `Dockerfile` we use to perform CI bui
         libltdl-dev \
         libtool \
         libssl-dev \
+        make \
         openjdk-17-jdk \
         patch \
-        unzip \
-        zip \
         pkg-config \
         python3 \
         python3-dev \
         python3-pip \
         python3-venv \
-        make \
         sudo \
-        wget
+        unzip \
+        wget \
+        zip
 
 
 Installing Android SDK

--- a/pythonforandroid/prerequisites.py
+++ b/pythonforandroid/prerequisites.py
@@ -151,7 +151,7 @@ class JDKPrerequisite(Prerequisite):
     name = "JDK"
     mandatory = dict(linux=False, darwin=True)
     installer_is_supported = dict(linux=False, darwin=True)
-    min_supported_version = 11
+    min_supported_version = 17
 
     def darwin_checker(self):
         if "JAVA_HOME" in os.environ:
@@ -206,12 +206,12 @@ class JDKPrerequisite(Prerequisite):
 
     def darwin_helper(self):
         info(
-            "python-for-android requires a JDK 11 or higher to be installed on macOS,"
+            "python-for-android requires a JDK 17 or higher to be installed on macOS,"
             "but seems like you don't have one installed."
         )
         info(
             "If you think that a valid JDK is already installed, please verify that "
-            "you have a JDK 11 or higher installed and that `/usr/libexec/java_home` "
+            "you have a JDK 17 or higher installed and that `/usr/libexec/java_home` "
             "shows the correct path."
         )
         info(
@@ -221,12 +221,12 @@ class JDKPrerequisite(Prerequisite):
 
     def darwin_installer(self):
         info(
-            "Looking for a JDK 11 or higher installation which is not the default one ..."
+            "Looking for a JDK 17 or higher installation which is not the default one ..."
         )
-        jdk_path = self._darwin_get_libexec_jdk_path(version="11+")
+        jdk_path = self._darwin_get_libexec_jdk_path(version="17+")
 
         if not self._darwin_jdk_is_supported(jdk_path):
-            info("We're unlucky, there's no JDK 11 or higher installation available")
+            info("We're unlucky, there's no JDK 17 or higher installation available")
 
             base_url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/"
             if platform.machine() == "arm64":

--- a/pythonforandroid/prerequisites.py
+++ b/pythonforandroid/prerequisites.py
@@ -151,7 +151,7 @@ class JDKPrerequisite(Prerequisite):
     name = "JDK"
     mandatory = dict(linux=False, darwin=True)
     installer_is_supported = dict(linux=False, darwin=True)
-    min_supported_version = 17
+    supported_version = 17
 
     def darwin_checker(self):
         if "JAVA_HOME" in os.environ:
@@ -197,21 +197,21 @@ class JDKPrerequisite(Prerequisite):
         res = _stdout_res.strip().decode()
 
         major_version = int(res.split(" ")[-1].split(".")[0])
-        if major_version >= self.min_supported_version:
+        if major_version == self.supported_version:
             info(f"Found a valid JDK at {jdk_path}")
             return True
         else:
-            error(f"JDK {self.min_supported_version} or higher is required")
+            error(f"JDK version {major_version} is not supported")
             return False
 
     def darwin_helper(self):
         info(
-            "python-for-android requires a JDK 17 or higher to be installed on macOS,"
+            f"python-for-android requires a JDK {self.supported_version} to be installed on macOS,"
             "but seems like you don't have one installed."
         )
         info(
             "If you think that a valid JDK is already installed, please verify that "
-            "you have a JDK 17 or higher installed and that `/usr/libexec/java_home` "
+            f"you have a JDK {self.supported_version} installed and that `/usr/libexec/java_home` "
             "shows the correct path."
         )
         info(
@@ -221,12 +221,12 @@ class JDKPrerequisite(Prerequisite):
 
     def darwin_installer(self):
         info(
-            "Looking for a JDK 17 or higher installation which is not the default one ..."
+            f"Looking for a JDK {self.supported_version} installation which is not the default one ..."
         )
-        jdk_path = self._darwin_get_libexec_jdk_path(version="17+")
+        jdk_path = self._darwin_get_libexec_jdk_path(version=str(self.supported_version))
 
         if not self._darwin_jdk_is_supported(jdk_path):
-            info("We're unlucky, there's no JDK 17 or higher installation available")
+            info(f"We're unlucky, there's no JDK {self.supported_version} or higher installation available")
 
             base_url = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/"
             if platform.machine() == "arm64":


### PR DESCRIPTION
- Updates `Dockerfile` (clean up of old requirements and change of base image)
- Set JDK version `17` as a prerequisite, newer JDK versions such as `21` are incompatible with our version of `gradle`, and `gradle` now requires at least `JDK 17`
- Update docs to reflect the current status (ouch, docs were super-outdated)
