### PR TITLE
Restrict Cython versions for numpy and pyjnius

### DIFF
--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -9,7 +9,7 @@ NUMPY_NDK_MESSAGE = "In order to build numpy, you must set minimum ndk api (mina
 class NumpyRecipe(MesonRecipe):
     version = 'v1.26.5'
     url = 'git+https://github.com/numpy/numpy'
-    hostpython_prerequisites = ["Cython>=3.0.6"]  # meson does not detects venv's cython
+    hostpython_prerequisites = ["Cython>=3.0.6,<3.1.0"]  # meson does not detects venv's cython
     extra_build_args = ['-Csetup-args=-Dblas=none', '-Csetup-args=-Dlapack=none']
     need_stl_shared = True
 

--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -9,6 +9,7 @@ class PyjniusRecipe(PyProjectRecipe):
     version = '1.6.1'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
+    hostpython_prerequisites = ["Cython>=0.29.33,<3"]
     depends = [('genericndkbuild', 'sdl2', 'sdl3'), 'six']
     site_packages_name = 'jnius'
 


### PR DESCRIPTION
These recipes both broke recently because of changes to Cython. I've restricted what Cython versions their hostpython can use.

Fixes #3150. Thanks to @T-Dynamos for identifying the problem.