### PR TITLE
build.gradle: set android.dependenciesInfo.includeInApk = false

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -106,6 +106,13 @@ android {
         noCompress "tflite"
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
 }
 
 dependencies {


### PR DESCRIPTION
This was requested by f-droid devs to publish an app.
ref https://gitlab.com/fdroid/fdroiddata/-/merge_requests/15858#note_2150822234

---

see https://android.izzysoft.de/articles/named/iod-scan-apkchecks#blobs

> BLOBs in APK signing blocks
> APK signing blocks are where signing details are stored in.
> [...]
> DEPENDENCY_INFO_BLOCK: This is supposed to be a binary representation of build dependencies inserted by Google itself, or also by Android Studio and IntelliJ IDEA (plus probably also some other development tools), when an APK is being signed. But it is also encrypted using a public key owned by Google, so one cannot really verify what else might have been placed there. This means when found (which is very often) I reach out to the corresponding developers, suggesting them to use apksigner for signing instead, which does not add this block – or to make sure Android Studio resp. IntelliJ IDEA will not include them (see below). Apkverifier includes a short comment in its code, a.o. „The data is compressed, encrypted by a Google Play signing key...“ (source)
> So this in essence is a „blob“ without transparency. As it’s encrypted using a Google Play public key, it cannot be decrypted without the corresponding private key – so except for Google, no one can say for sure which other bits might have been added along.