### PR TITLE
Arch type error when creating apk for project with setup.py

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -764,7 +764,7 @@ def run_pymodules_install(ctx, arch, modules, project_dir=None,
         if project_dir is not None and (
                 project_has_setup_py(project_dir) and not ignore_setup_py
                 ):
-            run_setuppy_install(ctx, project_dir, env, arch.arch)
+            run_setuppy_install(ctx, project_dir, env, arch)
         elif not ignore_setup_py:
             info("No setup.py found in project directory: " + str(project_dir))
 


### PR DESCRIPTION
p4a apk failing for project with setup.py because arch string is being passed into a method that's expecting the arch object. Below is the build output

INFO:p4a:[INFO]:    android==1.0
Cython==3.0.8
pyjnius==1.6.1
six==1.15.0

[INFO]:    Populating venv's site-packages with ctx.get_site_packages_dir()...
INFO:p4a:[INFO]:    Populating venv's site-packages with ctx.get_site_packages_dir()...
Traceback (most recent call last):
  File "/home/pimmaneni/.local/bin/p4a", line 8, in <module>
    sys.exit(main())
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/entrypoints.py", line 18, in main
    ToolchainCL()
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/toolchain.py", line 685, in __init__
    getattr(self, command)(args)
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/toolchain.py", line 104, in wrapper_func
    build_dist_from_args(ctx, dist, args)
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/toolchain.py", line 163, in build_dist_from_args
    build_recipes(build_order, python_modules, ctx,
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/build.py", line 528, in build_recipes
    run_pymodules_install(
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/build.py", line 767, in run_pymodules_install
    run_setuppy_install(ctx, project_dir, env, arch.arch)
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/build.py", line 579, in run_setuppy_install
    os.path.abspath(ctx.get_site_packages_dir(arch))
  File "/home/pimmaneni/.local/lib/python3.10/site-packages/pythonforandroid/build.py", line 424, in get_site_packages_dir
    return self.get_python_install_dir(arch.arch)
AttributeError: 'str' object has no attribute 'arch'