### PR TITLE
Bump Kivy version to `2.3.0`

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -22,7 +22,7 @@ def is_kivy_affected_by_deadlock_issue(recipe=None, arch=None):
 
 
 class KivyRecipe(CythonRecipe):
-    version = '2.2.1'
+    version = '2.3.0'
     url = 'https://github.com/kivy/kivy/archive/{version}.zip'
     name = 'kivy'
 


### PR DESCRIPTION
Bump `kivy` version to `2.3.0` (latest release)