### PR TITLE
:white_check_mark: Increase test coverage for logger, prerequisites, and pythonpackage

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,226 @@
+import logging
+import sh
+import pytest
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock, patch
 from pythonforandroid import logger
+
+
+class TestColorSetup:
+    """Test color setup and configuration."""
+
+    def teardown_method(self):
+        """Reset color state after each test to avoid affecting other tests."""
+        logger.setup_color('never')
+
+    def test_setup_color_never(self):
+        """Test color disabled when set to 'never'."""
+        logger.setup_color('never')
+        assert not logger.Out_Style._enabled
+        assert not logger.Out_Fore._enabled
+        assert not logger.Err_Style._enabled
+        assert not logger.Err_Fore._enabled
+
+    def test_setup_color_always(self):
+        """Test color enabled when set to 'always'."""
+        logger.setup_color('always')
+        assert logger.Out_Style._enabled
+        assert logger.Out_Fore._enabled
+        assert logger.Err_Style._enabled
+        assert logger.Err_Fore._enabled
+
+    @patch('pythonforandroid.logger.stdout')
+    @patch('pythonforandroid.logger.stderr')
+    def test_setup_color_auto_with_tty(self, mock_stderr, mock_stdout):
+        """Test color enabled when auto and isatty() returns True."""
+        mock_stdout.isatty.return_value = True
+        mock_stderr.isatty.return_value = True
+        logger.setup_color('auto')
+        assert logger.Out_Style._enabled
+        assert logger.Err_Style._enabled
+
+
+class TestUtilityFunctions:
+    """Test logger utility functions."""
+
+    def test_shorten_string_short(self):
+        """Test shorten_string returns string unchanged when under limit."""
+        result = logger.shorten_string("short", 50)
+        assert result == "short"
+
+    def test_shorten_string_long(self):
+        """Test shorten_string truncates long strings correctly."""
+        long_string = "a" * 100
+        result = logger.shorten_string(long_string, 50)
+        assert "...(and" in result
+        assert "more)" in result
+        assert len(result) <= 50
+
+    def test_shorten_string_bytes(self):
+        """Test shorten_string handles bytes input."""
+        byte_string = b"test" * 50
+        result = logger.shorten_string(byte_string, 50)
+        assert "...(and" in result
+
+    @patch.dict('os.environ', {'COLUMNS': '120'})
+    def test_get_console_width_from_env(self):
+        """Test get_console_width reads from COLUMNS env var."""
+        width = logger.get_console_width()
+        assert width == 120
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('os.popen')
+    def test_get_console_width_from_stty(self, mock_popen):
+        """Test get_console_width falls back to stty command."""
+        mock_popen.return_value.read.return_value = "40 80"
+        width = logger.get_console_width()
+        assert width == 80
+        mock_popen.assert_called_once_with('stty size', 'r')
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('os.popen')
+    def test_get_console_width_default(self, mock_popen):
+        """Test get_console_width returns default when stty fails."""
+        mock_popen.return_value.read.side_effect = Exception("stty failed")
+        width = logger.get_console_width()
+        assert width == 100
+
+
+class TestLevelDifferentiatingFormatter:
+    """Test custom log message formatter."""
+
+    def test_format_error_level(self):
+        """Test formatter adds [ERROR] prefix for ERROR level."""
+        formatter = logger.LevelDifferentiatingFormatter('%(message)s')
+        record = logging.LogRecord(
+            name='test', level=40, pathname='', lineno=0,
+            msg='test error', args=(), exc_info=None
+        )
+        formatted = formatter.format(record)
+        assert '[ERROR]' in formatted
+
+    def test_format_warning_level(self):
+        """Test formatter adds [WARNING] prefix for WARNING level."""
+        formatter = logger.LevelDifferentiatingFormatter('%(message)s')
+        record = logging.LogRecord(
+            name='test', level=30, pathname='', lineno=0,
+            msg='test warning', args=(), exc_info=None
+        )
+        formatted = formatter.format(record)
+        assert '[WARNING]' in formatted
+
+    def test_format_info_level(self):
+        """Test formatter adds [INFO] prefix for INFO level."""
+        formatter = logger.LevelDifferentiatingFormatter('%(message)s')
+        record = logging.LogRecord(
+            name='test', level=20, pathname='', lineno=0,
+            msg='test info', args=(), exc_info=None
+        )
+        formatted = formatter.format(record)
+        assert '[INFO]' in formatted
+
+    def test_format_debug_level(self):
+        """Test formatter adds [DEBUG] prefix for DEBUG level."""
+        formatter = logger.LevelDifferentiatingFormatter('%(message)s')
+        record = logging.LogRecord(
+            name='test', level=10, pathname='', lineno=0,
+            msg='test debug', args=(), exc_info=None
+        )
+        formatted = formatter.format(record)
+        assert '[DEBUG]' in formatted
+
+
+class TestShprintErrorHandling:
+    """Test shprint error handling and edge cases."""
+
+    @patch('pythonforandroid.logger.get_console_width')
+    def test_shprint_with_filter(self, mock_width):
+        """Test shprint filters output with _filter parameter."""
+        mock_width.return_value = 100
+
+        command = MagicMock()
+        # Create a mock error with required attributes
+        error = Mock(spec=sh.ErrorReturnCode)
+        error.stdout = b'line1\nfiltered_line\nline3'
+        error.stderr = b''
+        command.side_effect = error
+
+        with pytest.raises(TypeError):
+            logger.shprint(command, _filter='filtered', _tail=10)
+
+    @patch('pythonforandroid.logger.get_console_width')
+    def test_shprint_with_filterout(self, mock_width):
+        """Test shprint excludes output with _filterout parameter."""
+        mock_width.return_value = 100
+
+        command = MagicMock()
+        error = Mock(spec=sh.ErrorReturnCode)
+        error.stdout = b'keep1\nexclude_line\nkeep2'
+        error.stderr = b''
+        command.side_effect = error
+
+        with pytest.raises(TypeError):
+            logger.shprint(command, _filterout='exclude', _tail=10)
+
+    @patch('pythonforandroid.logger.get_console_width')
+    @patch('pythonforandroid.logger.stdout')
+    @patch.dict('os.environ', {'P4A_FULL_DEBUG': '1'})
+    def test_shprint_full_debug_mode(self, mock_stdout, mock_width):
+        """Test shprint in P4A_FULL_DEBUG mode shows all output."""
+        mock_width.return_value = 100
+
+        command = MagicMock()
+        command.return_value = iter(['debug line 1\n', 'debug line 2\n'])
+
+        logger.shprint(command)
+        # In full debug mode, output is written directly to stdout
+        assert mock_stdout.write.called
+
+    @patch('pythonforandroid.logger.get_console_width')
+    @patch.dict('os.environ', {}, clear=True)
+    def test_shprint_critical_failure_exits(self, mock_width):
+        """Test shprint exits on critical command failure."""
+        mock_width.return_value = 100
+
+        command = MagicMock()
+
+        # Create a proper exception class that mimics sh.ErrorReturnCode
+        class MockErrorReturnCode(sh.ErrorReturnCode):
+            def __init__(self):
+                self.full_cmd = 'test'
+                self.stdout = b'output'
+                self.stderr = b'error'
+                self.exit_code = 1
+
+        error = MockErrorReturnCode()
+        command.side_effect = error
+
+        with patch('pythonforandroid.logger.exit', side_effect=SystemExit) as mock_exit:
+            with pytest.raises(SystemExit):
+                logger.shprint(command, _critical=True, _tail=5)
+            mock_exit.assert_called_once_with(1)
+
+
+class TestLoggingHelpers:
+    """Test logging helper functions."""
+
+    @patch('pythonforandroid.logger.logger')
+    def test_info_main(self, mock_logger):
+        """Test info_main logs with bright green formatting."""
+        logger.info_main('test', 'message')
+        mock_logger.info.assert_called_once()
+        # Verify the call contains color codes and text
+        call_args = mock_logger.info.call_args[0][0]
+        assert 'test' in call_args
+        assert 'message' in call_args
+
+    @patch('pythonforandroid.logger.info')
+    def test_info_notify(self, mock_info):
+        """Test info_notify logs with blue formatting."""
+        logger.info_notify('notification')
+        mock_info.assert_called_once()
+        call_args = mock_info.call_args[0][0]
+        assert 'notification' in call_args
 
 
 class TestShprint(unittest.TestCase):

--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -2,8 +2,10 @@ import unittest
 from unittest import mock, skipIf
 
 import sys
+import pytest
 
 from pythonforandroid.prerequisites import (
+    Prerequisite,
     JDKPrerequisite,
     HomebrewPrerequisite,
     OpenSSLPrerequisite,
@@ -13,6 +15,7 @@ from pythonforandroid.prerequisites import (
     PkgConfigPrerequisite,
     CmakePrerequisite,
     get_required_prerequisites,
+    check_and_install_default_prerequisites,
 )
 
 
@@ -300,3 +303,303 @@ class TestDefaultPrerequisitesCheckandInstall(unittest.TestCase):
             [
             ],
         )
+
+
+class TestPrerequisiteBaseClass:
+    """Test base Prerequisite class methods."""
+
+    @mock.patch('pythonforandroid.prerequisites.info')
+    @mock.patch.object(Prerequisite, 'checker')
+    def test_is_valid_when_met(self, mock_checker, mock_info):
+        """Test is_valid returns True when prerequisite is met."""
+        mock_checker.return_value = True
+        prerequisite = Prerequisite()
+        result = prerequisite.is_valid()
+        assert result == (True, "")
+        mock_info.assert_called()
+        assert "is met" in mock_info.call_args[0][0]
+
+    @mock.patch('pythonforandroid.prerequisites.warning')
+    @mock.patch.object(Prerequisite, 'checker')
+    def test_is_valid_when_not_met_non_mandatory(self, mock_checker, mock_warning):
+        """Test is_valid warns when non-mandatory prerequisite not met."""
+        mock_checker.return_value = False
+        prerequisite = Prerequisite()
+        prerequisite.mandatory = dict(linux=False, darwin=False)
+
+        result = prerequisite.is_valid()
+        assert result is None
+        mock_warning.assert_called()
+        assert "not met" in mock_warning.call_args[0][0]
+
+    @mock.patch('pythonforandroid.prerequisites.error')
+    @mock.patch.object(Prerequisite, 'checker')
+    @mock.patch('sys.platform', 'linux')
+    def test_is_valid_when_not_met_mandatory(self, mock_checker, mock_error):
+        """Test is_valid errors when mandatory prerequisite not met."""
+        mock_checker.return_value = False
+        prerequisite = Prerequisite()
+        prerequisite.mandatory = dict(linux=True, darwin=False)
+
+        result = prerequisite.is_valid()
+        assert result is None
+        mock_error.assert_called()
+        assert "not met" in mock_error.call_args[0][0]
+
+    @mock.patch('sys.platform', 'linux')
+    @mock.patch.object(Prerequisite, 'linux_checker')
+    def test_checker_calls_linux_checker(self, mock_linux_checker):
+        """Test checker dispatches to linux_checker on Linux."""
+        mock_linux_checker.return_value = True
+        prerequisite = Prerequisite()
+        result = prerequisite.checker()
+        assert result is True
+        mock_linux_checker.assert_called_once()
+
+    @mock.patch('sys.platform', 'darwin')
+    @mock.patch.object(Prerequisite, 'darwin_checker')
+    def test_checker_calls_darwin_checker(self, mock_darwin_checker):
+        """Test checker dispatches to darwin_checker on macOS."""
+        mock_darwin_checker.return_value = True
+        prerequisite = Prerequisite()
+        result = prerequisite.checker()
+        assert result is True
+        mock_darwin_checker.assert_called_once()
+
+    @mock.patch('sys.platform', 'win32')
+    def test_checker_raises_on_unsupported_platform(self):
+        """Test checker raises exception on unsupported platform."""
+        prerequisite = Prerequisite()
+        with pytest.raises(Exception, match="Unsupported platform"):
+            prerequisite.checker()
+
+
+class TestPrerequisiteInstallation:
+    """Test prerequisite installation workflow."""
+
+    @mock.patch.dict('os.environ', {'PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE': '1'})
+    @mock.patch('builtins.input')
+    def test_ask_to_install_user_accepts(self, mock_input):
+        """Test ask_to_install returns True when user enters 'y'."""
+        prerequisite = Prerequisite()
+        prerequisite.name = "TestPrerequisite"
+        mock_input.return_value = 'y'
+        result = prerequisite.ask_to_install()
+        assert result is True
+
+    @mock.patch.dict('os.environ', {'PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE': '1'})
+    @mock.patch('builtins.input')
+    def test_ask_to_install_user_declines(self, mock_input):
+        """Test ask_to_install returns False when user enters 'n'."""
+        prerequisite = Prerequisite()
+        prerequisite.name = "TestPrerequisite"
+        mock_input.return_value = 'n'
+        result = prerequisite.ask_to_install()
+        assert result is False
+
+    @mock.patch.dict('os.environ', {'PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE': '0'})
+    @mock.patch('pythonforandroid.prerequisites.info')
+    def test_ask_to_install_non_interactive(self, mock_info):
+        """Test ask_to_install returns True in non-interactive mode (CI)."""
+        prerequisite = Prerequisite()
+        prerequisite.name = "TestPrerequisite"
+        result = prerequisite.ask_to_install()
+        assert result is True
+        mock_info.assert_called()
+        assert "not interactive" in mock_info.call_args[0][0]
+
+    @mock.patch('sys.platform', 'linux')
+    @mock.patch.object(Prerequisite, 'ask_to_install')
+    @mock.patch.object(Prerequisite, 'linux_installer')
+    @mock.patch('pythonforandroid.prerequisites.info')
+    def test_install_when_user_accepts_linux(self, mock_info, mock_installer, mock_ask):
+        """Test install calls linux_installer when user accepts on Linux."""
+        prerequisite = Prerequisite()
+        prerequisite.installer_is_supported = dict(linux=True, darwin=True)
+        mock_ask.return_value = True
+        prerequisite.install()
+        mock_installer.assert_called_once()
+
+    @mock.patch('sys.platform', 'darwin')
+    @mock.patch.object(Prerequisite, 'ask_to_install')
+    @mock.patch.object(Prerequisite, 'darwin_installer')
+    def test_install_when_user_accepts_darwin(self, mock_installer, mock_ask):
+        """Test install calls darwin_installer when user accepts on macOS."""
+        prerequisite = Prerequisite()
+        prerequisite.installer_is_supported = dict(linux=True, darwin=True)
+        mock_ask.return_value = True
+        prerequisite.install()
+        mock_installer.assert_called_once()
+
+    @mock.patch.object(Prerequisite, 'ask_to_install')
+    @mock.patch('pythonforandroid.prerequisites.info')
+    def test_install_when_user_declines(self, mock_info, mock_ask):
+        """Test install skips installation when user declines."""
+        prerequisite = Prerequisite()
+        prerequisite.name = "TestPrerequisite"
+        mock_ask.return_value = False
+        prerequisite.install()
+        mock_info.assert_called()
+        assert "Skipping" in mock_info.call_args[0][0]
+
+    def test_install_is_supported(self):
+        """Test install_is_supported returns correct platform support."""
+        prerequisite = Prerequisite()
+        prerequisite.installer_is_supported = dict(linux=True, darwin=False)
+        with mock.patch('sys.platform', 'linux'):
+            assert prerequisite.install_is_supported() is True
+
+
+class TestJDKPrerequisiteVersionChecking:
+    """Test JDK version checking logic."""
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.Popen')
+    @mock.patch('os.path.exists')
+    def test_darwin_jdk_is_supported_valid_version(self, mock_exists, mock_popen):
+        """Test _darwin_jdk_is_supported returns True for valid JDK 17."""
+        prerequisite = JDKPrerequisite()
+        mock_exists.return_value = True
+
+        # Mock javac version output
+        mock_process = mock.Mock()
+        mock_process.returncode = 0
+        mock_process.communicate.return_value = (b'javac 17.0.2\n', b'')
+        mock_popen.return_value = mock_process
+
+        result = prerequisite._darwin_jdk_is_supported('/path/to/jdk')
+        assert result is True
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.Popen')
+    @mock.patch('os.path.exists')
+    def test_darwin_jdk_is_supported_invalid_version(self, mock_exists, mock_popen):
+        """Test _darwin_jdk_is_supported returns False for wrong JDK version."""
+        prerequisite = JDKPrerequisite()
+        mock_exists.return_value = True
+
+        mock_process = mock.Mock()
+        mock_process.returncode = 0
+        mock_process.communicate.return_value = (b'javac 11.0.1\n', b'')
+        mock_popen.return_value = mock_process
+
+        result = prerequisite._darwin_jdk_is_supported('/path/to/jdk')
+        assert result is False
+
+    @mock.patch('os.path.exists')
+    def test_darwin_jdk_is_supported_no_javac(self, mock_exists):
+        """Test _darwin_jdk_is_supported returns False when javac doesn't exist."""
+        prerequisite = JDKPrerequisite()
+        mock_exists.return_value = False
+        result = prerequisite._darwin_jdk_is_supported('/path/to/jdk')
+        assert result is False
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.run')
+    def test_darwin_get_libexec_jdk_path(self, mock_run):
+        """Test _darwin_get_libexec_jdk_path calls java_home correctly."""
+        prerequisite = JDKPrerequisite()
+        mock_run.return_value = mock.Mock(stdout=b'/Library/Java/JDK/17\n')
+
+        result = prerequisite._darwin_get_libexec_jdk_path(version='17')
+        assert result == '/Library/Java/JDK/17'
+        mock_run.assert_called_once()
+        assert '-v' in mock_run.call_args[0][0]
+        assert '17' in mock_run.call_args[0][0]
+
+    @mock.patch.dict('os.environ', {'JAVA_HOME': '/custom/jdk'})
+    @mock.patch.object(JDKPrerequisite, '_darwin_jdk_is_supported')
+    def test_darwin_checker_uses_java_home_env(self, mock_is_supported):
+        """Test darwin_checker uses JAVA_HOME env var if set."""
+        prerequisite = JDKPrerequisite()
+        mock_is_supported.return_value = True
+
+        result = prerequisite.darwin_checker()
+        assert result is True
+        mock_is_supported.assert_called_with('/custom/jdk')
+
+
+class TestHomebrewHelpers:
+    """Test Homebrew helper methods."""
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.Popen')
+    def test_darwin_get_brew_formula_location_prefix_success(self, mock_popen):
+        """Test _darwin_get_brew_formula_location_prefix returns path on success."""
+        prerequisite = Prerequisite()
+        mock_process = mock.Mock()
+        mock_process.returncode = 0
+        mock_process.communicate.return_value = (b'/opt/homebrew/opt/openssl@3\n', b'')
+        mock_popen.return_value = mock_process
+
+        result = prerequisite._darwin_get_brew_formula_location_prefix('openssl@3')
+        assert result == '/opt/homebrew/opt/openssl@3'
+        mock_popen.assert_called_once()
+        assert 'brew' in mock_popen.call_args[0][0]
+        assert '--prefix' in mock_popen.call_args[0][0]
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.Popen')
+    @mock.patch('pythonforandroid.prerequisites.error')
+    def test_darwin_get_brew_formula_location_prefix_failure(self, mock_error, mock_popen):
+        """Test _darwin_get_brew_formula_location_prefix returns None on failure."""
+        prerequisite = Prerequisite()
+        mock_process = mock.Mock()
+        mock_process.returncode = 1
+        mock_process.communicate.return_value = (b'', b'Formula not found\n')
+        mock_popen.return_value = mock_process
+
+        result = prerequisite._darwin_get_brew_formula_location_prefix('nonexistent')
+        assert result is None
+        mock_error.assert_called()
+
+    @mock.patch('pythonforandroid.prerequisites.subprocess.Popen')
+    def test_darwin_get_brew_formula_location_prefix_with_installed_flag(self, mock_popen):
+        """Test _darwin_get_brew_formula_location_prefix uses --installed flag."""
+        prerequisite = Prerequisite()
+        mock_process = mock.Mock()
+        mock_process.returncode = 0
+        mock_process.communicate.return_value = (b'/opt/homebrew/opt/cmake\n', b'')
+        mock_popen.return_value = mock_process
+
+        prerequisite._darwin_get_brew_formula_location_prefix('cmake', installed=True)
+        assert '--installed' in mock_popen.call_args[0][0]
+
+
+class TestCheckAndInstallPrerequisites:
+    """Test main prerequisite checking workflow."""
+
+    @mock.patch('pythonforandroid.prerequisites.get_required_prerequisites')
+    def test_check_and_install_all_met(self, mock_get_prereqs):
+        """Test check_and_install when all prerequisites are met."""
+        # Create mock prerequisites that are all valid
+        mock_prereq1 = mock.Mock()
+        mock_prereq1.is_valid.return_value = True
+        mock_prereq2 = mock.Mock()
+        mock_prereq2.is_valid.return_value = True
+
+        mock_get_prereqs.return_value = [mock_prereq1, mock_prereq2]
+
+        check_and_install_default_prerequisites()
+
+        # Verify prerequisites were checked
+        mock_prereq1.is_valid.assert_called_once()
+        mock_prereq2.is_valid.assert_called_once()
+
+        # Verify no installation attempted
+        mock_prereq1.install.assert_not_called()
+        mock_prereq2.install.assert_not_called()
+
+    @mock.patch('pythonforandroid.prerequisites.get_required_prerequisites')
+    def test_check_and_install_some_not_met(self, mock_get_prereqs):
+        """Test check_and_install when some prerequisites are not met."""
+        # First prerequisite valid, second not valid but has installer
+        mock_prereq1 = mock.Mock()
+        mock_prereq1.is_valid.return_value = True
+
+        mock_prereq2 = mock.Mock()
+        mock_prereq2.is_valid.return_value = False
+        mock_prereq2.install_is_supported.return_value = True
+
+        mock_get_prereqs.return_value = [mock_prereq1, mock_prereq2]
+
+        check_and_install_default_prerequisites()
+
+        # Verify second prerequisite triggers installation workflow
+        mock_prereq2.show_helper.assert_called_once()
+        mock_prereq2.install.assert_called_once()


### PR DESCRIPTION
Add comprehensive tests to improve coverage:

Logger module:
- Color setup and configuration (never/always/auto modes)
- Utility functions (shorten_string, get_console_width)
- LevelDifferentiatingFormatter for all log levels
- shprint error handling with filters and critical failures
- Logging helpers (info_main, info_notify)

Prerequisites module:
- Base Prerequisite class methods (is_valid, checker)
- Installation workflow (ask_to_install, install)
- JDK version checking and JAVA_HOME support
- Homebrew formula location helpers
- Main check_and_install workflow

Pythonpackage module:
- Parametrized tests for parse_as_folder_reference edge cases
- Filesystem path detection for relative paths and git URLs
- Dependency transformation with query params and fragments
- Error handling for package extraction and invalid metadata