### PR TITLE
Add foregroundServiceType support to AndroidManifest templates

### DIFF
--- a/doc/source/services.rst
+++ b/doc/source/services.rst
@@ -64,9 +64,15 @@ The ``PATH_TO_SERVICE_PY`` is the relative path to the service entry point (like
 You can optionally specify the following parameters:
  - :code:`:foreground` for launching a service as an Android foreground service
  - :code:`:sticky` for launching a service that gets restarted by the Android OS on exit/error
+ - :code:`:foregroundServiceType=TYPE` to specify the type of foreground service,
+   where TYPE is one of the valid Android foreground service types
+   (see `Android documentation <https://developer.android.com/reference/android/app/Service.html#START_FOREGROUND_SERVICE>`__
+   for more details). You can specify multiple types separated by a pipe
+   character "|", e.g. :code:`:foregroundServiceType=location|mediaPlayback`. Mandatory
+   if :code:`:foreground` is used on Android 14+.
 
 Full command with all the optional parameters included would be: 
-:code:`--service=myservice:services/myservice.py:foreground:sticky`
+:code:`--service=myservice:services/myservice.py:foreground:sticky:foregroundServiceType=location`
 
 You can add multiple
 :code:`--service` arguments to include multiple services, or separate

--- a/doc/source/services.rst
+++ b/doc/source/services.rst
@@ -66,7 +66,7 @@ You can optionally specify the following parameters:
  - :code:`:sticky` for launching a service that gets restarted by the Android OS on exit/error
  - :code:`:foregroundServiceType=TYPE` to specify the type of foreground service,
    where TYPE is one of the valid Android foreground service types
-   (see `Android documentation <https://developer.android.com/reference/android/app/Service.html#START_FOREGROUND_SERVICE>`__
+   (see `Android documentation <https://developer.android.com/develop/background-work/services/fgs/service-types>`__
    for more details). You can specify multiple types separated by a pipe
    character "|", e.g. :code:`:foregroundServiceType=location|mediaPlayback`. Mandatory
    if :code:`:foreground` is used on Android 14+.

--- a/pythonforandroid/bootstraps/_sdl_common/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/_sdl_common/build/templates/AndroidManifest.tmpl.xml
@@ -115,8 +115,11 @@
         <service android:name="{{ args.service_class_name }}"
                  android:process=":pythonservice" />
         {% endif %}
-        {% for name in service_names %}
+        {% for name, foreground_type in service_data %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
+                 {% if foreground_type %}
+                 android:foregroundServiceType="{{ foreground_type }}"
+                 {% endif %}
                  android:process=":service_{{ name }}" />
         {% endfor %}
         {% for name in native_services %}

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -466,7 +466,7 @@ main.py that loads it.''')
         if exists(service_main) or exists(service_main + 'o'):
             service = True
 
-    service_names = []
+    service_data = []
     base_service_class = args.service_class_name.split('.')[-1]
     for sid, spec in enumerate(args.services):
         spec = spec.split(':')
@@ -476,8 +476,20 @@ main.py that loads it.''')
 
         foreground = 'foreground' in options
         sticky = 'sticky' in options
+        foreground_type_option = next((s for s in options if s.startswith('foregroundServiceType')), None)
+        if foreground_type_option:
+            try:
+                foreground_type = foreground_type_option.split('=')[1]
+                if not foreground_type:
+                    raise ValueError('Missing value for `foregroundServiceType` option. '
+                                    'Expected format: foregroundServiceType=location')
+            except IndexError:
+                raise ValueError('Missing value for `foregroundServiceType` option. '
+                                'Expected format: foregroundServiceType=location')
+        else:
+            foreground_type = None
 
-        service_names.append(name)
+        service_data.append((name, foreground_type))
         service_target_path =\
             'src/main/java/{}/Service{}.java'.format(
                 args.package.replace(".", "/"),
@@ -541,10 +553,10 @@ main.py that loads it.''')
     render_args = {
         "args": args,
         "service": service,
-        "service_names": service_names,
+        "service_data": service_data,
         "android_api": android_api,
         "debug": "debug" in args.build_mode,
-        "native_services": args.native_services
+        "native_services": args.native_services,
     }
     if is_sdl_bootstrap():
         render_args["url_scheme"] = url_scheme

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -477,17 +477,15 @@ main.py that loads it.''')
         foreground = 'foreground' in options
         sticky = 'sticky' in options
         foreground_type_option = next((s for s in options if s.startswith('foregroundServiceType')), None)
+        foreground_type = None
         if foreground_type_option:
-            try:
-                foreground_type = foreground_type_option.split('=')[1]
-                if not foreground_type:
-                    raise ValueError('Missing value for `foregroundServiceType` option. '
-                                    'Expected format: foregroundServiceType=location')
-            except IndexError:
-                raise ValueError('Missing value for `foregroundServiceType` option. '
-                                'Expected format: foregroundServiceType=location')
-        else:
-            foreground_type = None
+            parts = foreground_type_option.split('=', 1)
+            if len(parts) != 2 or not parts[1]:
+                raise ValueError(
+                    'Missing value for `foregroundServiceType` option. '
+                    'Expected format: foregroundServiceType=location'
+                )
+            foreground_type = parts[1]
 
         service_data.append((name, foreground_type))
         service_target_path =\

--- a/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
@@ -91,8 +91,11 @@
         <service android:name="{{ args.service_class_name }}"
                  android:process=":pythonservice" />
         {% endif %}
-        {% for name in service_names %}
+        {% for name, foreground_type in service_data %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
+                 {% if foreground_type %}
+                 android:foregroundServiceType="{{ foreground_type }}"
+                 {% endif %}
                  android:process=":service_{{ name }}" />
         {% endfor %}
         {% for name in native_services %}

--- a/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
@@ -7,8 +7,11 @@
     <uses-sdk android:minSdkVersion="{{ args.min_sdk_version }}" android:targetSdkVersion="{{ android_api }}" />
 
     <application {% if debug %}android:debuggable="true"{% endif %} >
-        {% for name in service_names %}
+        {% for name, foreground_type in service_data %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
+                 {% if foreground_type %}
+                 android:foregroundServiceType="{{ foreground_type }}"
+                 {% endif %}
                  android:process=":service_{{ name }}"
                  android:exported="true" />
         {% endfor %}

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -72,8 +72,11 @@
                  android:process=":pythonservice"
                  android:exported="true"/>
         {% endif %}
-        {% for name in service_names %}
+        {% for name, foreground_type in service_data %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
+                 {% if foreground_type %}
+                 android:foregroundServiceType="{{ foreground_type }}"
+                 {% endif %}
                  android:process=":service_{{ name }}"
                  android:exported="true" />
         {% endfor %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -81,8 +81,11 @@
         <service android:name="org.kivy.android.PythonService"
                  android:process=":pythonservice" />
         {% endif %}
-        {% for name in service_names %}
+        {% for name, foreground_type in service_data %}
         <service android:name="{{ args.package }}.Service{{ name|capitalize }}"
+                 {% if foreground_type %}
+                 android:foregroundServiceType="{{ foreground_type }}"
+                 {% endif %}
                  android:process=":service_{{ name }}" />
         {% endfor %}
 


### PR DESCRIPTION
This commit introduces support for the 'foregroundServiceType' attribute in the AndroidManifest templates across all bootstraps. This change allows specifying the service type for foreground services, which is a mandatory requirement for apps targeting Android 14 (API level 34) and above to prevent runtime crashes.

example of how to specify in buildozer.spec file:
```spec
services = Test:service.py:foreground:sticky:foregroundServiceType=location|dataSync
```
or
```spec
services = Test:service.py:foreground:sticky:foregroundServiceType=location
```
Android documentation references:

- https://developer.android.com/develop/background-work/services/fgs/changes#api-34
- https://developer.android.com/develop/background-work/services/fgs/service-types