### PR TITLE
:construction_worker: Publish to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: make docker/build
+      - run: make docker/login
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: docker push
+        if: github.ref == 'develop'
+        run: make docker/push

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ docker/pull:
 docker/build:
 	docker build --cache-from=$(DOCKER_IMAGE) --tag=$(DOCKER_IMAGE) .
 
+docker/login:
+	@echo $(DOCKERHUB_TOKEN) | docker login --username $(DOCKERHUB_USERNAME) --password-stdin
+
 docker/push:
 	docker push $(DOCKER_IMAGE)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ python-for-android is not limited to being used with Buildozer.
 
 [![Unit tests & build apps](https://github.com/kivy/python-for-android/workflows/Unit%20tests%20&%20build%20apps/badge.svg?branch=develop)](https://github.com/kivy/python-for-android/actions?query=workflow%3A%22Unit+tests+%26+build+apps%22)
 [![Coverage Status](https://coveralls.io/repos/github/kivy/python-for-android/badge.svg?branch=develop&kill_cache=1)](https://coveralls.io/github/kivy/python-for-android?branch=develop)
+[![Docker](https://github.com/kivy/python-for-android/actions/workflows/docker.yml/badge.svg)](https://github.com/kivy/python-for-android/actions/workflows/docker.yml)
 
 ## Documentation
 


### PR DESCRIPTION
Our public DockerHub Image was 3 years old as the automatic build became a pro feature.
With this change we're now publishing to DockerHub from the CI on push to the develop branch.

Authentication to DockerHub is done using personal access tokens configured using `andremiras` username, but this can be updated anytime with another token refs:
- https://app.docker.com/settings/personal-access-tokens
- https://github.com/kivy/python-for-android/settings/secrets/actions

We use a dedicated docker.yml workflow file rather than building on top of the existing push.yml one to keep things clean and separated. In the future we may add multi architecture support.

Updating the public image also fixes the issue where the sh logger was too verbose leading to huge and unreadable CI logs.