### PR TITLE
libsodium-recipe-update to url

### DIFF
--- a/pythonforandroid/recipes/libsodium/__init__.py
+++ b/pythonforandroid/recipes/libsodium/__init__.py
@@ -3,14 +3,23 @@ from pythonforandroid.util import current_directory
 from pythonforandroid.logger import shprint
 from multiprocessing import cpu_count
 import sh
+from packaging import version as packaging_version
 
 
 class LibsodiumRecipe(Recipe):
     version = '1.0.16'
-    url = 'https://github.com/jedisct1/libsodium/releases/download/{version}/libsodium-{version}.tar.gz'
+    url = 'https://github.com/jedisct1/libsodium/releases/download/{}/libsodium-{}.tar.gz'
     depends = []
     patches = ['size_max_fix.patch']
     built_libraries = {'libsodium.so': 'src/libsodium/.libs'}
+
+    @property
+    def versioned_url(self):
+        asked_version = packaging_version.parse(self.version)
+        if asked_version > packaging_version.parse('1.0.16'):
+            return self._url.format(self.version + '-RELEASE', self.version)
+        else:
+            return self._url.format(self.version, self.version)
 
     def build_arch(self, arch):
         env = self.get_recipe_env(arch)


### PR DESCRIPTION
libsodium releases changed their url formatting since version 1.0.18.

Anyone trying to use newer versions of libsodium would receive the error ->

```
[INFO]:    Downloading libsodium from https://github.com/jedisct1/libsodium/releases/download/1.0.18/libsodium-1.0.18.tar.gz
Traceback (most recent call last):
(...)
urllib.error.HTTPError: HTTP Error 404: Not Found
Download failed: HTTP Error 404: Not Found; retrying in 1 second(s)...Download failed: HTTP Error 404: Not Found; retrying in 2 second(s)...Download failed: HTTP Error 404: Not Found; retrying in 4 second(s)...Download failed: HTTP Error 404: Not Found; retrying in 8 second(s)...

```
Suggest updating the url formatting to support newer versions and the default version to start at 1.0.18 instead of 1.0.16.

Background: encounter the above error trying to specify pynacl==1.5.0 as a requirement within my spec file.  The apk compiled and was missing references from the libsodium libs upon execution.  As I specified libsodium==1.0.18,pynacl==1.5.0 I saw the error.

**PS (BACKWARDS COMPATIBILITY CAVEAT)** -> anyone hardcoding as a requirement something lower than 1.0.18 (i.e., 1.0.16 or lower) would receive this error after this change.  Using libsodium without any version specified would result in a successful download of 1.0.18. 