### PR TITLE
:memo: Fix documentation linkcheck failures

### DIFF
--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -140,7 +140,7 @@ With Kivy, add an ``on_pause`` method to your App class, which returns True::
 
 With the webview bootstrap, pausing should work automatically.
 
-Under SDL2, you can handle the `appropriate events <https://wiki.libsdl.org/SDL_EventType>`__ (see SDL_APP_WILLENTERBACKGROUND etc.).
+Under SDL2, you can handle the `appropriate events <https://wiki.libsdl.org/SDL3/SDL_EventType>`__ (see SDL_APP_WILLENTERBACKGROUND etc.).
 
 
 Observing Activity result

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -321,3 +321,15 @@ linkcheck_ignore = [
     r"https://github.com/kivy/python-for-android/blob.*",
     ]
 
+# Allow redirects for URLs where we prefer to keep the original form
+linkcheck_allowed_redirects = {
+    # Kivy chat redirects to Discord invite
+    r"https://chat\.kivy\.org/": r"https://discord\.com/.*",
+    # GitHub archive URLs redirect to codeload
+    r"https://github\.com/kivy/python-for-android/archive/.*": r"https://codeload\.github\.com/.*",
+    # GitHub gist homepage redirects to starred
+    r"https://gist\.github\.com/$": r"https://gist\.github\.com/.*",
+    # Google Play Store redirects
+    r"https://play\.google\.com/store/$": r"https://play\.google\.com/store/.*",
+}
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,7 +18,7 @@ It can generate:
 
 It supports multiple CPU architectures.
 
-It supports apps developed with `Kivy framework <http://kivy.org>`_, but was
+It supports apps developed with `Kivy framework <https://kivy.org/>`_, but was
 built to be flexible about the backend libraries (through "bootstraps"), and
 also supports `PySDL2 <https://pypi.org/project/PySDL2/>`_, and a
 `WebView <https://developer.android.com/reference/android/webkit/WebView>`_ with
@@ -34,7 +34,7 @@ dependencies for Android devices, and bundling it with the app's python code
 and dependencies. The Python code is then interpreted on the Android device.
 
 It is recommended that python-for-android be used via
-`Buildozer <https://buildozer.readthedocs.io/>`_, which ensures the correct
+`Buildozer <https://buildozer.readthedocs.io/en/latest/>`_, which ensures the correct
 dependencies are pre-installed, and centralizes the configuration. However,
 python-for-android is not limited to being used with Buildozer.
 


### PR DESCRIPTION
Update 3 URLs to their final destinations to avoid redirects:
- kivy.org: use HTTPS
- buildozer.readthedocs.io: include /en/latest/ path
- wiki.libsdl.org: update to SDL3 path

Add linkcheck_allowed_redirects config for URLs where we prefer to keep the original form (chat.kivy.org, GitHub archives, gist, Play Store).

Fixes build failure "build finished with problems, 2 warnings." https://github.com/kivy/python-for-android/actions/runs/20007003935/job/57370783126