### PR TITLE
remove patchelf dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN ${RETRY} apt -y update -qq > /dev/null \
         make \
         openjdk-17-jdk \
         patch \
-        patchelf \
         pkg-config \
         python3 \
         python3-dev \

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -86,7 +86,6 @@ the following command (re-adapted from the `Dockerfile` we use to perform CI bui
         make \
         openjdk-17-jdk \
         patch \
-        patchelf \
         pkg-config \
         python3 \
         python3-dev \

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1311,7 +1311,7 @@ class PyProjectRecipe(PythonRecipe):
             return
 
         self.install_hostpython_prerequisites(
-            packages=["build[virtualenv]", "pip", "setuptools"] + self.hostpython_prerequisites
+            packages=["build[virtualenv]", "pip", "setuptools", "patchelf"] + self.hostpython_prerequisites
         )
         self.patch_shebangs(self._host_recipe.site_bin, self.real_hostpython_location)
 


### PR DESCRIPTION
Previously, users were required to install patchelf manually; without it, various strange errors occurred. This PR removes the need for users to install patchelf themselves, as it is now installed automatically via the hostpython prerequisites.