### PR TITLE
`archs.py`: remove backslash logic

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -144,9 +144,8 @@ class Arch:
             ' '
             + " ".join(
                 [
-                    "-L'"
-                    + link_path.replace("'", "'\"'\"'")
-                    + "'"  # no shlex.quote in py2
+                    "-L"
+                    + link_path
                     for link_path in self.extra_global_link_paths
                 ]
             )


### PR DESCRIPTION
As we are not using shlex anymore.

Also fixes (in meson recipes):

```
ERROR: Malformed value in machine file variable 'c_link_args': Expecting lparen got fslash.
['-L'/home/runner/work/p4a-prebuilt/p4a-prebuilt/.buildozer/android/platform/build-arm64-v8a_armeabi-v7a_x86_64_x86/build/other_builds/libpthread/arm64-v8a__ndk_target_24/libpthread/p4a-libpthread-recipe-tempdir'', '-L'/home/runner/work/p4a-prebuilt/p4a-prebuilt/.buildozer/android/platform/build-arm64-v8a_armeabi-v7a_x86_64_x86/build/other_builds/librt/arm64-v8a__ndk_target_24/librt/p4a-librt-recipe-tempdir'', '-L/home/runner/work/p4a-prebuilt/p4a-prebuilt/.buildozer/android/platform/build-arm64-v8a_armeabi-v7a_x86_64_x86/build/libs_collections/myapp/arm64-v8a', '-L/home/runner/work/p4a-prebuilt/p4a-prebuilt/.buildozer/android/platform/build-arm64-v8a_armeabi-v7a_x86_64_x86/build/other_builds/python3-libbz2-liblzma/arm64-v8a__ndk_target_24/python3/android-build', '-lpython3.11']
```

(because of that extra ')