### PR TITLE
OpenJDK 11 incompatibility beacuse of Gradle 8.x / cannot build apk on WSL v1

### DIFF
--- a/pythonforandroid/bootstraps/common/build/gradle/wrapper/gradle-wrapper.properties
+++ b/pythonforandroid/bootstraps/common/build/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -5,7 +5,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 


### PR DESCRIPTION
Downgrade gradle-8.0.2 to gradle-7.6.2 and gradle:8.1.1 to gradle:7.4.2 to keep JDK 11 compatibility