### PR TITLE
`pyjnius`: pin cython version

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -14,6 +14,7 @@ class PyjniusRecipe(PyProjectRecipe):
 
     patches = [
         "use_cython.patch",
+        "cython_version_pin.patch",
         ('genericndkbuild_jnienv_getter.patch', will_build('genericndkbuild')),
         ('sdl3_jnienv_getter.patch', will_build('sdl3')),
     ]

--- a/pythonforandroid/recipes/pyjnius/cython_version_pin.patch
+++ b/pythonforandroid/recipes/pyjnius/cython_version_pin.patch
@@ -1,0 +1,9 @@
+--- pyjnius-1.6.1/pyproject.toml	2023-11-05 21:07:43.000000000 +0530
++++ pyjnius-1.6.1.mod/pyproject.toml	2025-05-11 20:31:14.699072764 +0530
+@@ -2,5 +2,5 @@
+ requires = [
+     "setuptools>=58.0.0",
+     "wheel",
+-    "Cython"
++    "Cython==3.0.0"
+ ]


### PR DESCRIPTION
As pyjnius build fails on latest cython.

```
[1/1] Cythonizing jnius/jnius.pyx
warning: jnius/jnius.pyx:102:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310

Error compiling Cython file:
------------------------------------------------------------
...
            score += 10
            continue

        if r == 'S' or r == 'I':
            if isinstance(arg, int) or (
                    (isinstance(arg, long) and arg < 2147483648)):
                                     ^
------------------------------------------------------------

jnius/jnius_utils.pxi:323:37: undeclared name not builtin: long
Traceback (most recent call last):
```