### PR TITLE
:recycle: Consolidate assemble_distribution() into base Bootstrap

### DIFF
--- a/pythonforandroid/bootstraps/_sdl_common/__init__.py
+++ b/pythonforandroid/bootstraps/_sdl_common/__init__.py
@@ -1,10 +1,7 @@
 from os.path import join
 
-import sh
-
-from pythonforandroid.toolchain import (
-    Bootstrap, shprint, current_directory, info, info_main)
-from pythonforandroid.util import ensure_dir, rmdir
+from pythonforandroid.toolchain import Bootstrap
+from pythonforandroid.util import ensure_dir
 
 
 class SDLGradleBootstrap(Bootstrap):
@@ -12,38 +9,15 @@ class SDLGradleBootstrap(Bootstrap):
 
     recipe_depends = []
 
-    def assemble_distribution(self):
-        info_main("# Creating Android project ({})".format(self.name))
+    def _assemble_distribution_for_arch(self, arch):
+        """SDL bootstrap skips distribute_aars() - handled differently."""
+        self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
+        # Note: SDL bootstrap does not call distribute_aars()
 
-        rmdir(self.dist_dir)
-        info("Copying SDL/gradle build")
-        shprint(sh.cp, "-r", self.build_dir, self.dist_dir)
-
-        # either the build use environment variable (ANDROID_HOME)
-        # or the local.properties if exists
-        with current_directory(self.dist_dir):
-            with open('local.properties', 'w') as fileh:
-                fileh.write('sdk.dir={}'.format(self.ctx.sdk_dir))
-
-        with current_directory(self.dist_dir):
-            info("Copying Python distribution")
-
-            self.distribute_javaclasses(self.ctx.javaclass_dir,
-                                        dest_dir=join("src", "main", "java"))
-
-            for arch in self.ctx.archs:
-                python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
-                ensure_dir(python_bundle_dir)
-
-                self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
-                site_packages_dir = self.ctx.python_recipe.create_python_bundle(
-                    join(self.dist_dir, python_bundle_dir), arch)
-                if not self.ctx.with_debug_symbols:
-                    self.strip_libraries(arch)
-                self.fry_eggs(site_packages_dir)
-
-            if 'sqlite3' not in self.ctx.recipe_build_order:
-                with open('blacklist.txt', 'a') as fileh:
-                    fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
-
-        super().assemble_distribution()
+        python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
+        ensure_dir(python_bundle_dir)
+        site_packages_dir = self.ctx.python_recipe.create_python_bundle(
+            join(self.dist_dir, python_bundle_dir), arch)
+        if not self.ctx.with_debug_symbols:
+            self.strip_libraries(arch)
+        self.fry_eggs(site_packages_dir)

--- a/pythonforandroid/bootstraps/service_only/__init__.py
+++ b/pythonforandroid/bootstraps/service_only/__init__.py
@@ -1,8 +1,4 @@
-import sh
-from os.path import join
-from pythonforandroid.toolchain import (
-    Bootstrap, current_directory, info, info_main, shprint)
-from pythonforandroid.util import ensure_dir, rmdir
+from pythonforandroid.toolchain import Bootstrap
 
 
 class ServiceOnlyBootstrap(Bootstrap):
@@ -12,41 +8,6 @@ class ServiceOnlyBootstrap(Bootstrap):
     recipe_depends = list(
         set(Bootstrap.recipe_depends).union({'genericndkbuild'})
     )
-
-    def assemble_distribution(self):
-        info_main('# Creating Android project from build and {} bootstrap'.format(
-            self.name))
-
-        info('This currently just copies the build stuff straight from the build dir.')
-        rmdir(self.dist_dir)
-        shprint(sh.cp, '-r', self.build_dir, self.dist_dir)
-        with current_directory(self.dist_dir):
-            with open('local.properties', 'w') as fileh:
-                fileh.write('sdk.dir={}'.format(self.ctx.sdk_dir))
-
-        with current_directory(self.dist_dir):
-            info('Copying python distribution')
-
-            self.distribute_javaclasses(self.ctx.javaclass_dir,
-                                        dest_dir=join("src", "main", "java"))
-
-            for arch in self.ctx.archs:
-                self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
-                self.distribute_aars(arch)
-
-                python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
-                ensure_dir(python_bundle_dir)
-                site_packages_dir = self.ctx.python_recipe.create_python_bundle(
-                    join(self.dist_dir, python_bundle_dir), arch)
-                if not self.ctx.with_debug_symbols:
-                    self.strip_libraries(arch)
-                self.fry_eggs(site_packages_dir)
-
-            if 'sqlite3' not in self.ctx.recipe_build_order:
-                with open('blacklist.txt', 'a') as fileh:
-                    fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
-
-        super().assemble_distribution()
 
 
 bootstrap = ServiceOnlyBootstrap()

--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -1,9 +1,4 @@
-from os.path import join
-
-import sh
-
-from pythonforandroid.toolchain import Bootstrap, current_directory, info, info_main, shprint
-from pythonforandroid.util import ensure_dir, rmdir
+from pythonforandroid.toolchain import Bootstrap
 
 
 class WebViewBootstrap(Bootstrap):
@@ -12,40 +7,6 @@ class WebViewBootstrap(Bootstrap):
     recipe_depends = list(
         set(Bootstrap.recipe_depends).union({'genericndkbuild'})
     )
-
-    def assemble_distribution(self):
-        info_main('# Creating Android project from build and {} bootstrap'.format(
-            self.name))
-
-        rmdir(self.dist_dir)
-        shprint(sh.cp, '-r', self.build_dir, self.dist_dir)
-        with current_directory(self.dist_dir):
-            with open('local.properties', 'w') as fileh:
-                fileh.write('sdk.dir={}'.format(self.ctx.sdk_dir))
-
-        with current_directory(self.dist_dir):
-            info('Copying python distribution')
-
-            self.distribute_javaclasses(self.ctx.javaclass_dir,
-                                        dest_dir=join("src", "main", "java"))
-
-            for arch in self.ctx.archs:
-                self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
-                self.distribute_aars(arch)
-
-                python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
-                ensure_dir(python_bundle_dir)
-                site_packages_dir = self.ctx.python_recipe.create_python_bundle(
-                    join(self.dist_dir, python_bundle_dir), arch)
-                if not self.ctx.with_debug_symbols:
-                    self.strip_libraries(arch)
-                self.fry_eggs(site_packages_dir)
-
-            if 'sqlite3' not in self.ctx.recipe_build_order:
-                with open('blacklist.txt', 'a') as fileh:
-                    fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
-
-        super().assemble_distribution()
 
 
 bootstrap = WebViewBootstrap()


### PR DESCRIPTION
Move duplicated assemble_distribution() logic from service_only, webview, and _sdl_common bootstraps into the base Bootstrap class using the Template Method pattern.

- Add _assemble_distribution_for_arch() hook for per-arch customization
- SDL bootstrap overrides hook to skip distribute_aars()
- service_only and webview now use base class directly
- Qt bootstrap unchanged (single-arch constraint requires full override)
- Update tests to mock base class instead of individual modules