### PR TITLE
Fix Cmake compatibility issue on jpeg recipe

### DIFF
--- a/pythonforandroid/recipes/jpeg/__init__.py
+++ b/pythonforandroid/recipes/jpeg/__init__.py
@@ -48,6 +48,9 @@ class JpegRecipe(Recipe):
                     # Force disable shared, with the static ones is enough
                     '-DENABLE_SHARED=0',
                     '-DENABLE_STATIC=1',
+
+                    # Fix cmake compatibility issue
+                    '-DCMAKE_POLICY_VERSION_MINIMUM=3.5',
                     _env=env)
             shprint(sh.make, _env=env)
 


### PR DESCRIPTION
The jpeg recipe doesn't compile anymore because CMake dropped compatibility with versions below 3.5.

"Calls to cmake_minimum_required() or cmake_policy() that set the policy version to an older value now issue an error."

Source: https://cmake.org/cmake/help/latest/release/4.0.html