### PR TITLE
Remove redundant class variable definition from recipes

### DIFF
--- a/pythonforandroid/recipes/aiohttp/__init__.py
+++ b/pythonforandroid/recipes/aiohttp/__init__.py
@@ -8,7 +8,6 @@ class AIOHTTPRecipe(CppCompiledComponentsPythonRecipe):  # type: ignore # pylint
     url = "https://pypi.python.org/packages/source/a/aiohttp/aiohttp-{version}.tar.gz"
     name = "aiohttp"
     depends: List[str] = ["setuptools"]
-    call_hostpython_via_targetpython = False
     install_in_hostpython = True
 
     def get_recipe_env(self, arch):

--- a/pythonforandroid/recipes/flask/__init__.py
+++ b/pythonforandroid/recipes/flask/__init__.py
@@ -11,7 +11,6 @@ class FlaskRecipe(PythonRecipe):
     python_depends = ['jinja2', 'werkzeug', 'markupsafe', 'itsdangerous', 'click']
 
     call_hostpython_via_targetpython = False
-    install_in_hostpython = False
 
 
 recipe = FlaskRecipe()

--- a/pythonforandroid/recipes/pandas/__init__.py
+++ b/pythonforandroid/recipes/pandas/__init__.py
@@ -12,9 +12,6 @@ class PandasRecipe(CppCompiledComponentsPythonRecipe):
     python_depends = ['python-dateutil', 'pytz']
     patches = ['fix_numpy_includes.patch']
 
-    call_hostpython_via_targetpython = False
-    need_stl_shared = True
-
     def get_recipe_env(self, arch):
         env = super().get_recipe_env(arch)
         # we need the includes from our installed numpy at site packages

--- a/pythonforandroid/recipes/protobuf_cpp/__init__.py
+++ b/pythonforandroid/recipes/protobuf_cpp/__init__.py
@@ -18,7 +18,6 @@ class ProtobufCppRecipe(CppCompiledComponentsPythonRecipe):
     name = 'protobuf_cpp'
     version = '3.6.1'
     url = 'https://github.com/google/protobuf/releases/download/v{version}/protobuf-python-{version}.tar.gz'
-    call_hostpython_via_targetpython = False
     depends = ['cffi', 'setuptools']
     site_packages_name = 'google/protobuf/pyext'
     setup_extra_args = ['--cpp_implementation']

--- a/pythonforandroid/recipes/pygame/__init__.py
+++ b/pythonforandroid/recipes/pygame/__init__.py
@@ -21,7 +21,6 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
 
     depends = ['sdl2', 'sdl2_image', 'sdl2_mixer', 'sdl2_ttf', 'setuptools', 'jpeg', 'png']
     call_hostpython_via_targetpython = False  # Due to setuptools
-    install_in_hostpython = False
 
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)

--- a/pythonforandroid/recipes/secp256k1/__init__.py
+++ b/pythonforandroid/recipes/secp256k1/__init__.py
@@ -7,8 +7,6 @@ class Secp256k1Recipe(CppCompiledComponentsPythonRecipe):
     version = '0.13.2.4'
     url = 'https://github.com/ludbb/secp256k1-py/archive/{version}.tar.gz'
 
-    call_hostpython_via_targetpython = False
-
     depends = [
         'openssl',
         'hostpython3',

--- a/pythonforandroid/recipes/sympy/__init__.py
+++ b/pythonforandroid/recipes/sympy/__init__.py
@@ -8,8 +8,6 @@ class SympyRecipe(PythonRecipe):
 
     depends = ['mpmath']
 
-    call_hostpython_via_targetpython = True
-
     patches = ['fix_timeutils.patch', 'fix_pretty_print.patch']
 
 

--- a/pythonforandroid/recipes/twisted/__init__.py
+++ b/pythonforandroid/recipes/twisted/__init__.py
@@ -11,9 +11,6 @@ class TwistedRecipe(CythonRecipe):
     depends = ['setuptools', 'zope_interface', 'incremental', 'constantly']
     patches = ['incremental.patch', 'remove_tests.patch']
 
-    call_hostpython_via_targetpython = False
-    install_in_hostpython = False
-
     def prebuild_arch(self, arch):
         super().prebuild_arch(arch)
         # TODO Need to whitelist tty.pyo and termios.so here


### PR DESCRIPTION
- Some of the variables like call_hostpython_via_targetpython, install_in_hostpython are redifined in the package recipes with the exact same value as its parent class, making the definitions redundant. This patch removes these redefinitions.