### PR TITLE
Update OpenSSL version to `1.1.1w`

### DIFF
--- a/pythonforandroid/recipes/openssl/__init__.py
+++ b/pythonforandroid/recipes/openssl/__init__.py
@@ -47,7 +47,7 @@ class OpenSSLRecipe(Recipe):
     version = '1.1'
     '''the major minor version used to link our recipes'''
 
-    url_version = '1.1.1m'
+    url_version = '1.1.1w'
     '''the version used to download our libraries'''
 
     url = 'https://www.openssl.org/source/openssl-{url_version}.tar.gz'


### PR DESCRIPTION
I encountered the following error:

`Downloading openssl from https://www.openssl.org/source/openssl-1.1.1m.tar.gz`
resulted in
`urllib.error.HTTPError: HTTP Error 404: Not Found`
and a failed build.

On visiting [the link from the old code](https://www.openssl.org/source/openssl-1.1.1m.tar.gz), it says

> Page Not Found
> Sorry, but the link you gave does not exist.

The download for old version has been moved to https://www.openssl.org/source/old/1.1.1/openssl-1.1.1m.tar.gz
The link for the latest version is https://www.openssl.org/source/openssl-1.1.1w.tar.gz

This commit includes the updated link to resolve the above error.