### PR TITLE
:green_heart: Fix sphinx documentation build errors

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -57,7 +57,7 @@ You can also test the master branch from Github using::
     pip install git+https://github.com/kivy/python-for-android.git
 
 Installing Prerequisites
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 p4a requires a few dependencies to be installed on your system to work
 properly. While we're working on a way to automate pre-requisites checks,

--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -73,9 +73,10 @@ For example, when downloading from a private github repository, you can specify 
 ```
 
 (For the DOWNLOAD_HEADERS_my-package-name environment variable - specify as a JSON formatted set of values)
-```
+.. code-block:: bash
+
     [["Authorization","token <your personal access token>"],["Accept", "application/vnd.github+json"]]
-```
+
 The actual build process takes place via three core methods::
 
       def prebuild_arch(self, arch):

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -128,6 +128,7 @@ class Recipe(metaclass=RecipeMeta):
     keys should be the generated libraries and the values the relative path of
     the library inside his build folder. This dict will be used to perform
     different operations:
+
         - copy the library into the right location, depending on if it's shared
           or static)
         - check if we have to rebuild the library
@@ -571,7 +572,6 @@ class Recipe(metaclass=RecipeMeta):
         '''Should perform any necessary test and return True only if it needs
         building again. Per default we implement a library test, in case that
         we detect so.
-
         '''
         if self.built_libraries:
             return not all(
@@ -591,7 +591,7 @@ class Recipe(metaclass=RecipeMeta):
         '''This method is always called after `build_arch`. In case that we
         detect a library recipe, defined by the class attribute
         `built_libraries`, we will copy all defined libraries into the
-         right location.
+        right location.
         '''
         if not self.built_libraries:
             return

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -750,6 +750,7 @@ class ToolchainCL:
         """
         Prints recipes basic info, e.g.
         .. code-block:: bash
+
             python3      3.7.1
                 depends: ['hostpython3', 'sqlite3', 'openssl', 'libffi']
                 conflicts: []


### PR DESCRIPTION
The errors & warnings were:
```
doc/source/quickstart.rst:60: WARNING: Title underline too short.

Installing Prerequisites
~~~~~~~~~~~~~~~~~~~~~~~
doc/source/quickstart.rst:60: WARNING: Title underline too short.

Installing Prerequisites
~~~~~~~~~~~~~~~~~~~~~~~
doc/source/recipes.rst:77: ERROR: Unexpected indentation.
doc/source/recipes.rst:75: WARNING: Inline literal start-string without end-string.
doc/source/recipes.rst:75: WARNING: Inline interpreted text or phrase reference start-string without end-string.
doc/source/recipes.rst:78: WARNING: Block quote ends without a blank line; unexpected unindent.
doc/source/recipes.rst:78: WARNING: Inline literal start-string without end-string.
WARNING: autodoc: failed to import class 'Recipe' from module 'toolchain'; the following exception was raised:
```
And more errors popped as we fixed the above ones. Full log:
https://github.com/kivy/python-for-android/actions/runs/12263397494/job/34218728454