### PR TITLE
`sourceCompatibility` 1.7 and `targetCompatibility` 1.7 are obsolete, use 1.8 by default

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -82,13 +82,8 @@ android {
     }
 
     compileOptions {
-    	{% if args.enable_androidx %}
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-	{% else %}
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
-	{% endif %}
         {%- for option in args.compile_options %}
         {{option}}
         {%- endfor %}


### PR DESCRIPTION
While upgrading to the new SDL2 (in fact the CI is failing), which uses lambdas in Java, I noticed we still have set both `sourceCompatibility` and `targetCompatibility` to `1.7` by default, unless `androidx` is enabled.

This PR makes `1.8` the default, even if `androidx` is disabled.

Some additional info about Java API on Android (and support for old APIs):
- https://developer.android.com/studio/write/java8-support
- https://developer.android.com/studio/write/java8-support-table

From #2927 CI run:
```
> Task :compileDebugJavaWithJavac FAILED

warning: [options] source value 7 is obsolete and will be removed in a future release

warning: [options] target value 7 is obsolete and will be removed in a future release

warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.

/Users/admin/.python-for-android/dists/bdist_unit_tests_app/src/main/java/org/libsdl/app/SDLAudioManager.java:37: error: lambda expressions are not supported in -source 7

                    Arrays.stream(addedDevices).forEach(deviceInfo -> addAudioDevice(deviceInfo.isSink(), deviceInfo.getId()));

                                                                   ^

  (use -source 8 or higher to enable lambda expressions)

/Users/admin/.python-for-android/dists/bdist_unit_tests_app/src/main/java/org/libsdl/app/SDLAudioManager.java:329: error: method references are not supported in -source 7

            return Arrays.stream(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)).mapToInt(AudioDeviceInfo::getId).toArray();

                                                                                                                      ^

  (use -source 8 or higher to enable method references)

2 errors

3 warnings
```