### PR TITLE
allow directory path as url

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -242,7 +242,6 @@ class Recipe(metaclass=RecipeMeta):
             if isdir(url):
                 shutil.copytree(url, target)
 
-
     def apply_patch(self, filename, arch, build_dir=None):
         """
         Apply a patch from the current recipe directory into the current

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -238,6 +238,10 @@ class Recipe(metaclass=RecipeMeta):
                     shprint(sh.git, 'pull', '--recurse-submodules')
                 shprint(sh.git, 'submodule', 'update', '--recursive', '--init', '--depth', '1')
             return target
+        elif parsed_url.scheme == '':
+            if isdir(url):
+                shutil.copytree(url, target)
+
 
     def apply_patch(self, filename, arch, build_dir=None):
         """


### PR DESCRIPTION
This patch allows the use of a local directory path for the `url` in a recipe.

For example, when building a local c extension, it is then possible to use a directory url, instead of having to contact the server:

```
    url = '/home/jsanchez/git/devsim'
```

I was encountering many difficulties using the `git+https` scheme and it was slowing down development time.