### PR TITLE
Add `httpx` recipe

### DIFF
--- a/pythonforandroid/recipes/httpx/__init__.py
+++ b/pythonforandroid/recipes/httpx/__init__.py
@@ -9,4 +9,5 @@ class HttpxRecipe(PyProjectRecipe):
     )
     depends = ["httpcore", "h11", "certifi", "idna", "sniffio"]
 
+
 recipe = HttpxRecipe()

--- a/pythonforandroid/recipes/httpx/__init__.py
+++ b/pythonforandroid/recipes/httpx/__init__.py
@@ -1,0 +1,12 @@
+from pythonforandroid.recipe import PyProjectRecipe
+
+
+class HttpxRecipe(PyProjectRecipe):
+    name = "httpx"
+    version = "0.28.1"
+    url = (
+        "https://pypi.python.org/packages/source/h/httpx/httpx-{version}.tar.gz"
+    )
+    depends = ["httpcore", "h11", "certifi", "idna", "sniffio"]
+
+recipe = HttpxRecipe()


### PR DESCRIPTION
Dependencies, from https://www.python-httpx.org:

"""
The HTTPX project relies on these excellent libraries:

- `httpcore `- The underlying transport implementation for httpx.
- `h11 `- HTTP/1.1 support.
- `certifi `- SSL certificates.
- `idna `- Internationalized domain name support.
- `sniffio `- Async library autodetection.

"""