### PR TITLE
:bug: Upgrade and fix gevent recipe, closes #2805

### DIFF
--- a/pythonforandroid/recipes/gevent/__init__.py
+++ b/pythonforandroid/recipes/gevent/__init__.py
@@ -1,22 +1,33 @@
+"""
+Note that this recipe doesn't yet build on macOS, the error is:
+```
+deps/libuv/src/unix/bsd-ifaddrs.c:31:10: fatal error: 'net/if_dl.h' file not found
+#include <net/if_dl.h>
+         ^~~~~~~~~~~~~
+1 error generated.
+error: command '/Users/runner/.android/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang' failed with exit code 1
+```
+"""
 import re
 from pythonforandroid.logger import info
-from pythonforandroid.recipe import CythonRecipe
+from pythonforandroid.recipe import PyProjectRecipe
 
 
-class GeventRecipe(CythonRecipe):
-    version = '1.4.0'
-    url = 'https://pypi.python.org/packages/source/g/gevent/gevent-{version}.tar.gz'
+class GeventRecipe(PyProjectRecipe):
+    version = '24.11.1'
+    url = 'https://github.com/gevent/gevent/archive/refs/tags/{version}.tar.gz'
     depends = ['librt', 'setuptools']
     patches = ["cross_compiling.patch"]
 
-    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
+    def get_recipe_env(self, arch, **kwargs):
         """
         - Moves all -I<inc> -D<macro> from CFLAGS to CPPFLAGS environment.
         - Moves all -l<lib> from LDFLAGS to LIBS environment.
         - Copies all -l<lib> from LDLIBS to LIBS environment.
-        - Fixes linker name (use cross compiler)  and flags (appends LIBS)
+        - Fixes linker name (use cross compiler) and flags (appends LIBS).
+        - Feds the command prefix for the configure --host flag.
         """
-        env = super().get_recipe_env(arch, with_flags_in_cc)
+        env = super().get_recipe_env(arch, **kwargs)
         # CFLAGS may only be used to specify C compiler flags, for macro definitions use CPPFLAGS
         regex = re.compile(r'(?:\s|^)-[DI][\S]+')
         env['CPPFLAGS'] = ''.join(re.findall(regex, env['CFLAGS'])).strip()
@@ -28,6 +39,8 @@ class GeventRecipe(CythonRecipe):
         env['LIBS'] += ' {}'.format(''.join(re.findall(regex, env['LDLIBS'])).strip())
         env['LDFLAGS'] = re.sub(regex, '', env['LDFLAGS'])
         info('Moved "{}" from LDFLAGS to LIBS.'.format(env['LIBS']))
+        # used with the `./configure --host` flag for cross compiling, refs #2805
+        env['COMMAND_PREFIX'] = arch.command_prefix
         return env
 
 

--- a/pythonforandroid/recipes/gevent/cross_compiling.patch
+++ b/pythonforandroid/recipes/gevent/cross_compiling.patch
@@ -1,26 +1,26 @@
 diff --git a/_setupares.py b/_setupares.py
-index dd184de6..bb16bebe 100644
+index c42fe369..cd8854df 100644
 --- a/_setupares.py
 +++ b/_setupares.py
-@@ -43,7 +43,7 @@ else:
+@@ -42,7 +42,7 @@ cflags = ('CFLAGS="%s"' % (cflags,)) if cflags else ''
  ares_configure_command = ' '.join([
      "(cd ", quoted_dep_abspath('c-ares'),
-     " && if [ -r ares_build.h ]; then cp ares_build.h ares_build.h.orig; fi ",
--    " && sh ./configure --disable-dependency-tracking " + _m32 + "CONFIG_COMMANDS= ",
-+    " && sh ./configure --host={} --disable-dependency-tracking ".format(os.environ['TOOLCHAIN_PREFIX']) + _m32 + "CONFIG_COMMANDS= ",
-     " && cp ares_config.h ares_build.h \"$OLDPWD\" ",
-     " && cat ares_build.h ",
-     " && if [ -r ares_build.h.orig ]; then mv ares_build.h.orig ares_build.h; fi)",
+     " && if [ -r include/ares_build.h ]; then cp include/ares_build.h include/ares_build.h.orig; fi ",
+-    " && sh ./configure --disable-dependency-tracking --disable-tests -C " + cflags,
++    " && sh ./configure --host={} --disable-dependency-tracking --disable-tests -C ".format(os.environ['COMMAND_PREFIX']) + cflags,
+     " && cp src/lib/ares_config.h include/ares_build.h \"$OLDPWD\" ",
+     " && cat include/ares_build.h ",
+     " && if [ -r include/ares_build.h.orig ]; then mv include/ares_build.h.orig include/ares_build.h; fi)",
 diff --git a/_setuplibev.py b/_setuplibev.py
-index 2a5841bf..b6433c94 100644
+index f05c2fe9..32f9bd81 100644
 --- a/_setuplibev.py
 +++ b/_setuplibev.py
-@@ -31,7 +31,7 @@ LIBEV_EMBED = should_embed('libev')
- # and the PyPy branch will clean it up.
+@@ -28,7 +28,7 @@ LIBEV_EMBED = should_embed('libev')
+ # Configure libev in place
  libev_configure_command = ' '.join([
      "(cd ", quoted_dep_abspath('libev'),
--    " && sh ./configure ",
-+    " && sh ./configure --host={} ".format(os.environ['TOOLCHAIN_PREFIX']),
-     " && cp config.h \"$OLDPWD\"",
+-    " && sh ./configure -C > configure-output.txt",
++    " && sh ./configure --host={} -C > configure-output.txt".format(os.environ['COMMAND_PREFIX']),
      ")",
-     '> configure-output.txt'
+ ])
+ 

--- a/tests/recipes/test_gevent.py
+++ b/tests/recipes/test_gevent.py
@@ -35,9 +35,9 @@ class TestGeventRecipe(RecipeCtx, unittest.TestCase):
             'LDFLAGS': mocked_ldflags,
             'LDLIBS': mocked_ldlibs,
         }
-        with patch('pythonforandroid.recipe.CythonRecipe.get_recipe_env') as m_get_recipe_env:
+        with patch('pythonforandroid.recipe.PyProjectRecipe.get_recipe_env') as m_get_recipe_env:
             m_get_recipe_env.return_value = mocked_env
-            env = self.recipe.get_recipe_env()
+            env = self.recipe.get_recipe_env(self.arch)
         expected_cflags = (
             ' -fomit-frame-pointer -mandroid -isystem /path/to/isystem'
             ' -isysroot /path/to/sysroot'
@@ -57,11 +57,13 @@ class TestGeventRecipe(RecipeCtx, unittest.TestCase):
         )
         expected_ldlibs = mocked_ldlibs
         expected_libs = '-lm -lpython3.7m -lm'
+        expected_command_prefix = 'aarch64-linux-android'
         expected_env = {
             'CFLAGS': expected_cflags,
             'CPPFLAGS': expected_cppflags,
             'LDFLAGS': expected_ldflags,
             'LDLIBS': expected_ldlibs,
             'LIBS': expected_libs,
+            'COMMAND_PREFIX': expected_command_prefix,
         }
         self.assertEqual(expected_env, env)


### PR DESCRIPTION
Update the gevent recipe from 1.4.0 (2019/01) to the latest version 24.11.1 (2024/11) and fix the build errors.

Note that the build fails on macOS, the error is:
```
deps/libuv/src/unix/bsd-ifaddrs.c:31:10: fatal error: 'net/if_dl.h' file not found
#include <net/if_dl.h>
         ^~~~~~~~~~~~~
```