### PR TITLE
:white_check_mark: improve sh mocking reliability

### DIFF
--- a/tests/recipes/recipe_lib_test.py
+++ b/tests/recipes/recipe_lib_test.py
@@ -88,7 +88,7 @@ class BaseTestForMakeRecipe(RecipeCtx):
         with mock.patch(
             f"pythonforandroid.recipes.{self.recipe_name}.sh.Command"
         ) as mock_sh_command, mock.patch(
-            f"pythonforandroid.recipes.{self.recipe_name}.sh.make"
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.make", create=True
         ) as mock_make:
             self.recipe.build_arch(self.arch)
 
@@ -130,9 +130,9 @@ class BaseTestForCmakeRecipe(BaseTestForMakeRecipe):
         # Since the following mocks are dynamic,
         # we mock it inside a Context Manager
         with mock.patch(
-            f"pythonforandroid.recipes.{self.recipe_name}.sh.make"
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.make", create=True
         ) as mock_make, mock.patch(
-            f"pythonforandroid.recipes.{self.recipe_name}.sh.cmake"
+            f"pythonforandroid.recipes.{self.recipe_name}.sh.cmake", create=True
         ) as mock_cmake:
             self.recipe.build_arch(self.arch)
 

--- a/tests/recipes/test_openal.py
+++ b/tests/recipes/test_openal.py
@@ -9,8 +9,8 @@ class TestOpenalRecipe(BaseTestForCmakeRecipe, unittest.TestCase):
     """
     recipe_name = "openal"
 
-    @mock.patch("pythonforandroid.recipes.openal.sh.cmake")
-    @mock.patch("pythonforandroid.recipes.openal.sh.make")
+    @mock.patch("pythonforandroid.recipes.openal.sh.cmake", create=True)
+    @mock.patch("pythonforandroid.recipes.openal.sh.make", create=True)
     @mock.patch("pythonforandroid.recipes.openal.sh.cp")
     @mock.patch("pythonforandroid.util.chdir")
     @mock.patch("pythonforandroid.build.ensure_dir")


### PR DESCRIPTION
Make sure the mocking also works on setup without cmake or make. Build dependencies should not be required to run uni tests. The error was:
```
AttributeError: <module 'sh' from 'venv/lib/python3.11/site-packages/sh.py'> does not have the attribute 'cmake'
```