### PR TITLE
:construction_worker: Runtime test the app from the CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,7 +80,7 @@ jobs:
             target: testapps-qt
     steps:
     - name: Checkout python-for-android
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Build python-for-android docker image
       run: |
         docker build --tag=kivy/python-for-android .
@@ -163,6 +163,26 @@ jobs:
         with:
           name: ${{ matrix.runs_on }}-${{ matrix.bootstrap.name }}-artifacts
           path: dist
+
+  test_on_emulator:
+    name: Run App on Emulator
+    needs: ubuntu_build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: ubuntu-latest-sdl2-artifacts
+          path: dist/
+
+      - name: Setup and start Android Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          arch: x86_64
+          script: ci/run_emulator_tests.sh
 
   ubuntu_rebuild_updated_recipes:
     name: Test updated recipes for arch ${{ matrix.android_arch }} [ ubuntu-latest ]

--- a/ci/run_emulator_tests.sh
+++ b/ci/run_emulator_tests.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Find the built APK file
+APK_FILE=$(find dist -name "*.apk" -print -quit)
+
+if [ -z "$APK_FILE" ]; then
+    echo "Error: No APK file found in dist/"
+    exit 1
+fi
+
+echo "Installing $APK_FILE..."
+adb install "$APK_FILE"
+
+# Extract package and activity names
+AAPT2_PATH=$(find ${ANDROID_HOME}/build-tools/ -name aapt2 | sort -r | head -n 1)
+APP_PACKAGE=$(${AAPT2_PATH} dump badging "${APK_FILE}" | awk -F"'" '/package: name=/{print $2}')
+APP_ACTIVITY=$(${AAPT2_PATH} dump badging "${APK_FILE}" | awk -F"'" '/launchable-activity/ {print $2}')
+
+echo "Launching $APP_PACKAGE/$APP_ACTIVITY..."
+adb shell am start -n "$APP_PACKAGE/$APP_ACTIVITY" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER
+
+# Poll for test completion with timeout
+MAX_WAIT=300
+POLL_INTERVAL=5
+elapsed=0
+
+echo "Waiting for tests to complete (max ${MAX_WAIT}s)..."
+
+while [ $elapsed -lt $MAX_WAIT ]; do
+    # Dump current logs
+    adb logcat -d -s python:I *:S > app_logs.txt
+
+    # Check if all success patterns are present
+    if grep --extended-regexp --quiet "I python[ ]+: Initialized python" app_logs.txt && \
+       grep --extended-regexp --quiet "I python[ ]+: Ran 14 tests in" app_logs.txt && \
+       grep --extended-regexp --quiet "I python[ ]+: OK" app_logs.txt; then
+        echo "✅ SUCCESS: App launched and all unit tests passed in ${elapsed}s."
+        exit 0
+    fi
+
+    # Check for early failure indicators
+    if grep --extended-regexp --quiet "I python[ ]+: FAILED" app_logs.txt; then
+        echo "❌ FAILURE: Tests failed after ${elapsed}s."
+        echo "--- Full Logs ---"
+        cat app_logs.txt
+        echo "-----------------"
+        exit 1
+    fi
+
+    sleep $POLL_INTERVAL
+    elapsed=$((elapsed + POLL_INTERVAL))
+    echo "Still waiting... (${elapsed}s elapsed)"
+done
+
+echo "❌ TIMEOUT: Tests did not complete within ${MAX_WAIT}s."
+echo "--- Full Logs ---"
+cat app_logs.txt
+echo "-----------------"
+exit 1


### PR DESCRIPTION
Leverage `reactivecircus/android-emulator-runner` to run the testapps artifact on an emulator and check the ADB logs.
We're currently checking for the following pattern from the logcat output:
- "I python: Initialized python"
- "I python: Ran 14 tests in"
- "I python: OK"

Note that we're keeping things simple for the first iteration and we only run the `ubuntu-latest-sdl2-artifacts` artifact.
In the future we may want to test the different bootstraps, build host and even updated recipes dynamically.