### PR TITLE
Fix kiwisolver recipe fatal error: 'Python.h' file not found

### DIFF
--- a/pythonforandroid/recipes/kiwisolver/__init__.py
+++ b/pythonforandroid/recipes/kiwisolver/__init__.py
@@ -8,5 +8,13 @@ class KiwiSolverRecipe(PyProjectRecipe):
     depends = ['cppy']
     need_stl_shared = True
 
+    # from https://github.com/kivy/python-for-android/issues/3115
+    def get_recipe_env(self, arch, **kwargs):
+        env = super().get_recipe_env(arch, **kwargs)
+        flags = " -I" + self.ctx.python_recipe.include_root(arch.arch)
+        env["CFLAGS"] = flags
+        env["CPPFLAGS"] = flags
+        return env
+
 
 recipe = KiwiSolverRecipe()


### PR DESCRIPTION
From https://github.com/kivy/python-for-android/issues/3115: Fixes the problem with the **KiwiSolver recipe** in the current **develop branch** of pythonforandroid.

Error to fix:
```log
[DEBUG]:        running build_ext
[DEBUG]:        building 'kiwisolver._cext' extension
[DEBUG]:        creating build/temp.linux-x86_64-cpython-311/py/src
...
[DEBUG]:        In file included from py/src/constraint.cpp:10:
[DEBUG]:        In file included from /tmp/build-env-lzty91e_/lib/python3.11/site-packages/cppy/include/cppy/cppy.h:16:
[DEBUG]:        /tmp/build-env-lzty91e_/lib/python3.11/site-packages/cppy/include/cppy/defines.h:10:10: fatal error: 'Python.h' file not found
[DEBUG]:        #include <Python.h>
[DEBUG]:                 ^~~~~~~~~~
[DEBUG]:        1 error generated.
[DEBUG]:        error: command '/usr/bin/ccache' failed with exit code 1
[DEBUG]:   
[DEBUG]:        ERROR Backend subprocess exited when trying to invoke build_wheel
```

buildozer.spec:
```spec
requirements = python3,kivy,kiwisolver
android.archs = arm64-v8a
p4a.branch = develop
log_level = 2
```
Minimal test:
```python
import kivy

from kivy.app import App
from kivy.uix.button import Button
from kiwisolver import Variable, Solver

def callback(instance):
  x1 = Variable('x1')
  x2 = Variable('x2')
  xm = Variable('xm')
  constraints = [x1 >= 0, x2 <= 100, x2 >= x1 + 10, xm == (x1 + x2) / 2]
  solver = Solver()
  for cn in constraints:
    solver.addConstraint(cn)
  solver.addEditVariable(xm, 'strong')
  solver.suggestValue(xm, 60)
  solver.updateVariables()
  print(f"xm = {xm.value()}, x1 = {x1.value()}, x2 = {x2.value()}")


class MyApp(App):
  def build(self):
    btn1 = Button(text='Kiwisolver demo', size=(100, 50))
    btn1.bind(on_press=callback)
    return btn1

if __name__ == '__main__':
    MyApp().run()
```

