### PR TITLE
:white_check_mark: Fix test_get_dep_names_of_package

### DIFF
--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -85,7 +85,7 @@ def test_get_dep_names_of_package():
     # TEST 1 from external ref:
     # Check that colorama is returned without the install condition when
     # just getting the names (it has a "; ..." conditional originally):
-    dep_names = get_dep_names_of_package("python-for-android")
+    dep_names = get_dep_names_of_package("python-for-android==2023.9.16")
     assert "colorama" in dep_names
     assert "setuptools" not in dep_names
     try:


### PR DESCRIPTION
Recent pythonf-for-android release added setuptools to install_requires. Pinning to previous release fixes to test.

The error was:
```
    def test_get_dep_names_of_package():
        # TEST 1 from external ref:
        # Check that colorama is returned without the install condition when
        # just getting the names (it has a "; ..." conditional originally):
        dep_names = get_dep_names_of_package("python-for-android")
        assert "colorama" in dep_names
>       assert "setuptools" not in dep_names
E       AssertionError: assert 'setuptools' not in {'Jinja2', 'appdirs', 'build', 'colorama', 'packaging', 'setuptools', ...}
tests/test_pythonpackage_basic.py:90: AssertionError
```