### PR TITLE
:white_check_mark: Fix broken sdl2 mixer test

### DIFF
--- a/tests/recipes/test_sdl2_mixer.py
+++ b/tests/recipes/test_sdl2_mixer.py
@@ -1,5 +1,5 @@
 import unittest
-from tests.recipes.recipe_lib_test import RecipeCtx
+from tests.recipes.recipe_ctx import RecipeCtx
 
 
 class TestSDL2MixerRecipe(RecipeCtx, unittest.TestCase):
@@ -7,6 +7,12 @@ class TestSDL2MixerRecipe(RecipeCtx, unittest.TestCase):
     An unittest for recipe :mod:`~pythonforandroid.recipes.sdl2_mixer`
     """
     recipe_name = "sdl2_mixer"
+
+    def setUp(self):
+        """Setups bootstrap build_dir."""
+        super().setUp()
+        bootstrap = self.ctx.bootstrap
+        bootstrap.build_dir = bootstrap.get_build_dir()
 
     def test_get_include_dirs(self):
         list_of_includes = self.recipe.get_include_dirs(self.arch)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -15,12 +15,12 @@ from pythonforandroid.build import Context
 from pythonforandroid.util import BuildInterruptingException
 from pythonforandroid.androidndk import AndroidNDK
 
-from test_graph import get_fake_recipe
+from tests.test_graph import get_fake_recipe
 
 
-class BaseClassSetupBootstrap(object):
+class BaseClassSetupBootstrap:
     """
-    An class object which is intended to be used as a base class to configure
+    An class which is intended to be used as a base class to configure
     an inherited class of `unittest.TestCase`. This class will override the
     `setUp` and `tearDown` methods.
     """
@@ -115,7 +115,7 @@ class TestBootstrapBasic(BaseClassSetupBootstrap, unittest.TestCase):
         ) < 0)
 
         # Test a random bootstrap is always lower priority than sdl2:
-        class _FakeBootstrap(object):
+        class _FakeBootstrap:
             def __init__(self, name):
                 self.name = name
         bs1 = _FakeBootstrap("alpha")

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,16 +1,16 @@
 import os
 import pytest
+import tempfile
 import types
 import unittest
 import warnings
 from unittest import mock
-from backports import tempfile
 
 from pythonforandroid.build import Context
 from pythonforandroid.recipe import Recipe, TargetPythonRecipe, import_recipe
 from pythonforandroid.archs import ArchAarch_64
 from pythonforandroid.bootstrap import Bootstrap
-from test_bootstrap import BaseClassSetupBootstrap
+from tests.test_bootstrap import BaseClassSetupBootstrap
 
 
 def patch_logger(level):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ basepython = python3
 deps =
     pytest
     py3: coveralls
-    backports.tempfile
 # posargs will be replaced by the tox args, so you can override pytest
 # args e.g. `tox -- tests/test_graph.py`
 commands = pytest {posargs:tests/}


### PR DESCRIPTION
Reproduce with:
```
PYTHONPATH=. pytest tests/recipes/test_sdl2_mixer.py
```
The error was:
```
=================================== FAILURES ===================================
__________________ TestSDL2MixerRecipe.test_get_include_dirs ___________________
self = <test_sdl2_mixer.TestSDL2MixerRecipe testMethod=test_get_include_dirs>
    def test_get_include_dirs(self):
>       list_of_includes = self.recipe.get_include_dirs(self.arch)
tests/recipes/test_sdl2_mixer.py:12:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pythonforandroid/recipes/sdl2_mixer/__init__.py:13: in get_include_dirs
    os.path.join(self.ctx.bootstrap.build_dir, "jni", "SDL2_mixer", "include")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
a = None, p = ('jni', 'SDL2_mixer', 'include')
>   ???
E   TypeError: expected str, bytes or os.PathLike object, not NoneType
<frozen posixpath>:76: TypeError
```

Also do some minor code clean up and absolute import path fixes.