### PR TITLE
reproducible apks: strip file path prefix from .pyc files

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -205,7 +205,14 @@ def compile_py_file(python_file, optimize_python=True):
     if PYTHON is None:
         return
 
-    args = [PYTHON, '-m', 'compileall', '-b', '-f', python_file]
+    path_prefix = os.path.commonpath([python_file, os.getcwd()])
+    args = [
+        PYTHON, '-m', 'compileall',
+        '-b',
+        '-s', path_prefix,  # for reproducible builds, do not leak paths into pyc
+        '-f',
+        python_file,
+    ]
     if optimize_python:
         # -OO = strip docstrings
         args.insert(1, '-OO')

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -360,7 +360,14 @@ class Python3Recipe(TargetPythonRecipe):
             longer used...uses .pyc (https://www.python.org/dev/peps/pep-0488)
         '''
         args = [self.ctx.hostpython]
-        args += ['-OO', '-m', 'compileall', '-b', '-f', dir]
+        args += [
+            '-OO',
+            '-m', 'compileall',
+            '-b',
+            '-s', dir,  # for reproducible builds, do not leak paths into pyc
+            '-f',
+            dir,
+        ]
         subprocess.call(args)
 
     def create_python_bundle(self, dirn, arch):

--- a/tests/recipes/test_python3.py
+++ b/tests/recipes/test_python3.py
@@ -56,7 +56,7 @@ class TestPython3Recipe(RecipeCtx, unittest.TestCase):
         hostpy = self.recipe.ctx.hostpython = '/fake/hostpython3'
         self.recipe.compile_python_files(fake_compile_dir)
         mock_subprocess.assert_called_once_with(
-            [hostpy, '-OO', '-m', 'compileall', '-b', '-f', fake_compile_dir],
+            [hostpy, '-OO', '-m', 'compileall', '-b', '-s', fake_compile_dir, '-f', fake_compile_dir],
         )
 
     @mock.patch("pythonforandroid.recipe.Recipe.check_recipe_choices")


### PR DESCRIPTION
Without this, paths from the build machine will leak into the generated `.pyc` files, which makes the builds more difficult to reproduce.

Note that the [`compileall -s` option](https://docs.python.org/3/library/compileall.html#cmdoption-compileall-s) was only added in python 3.9. Not sure if that is acceptable, as this limits the hostpython3 recipe to 3.9+.