### PR TITLE
Fix `md5sum` for SDL3 recipe version `3.2.18`

### DIFF
--- a/pythonforandroid/recipes/sdl3/__init__.py
+++ b/pythonforandroid/recipes/sdl3/__init__.py
@@ -8,7 +8,7 @@ import sh
 class LibSDL3Recipe(BootstrapNDKRecipe):
     version = "3.2.18"
     url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL3-{version}.tar.gz"
-    md5sum = "70cda886bcf5a4fdac550db796d2efa2"
+    md5sum = "C7808EF624B74E2AC69CF531E78E0C6E"
 
     conflicts = ["sdl2"]
 

--- a/pythonforandroid/recipes/sdl3/__init__.py
+++ b/pythonforandroid/recipes/sdl3/__init__.py
@@ -8,7 +8,7 @@ import sh
 class LibSDL3Recipe(BootstrapNDKRecipe):
     version = "3.2.18"
     url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL3-{version}.tar.gz"
-    md5sum = "C7808EF624B74E2AC69CF531E78E0C6E"
+    md5sum = "c7808ef624b74e2ac69cf531e78e0c6e"
 
     conflicts = ["sdl2"]
 


### PR DESCRIPTION
This update was missing here: https://github.com/kivy/python-for-android/pull/3182