### PR TITLE
:construction_worker: CI disk cleanup via maximize-build-space

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -78,17 +78,18 @@ jobs:
           - name: qt
             target: testapps-qt
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@v10
+      with:
+        root-reserve-mb: 30720
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
     - name: Checkout python-for-android
       uses: actions/checkout@v5
-    # helps with GitHub runner getting out of space
-    - name: Free disk space
-      run: |
-        df -h
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt -y clean
-        docker images -q | xargs -r docker rmi
-        df -h
     - name: Build python-for-android docker image
       run: |
         docker build --tag=kivy/python-for-android .
@@ -203,19 +204,20 @@ jobs:
     env:
       REBUILD_UPDATED_RECIPES_EXTRA_ARGS: --arch=${{ matrix.android_arch }}
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@v10
+      with:
+        root-reserve-mb: 30720
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
     - name: Checkout python-for-android (all-history)
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    # helps with GitHub runner getting out of space
-    - name: Free disk space
-      run: |
-        df -h
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt -y clean
-        docker images -q | xargs -r docker rmi
-        df -h
     - name: Pull docker image
       run: |
         make docker/pull


### PR DESCRIPTION
Replace manual disk cleanup scripts with easimon/maximize-build-space@v10 in ubuntu_build and ubuntu_rebuild_updated_recipes jobs. This action can free 40-60 GB compared to the previous ~2-4 GB cleanup, resolving intermittent "No space left on device" build failures.