### PR TITLE
:mute: Fix sh logs too verbose

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -12,8 +12,6 @@ import urllib.request
 from urllib.request import urlretrieve
 from os import listdir, unlink, environ, curdir, walk
 from sys import stdout
-from wheel.wheelfile import WheelFile
-from wheel.cli.tags import tags as wheel_tags
 import time
 try:
     from urlparse import urlparse
@@ -26,7 +24,7 @@ from pythonforandroid.logger import (
     logger, info, warning, debug, shprint, info_main, error)
 from pythonforandroid.util import (
     current_directory, ensure_dir, BuildInterruptingException, rmdir, move,
-    touch)
+    touch, patch_wheel_setuptools_logging)
 from pythonforandroid.util import load_source as import_recipe
 
 
@@ -1205,6 +1203,9 @@ class PyProjectRecipe(PythonRecipe):
         }[arch.arch]
 
     def install_wheel(self, arch, built_wheels):
+        with patch_wheel_setuptools_logging():
+            from wheel.cli.tags import tags as wheel_tags
+            from wheel.wheelfile import WheelFile
         _wheel = built_wheels[0]
         built_wheel_dir = dirname(_wheel)
         # Fix wheel platform tag

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -1,4 +1,5 @@
 import contextlib
+from unittest import mock
 from fnmatch import fnmatch
 import logging
 from os.path import exists, join
@@ -163,3 +164,16 @@ def max_build_tool_version(
     """
 
     return max(build_tools_versions, key=build_tools_version_sort_key)
+
+
+def patch_wheel_setuptools_logging():
+    """
+    When setuptools is not present and the root logger has no handlers,
+    Wheels would configure the root logger with DEBUG level, refs:
+    - https://github.com/pypa/wheel/blob/0.44.0/src/wheel/util.py
+    - https://github.com/pypa/wheel/blob/0.44.0/src/wheel/_setuptools_logging.py
+
+    Both of these conditions are met in our CI, leading to very verbose
+    and unreadable `sh` logs. Patching it prevents that.
+    """
+    return mock.patch("wheel._setuptools_logging.configure")


### PR DESCRIPTION
When setuptools is not present and the root logger has no handlers, Wheels would configure the root logger with DEBUG level, refs:
- https://github.com/pypa/wheel/blob/0.44.0/src/wheel/util.py
- https://github.com/pypa/wheel/blob/0.44.0/src/wheel/_setuptools_logging.py

Both of these conditions are met in our CI, leading to very verbose and unreadable `sh` logs. Patching it prevents that.