### PR TITLE
Require `c++` stl for Kivy when `sdl3` is used (Kivy 3.0.0)

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -34,6 +34,13 @@ class KivyRecipe(PyProjectRecipe):
     # WARNING: Remove this patch when a new Kivy version is released.
     patches = [("sdl-gl-swapwindow-nogil.patch", is_kivy_affected_by_deadlock_issue), "use_cython.patch"]
 
+    @property
+    def need_stl_shared(self):
+        if "sdl3" in self.ctx.recipe_build_order:
+            return True
+        else:
+            return False
+
     def get_recipe_env(self, arch, **kwargs):
         env = super().get_recipe_env(arch, **kwargs)
 


### PR DESCRIPTION
This pull request introduces a dynamic property to the `KivyRecipe` class in the `pythonforandroid` project to determine whether the shared STL library is required based on the presence of `sdl3` in the build order.
