### PR TITLE
`ffmpeg`, `python3`: include executable

### DIFF
--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -125,7 +125,7 @@ enabled in the build configuration:
 
 Without these, FFmpeg may be present but lack the required codec support.
 
-See also: `APK native library execution restrictions <https://github.com/agnostic-apollo/Android-Docs/blob/master/site/pages/en/projects/docs/apps/processes/app-data-file-execute-restrictions.md#apk-native-library>`_
+See also: `APK native library execution restrictions <https://github.com/agnostic-apollo/Android-Docs/blob/master/site/pages/en/projects/docs/apps/processes/app-data-file-execute-restrictions.md>`_
 
 Dismissing the splash screen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -80,6 +80,53 @@ https://developer.android.com/reference/android/Manifest.permission
 Other common tasks
 ------------------
 
+Running executables
+~~~~~~~~~~~~~~~~~~~
+
+Android restricts executing files from application data directories.
+``python-for-android`` works around this by creating symbolic links to a
+small set of supported executables inside an internal executable
+directory that is added to ``PATH``.
+
+During startup, ``start.c`` (compiled into ``libmain.so``) scans loaded
+native libraries and creates symlinks for any library matching::
+
+    lib<binary_name>bin.so
+
+Each matching library is exposed at runtime as::
+
+    <binary_name>
+
+For example::
+
+    libffmpegbin.so -> ffmpeg
+
+Recipe developers may expose additional executables by renaming them
+using the same naming convention.
+
+The following example performs a minimal FFmpeg sanity check using an
+in-memory test source and discards the output::
+
+    import subprocess
+
+    subprocess.run(
+        ["ffmpeg", "-f", "lavfi", "-i", "testsrc", "-t", "1", "-f", "null", "-"],
+        check=True
+    )
+
+This verifies that ``ffmpeg`` is available and executable on the device.
+Ensure ``ffmpeg`` is included in your ``requirements``.
+
+If video encoding is required, the following codec options must also be
+enabled in the build configuration:
+
+- ``av_codecs``
+- ``libx264``
+
+Without these, FFmpeg may be present but lack the required codec support.
+
+See also: `APK native library execution restrictions <https://github.com/agnostic-apollo/Android-Docs/blob/master/site/pages/en/projects/docs/apps/processes/app-data-file-execute-restrictions.md#apk-native-library>`_
+
 Dismissing the splash screen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pythonforandroid/androidndk.py
+++ b/pythonforandroid/androidndk.py
@@ -67,6 +67,10 @@ class AndroidNDK:
         return f"{self.llvm_binutils_prefix}strip"
 
     @property
+    def llvm_nm(self):
+        return f"{self.llvm_binutils_prefix}nm"
+
+    @property
     def sysroot(self):
         return os.path.join(self.llvm_prebuilt_dir, "sysroot")
 

--- a/pythonforandroid/recipes/ffmpeg/patches/backport-Android15-MediaCodec-fix.patch
+++ b/pythonforandroid/recipes/ffmpeg/patches/backport-Android15-MediaCodec-fix.patch
@@ -1,0 +1,236 @@
+From 4531cc1b325b50a77fa22981f44a25fbce025a5e Mon Sep 17 00:00:00 2001
+From: Dmitrii Okunev <xaionaro@dx.center>
+Date: Sat, 22 Nov 2025 19:57:19 +0000
+Subject: [PATCH] fftools: Fix MediaCodec on Android15+
+
+On Android15+ MediaCodec HAL backend was switched from HIDL to AIDL.
+As a result, MediaCodec operations started to hang, see:
+
+    https://trac.ffmpeg.org/ticket/11363
+    https://github.com/termux/termux-packages/issues/21264
+    https://issuetracker.google.com/issues/382831999
+
+To fix that it is necessary to initialize binder thread pool.
+
+Signed-off-by: Dmitrii Okunev <xaionaro@dx.center>
+---
+ compat/android/binder.c | 114 ++++++++++++++++++++++++++++++++++++++++
+ compat/android/binder.h |  31 +++++++++++
+ configure               |   3 +-
+ fftools/Makefile        |   1 +
+ fftools/ffmpeg.c        |   7 +++
+ 5 files changed, 155 insertions(+), 1 deletion(-)
+ create mode 100644 compat/android/binder.c
+ create mode 100644 compat/android/binder.h
+
+diff --git a/compat/android/binder.c b/compat/android/binder.c
+new file mode 100644
+index 0000000000..a214d977cc
+--- /dev/null
++++ b/compat/android/binder.c
+@@ -0,0 +1,114 @@
++/*
++ * Android Binder handler
++ *
++ * Copyright (c) 2025 Dmitrii Okunev
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++
++#if defined(__ANDROID__)
++
++#include <dlfcn.h>
++#include <stdint.h>
++#include <stdlib.h>
++
++#include "libavutil/log.h"
++#include "binder.h"
++
++#define THREAD_POOL_SIZE 1
++
++static void *dlopen_libbinder_ndk(void)
++{
++    /*
++     * libbinder_ndk.so often does not contain the functions we need, so making
++     * this dependency optional, thus using dlopen/dlsym instead of linking.
++     *
++     * See also: https://source.android.com/docs/core/architecture/aidl/aidl-backends
++     */
++
++    void *h = dlopen("libbinder_ndk.so", RTLD_NOW | RTLD_LOCAL);
++    if (h != NULL)
++        return h;
++
++    av_log(NULL, AV_LOG_WARNING,
++           "android/binder: unable to load libbinder_ndk.so: '%s'; skipping binder threadpool init (MediaCodec likely won't work)\n",
++           dlerror());
++    return NULL;
++}
++
++static void android_binder_threadpool_init(void)
++{
++    typedef int (*set_thread_pool_max_fn)(uint32_t);
++    typedef void (*start_thread_pool_fn)(void);
++
++    set_thread_pool_max_fn set_thread_pool_max = NULL;
++    start_thread_pool_fn start_thread_pool = NULL;
++
++    void *h = dlopen_libbinder_ndk();
++    if (h == NULL)
++        return;
++
++    unsigned thead_pool_size = THREAD_POOL_SIZE;
++
++    set_thread_pool_max =
++        (set_thread_pool_max_fn) dlsym(h,
++                                       "ABinderProcess_setThreadPoolMaxThreadCount");
++    start_thread_pool =
++        (start_thread_pool_fn) dlsym(h, "ABinderProcess_startThreadPool");
++
++    if (start_thread_pool == NULL) {
++        av_log(NULL, AV_LOG_WARNING,
++               "android/binder: ABinderProcess_startThreadPool not found; skipping threadpool init (MediaCodec likely won't work)\n");
++        return;
++    }
++
++    if (set_thread_pool_max != NULL) {
++        int ok = set_thread_pool_max(thead_pool_size);
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: ABinderProcess_setThreadPoolMaxThreadCount(%u) => %s\n",
++               thead_pool_size, ok ? "ok" : "fail");
++    } else {
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: ABinderProcess_setThreadPoolMaxThreadCount is unavailable; using the library default\n");
++    }
++
++    start_thread_pool();
++    av_log(NULL, AV_LOG_DEBUG,
++           "android/binder: ABinderProcess_startThreadPool() called\n");
++}
++
++void android_binder_threadpool_init_if_required(void)
++{
++#if __ANDROID_API__ >= 24
++    if (android_get_device_api_level() < 35) {
++        // the issue with the thread pool was introduced in Android 15 (API 35)
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: API<35, thus no need to initialize a thread pool\n");
++        return;
++    }
++    android_binder_threadpool_init();
++#else
++    // android_get_device_api_level was introduced in API 24, so we cannot use it
++    // to detect the API level in API<24. For simplicity we just assume
++    // libbinder_ndk.so on the system running this code would have API level < 35;
++    av_log(NULL, AV_LOG_DEBUG,
++           "android/binder: is built with API<24, assuming this is not Android 15+\n");
++#endif
++}
++
++#endif                          /* __ANDROID__ */
+diff --git a/compat/android/binder.h b/compat/android/binder.h
+new file mode 100644
+index 0000000000..2b1ca53fe8
+--- /dev/null
++++ b/compat/android/binder.h
+@@ -0,0 +1,31 @@
++/*
++ * Android Binder handler
++ *
++ * Copyright (c) 2025 Dmitrii Okunev
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef COMPAT_ANDROID_BINDER_H
++#define COMPAT_ANDROID_BINDER_H
++
++/**
++ * Initialize Android Binder thread pool.
++ */
++void android_binder_threadpool_init_if_required(void);
++
++#endif                          // COMPAT_ANDROID_BINDER_H
+diff --git a/configure b/configure
+index af125bc115..098fe12f39 100755
+--- a/configure
++++ b/configure
+@@ -7312,7 +7312,8 @@ enabled mbedtls           && { check_pkg_config mbedtls mbedtls mbedtls/x509_crt
+                                check_pkg_config mbedtls mbedtls mbedtls/ssl.h mbedtls_ssl_init ||
+                                check_lib mbedtls mbedtls/ssl.h mbedtls_ssl_init -lmbedtls -lmbedx509 -lmbedcrypto ||
+                                die "ERROR: mbedTLS not found"; }
+-enabled mediacodec        && { enabled jni || die "ERROR: mediacodec requires --enable-jni"; }
++enabled mediacodec        && { enabled jni || die "ERROR: mediacodec requires --enable-jni"; } &&
++                               add_compat android/binder.o
+ enabled mmal              && { check_lib mmal interface/mmal/mmal.h mmal_port_connect -lmmal_core -lmmal_util -lmmal_vc_client -lbcm_host ||
+                                { ! enabled cross_compile &&
+                                  add_cflags -isystem/opt/vc/include/ -isystem/opt/vc/include/interface/vmcs_host/linux -isystem/opt/vc/include/interface/vcos/pthreads -fgnu89-inline &&
+diff --git a/fftools/Makefile b/fftools/Makefile
+index bdb44fc5ce..01b16fa8f4 100644
+--- a/fftools/Makefile
++++ b/fftools/Makefile
+@@ -51,6 +51,7 @@ OBJS-ffprobe +=                       \
+     fftools/textformat/tw_buffer.o    \
+     fftools/textformat/tw_stdout.o    \
+ 
++OBJS-ffmpeg += $(COMPAT_OBJS:%=compat/%)
+ OBJS-ffplay += fftools/ffplay_renderer.o
+ 
+ define DOFFTOOL
+diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
+index 444d027c15..c2c85d46bd 100644
+--- a/fftools/ffmpeg.c
++++ b/fftools/ffmpeg.c
+@@ -78,6 +78,9 @@
+ #include "libavdevice/avdevice.h"
+ 
+ #include "cmdutils.h"
++#if CONFIG_MEDIACODEC
++#include "compat/android/binder.h"
++#endif
+ #include "ffmpeg.h"
+ #include "ffmpeg_sched.h"
+ #include "ffmpeg_utils.h"
+@@ -1019,6 +1022,10 @@ int main(int argc, char **argv)
+         goto finish;
+     }
+ 
++#if CONFIG_MEDIACODEC
++    android_binder_threadpool_init_if_required();
++#endif
++
+     current_time = ti = get_benchmark_time_stamps();
+     ret = transcode(sch);
+     if (ret >= 0 && do_benchmark) {
+-- 
+2.49.1
+

--- a/pythonforandroid/recipes/ffmpeg/patches/configure.patch
+++ b/pythonforandroid/recipes/ffmpeg/patches/configure.patch
@@ -1,8 +1,6 @@
-diff --git a/configure b/configure
-index 5af693c954..d1d0a4f0a2 100755
---- a/configure
-+++ b/configure
-@@ -6800,7 +6800,7 @@ enabled librsvg           && require_pkg_config librsvg librsvg-2.0 librsvg-2.0/
+--- ffmpeg-8.0/configure	2025-08-22 14:54:23.000000000 +0530
++++ ffmpeg-8.0.mod/configure	2026-01-03 13:40:42.264702438 +0530
+@@ -7141,7 +7141,7 @@
  enabled librtmp           && require_pkg_config librtmp librtmp librtmp/rtmp.h RTMP_Socket
  enabled librubberband     && require_pkg_config librubberband "rubberband >= 1.8.1" rubberband/rubberband-c.h rubberband_new -lstdc++ && append librubberband_extralibs "-lstdc++"
  enabled libshaderc        && require_pkg_config spirv_compiler "shaderc >= 2019.1" shaderc/shaderc.h shaderc_compiler_initialize
@@ -11,12 +9,42 @@ index 5af693c954..d1d0a4f0a2 100755
  enabled libsmbclient      && { check_pkg_config libsmbclient smbclient libsmbclient.h smbc_init ||
                                 require libsmbclient libsmbclient.h smbc_init -lsmbclient; }
  enabled libsnappy         && require libsnappy snappy-c.h snappy_compress -lsnappy -lstdc++
-@@ -6850,7 +6850,7 @@ enabled libvpx            && {
+@@ -7195,7 +7195,7 @@
  enabled libwebp           && {
      enabled libwebp_encoder      && require_pkg_config libwebp "libwebp >= 0.2.0" webp/encode.h WebPGetEncoderVersion
      enabled libwebp_anim_encoder && check_pkg_config libwebp_anim_encoder "libwebpmux >= 0.4.0" webp/mux.h WebPAnimEncoderOptionsInit; }
 -enabled libx264           && require_pkg_config libx264 x264 "stdint.h x264.h" x264_encoder_encode &&
 +enabled libx264           && require "x264" "stdint.h x264.h" x264_encoder_encode &&
-                              require_cpp_condition libx264 x264.h "X264_BUILD >= 122" && {
+                              require_cpp_condition libx264 x264.h "X264_BUILD >= 155" && {
                               [ "$toolchain" != "msvc" ] ||
                               require_cpp_condition libx264 x264.h "X264_BUILD >= 158"; } &&
+@@ -7258,13 +7258,7 @@
+ enabled omx               && require_headers OMX_Core.h && \
+     warn "The OpenMAX encoders are deprecated and will be removed in future versions"
+ 
+-enabled openssl           && { { check_pkg_config openssl "openssl >= 3.0.0" openssl/ssl.h OPENSSL_init_ssl &&
+-                                 { enabled gplv3 || ! enabled gpl || enabled nonfree || die "ERROR: OpenSSL >=3.0.0 requires --enable-version3"; }; } ||
+-                               { enabled gpl && ! enabled nonfree && die "ERROR: OpenSSL <3.0.0 is incompatible with the gpl"; } ||
+-                               check_pkg_config openssl "openssl >= 1.1.0" openssl/ssl.h OPENSSL_init_ssl ||
+-                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto ||
+-                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto -lws2_32 -lgdi32 ||
+-                               die "ERROR: openssl (>= 1.1.0) not found"; }
++enabled openssl           && true 
+ enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
+ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
+                                require_pkg_config rockchip_mpp "rockchip_mpp >= 1.3.7" rockchip/rk_mpi.h mpp_create &&
+@@ -7273,14 +7267,6 @@
+                              }
+ enabled vapoursynth       && require_headers "vapoursynth/VSScript4.h vapoursynth/VapourSynth4.h"
+ 
+-enabled openssl            && {
+-    enabled whip_muxer && {
+-        $pkg_config --exists --print-errors "openssl >= 1.0.1k" ||
+-        require_pkg_config openssl "openssl >= 1.0.1k" openssl/ssl.h SSL_library_init ||
+-        require_pkg_config openssl "openssl >= 1.0.1k" openssl/ssl.h OPENSSL_init_ssl
+-    }
+-}
+-
+ 
+ if enabled gcrypt; then
+     GCRYPT_CONFIG="${cross_prefix}libgcrypt-config"

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -183,6 +183,8 @@ class Python3Recipe(TargetPythonRecipe):
     disable_gil = False
     '''python3.13 experimental free-threading build'''
 
+    built_libraries = {"libpythonbin.so": "./android-build/"}
+
     def __init__(self, *args, **kwargs):
         self._ctx = None
         super().__init__(*args, **kwargs)
@@ -364,6 +366,11 @@ class Python3Recipe(TargetPythonRecipe):
                 'INSTSONAME={lib_name}'.format(lib_name=self._libpython),
                 _env=env
             )
+            # rename executable
+            if isfile("python"):
+                sh.cp('python', 'libpythonbin.so')
+            elif isfile("python.exe"):  # for macos
+                sh.cp('python.exe', 'libpythonbin.so')
 
             # TODO: Look into passing the path to pyconfig.h in a
             # better way, although this is probably acceptable


### PR DESCRIPTION
Closes #3137

Notes:

* https://github.com/agnostic-apollo/Android-Docs/blob/master/site/pages/en/projects/docs/apps/processes/app-data-file-execute-restrictions.md#apk-native-library
* `python` binary is just 8KB
* `ffmpeg` binary is about 252K or around 0.25MB

Test code:
```python
import subprocess

def run_process(cmd):
    res = subprocess.run(cmd, capture_output=True, text=True)
    print(res.stdout)
    print(res.stderr)

import os
import sys

print(sys.executable)

# test python
run_process(["python", "--version"])
run_process(["python", "-m", "this"])

# test ffmpeg
run_process(["ffmpeg", "-version"])
run_process([
    "ffmpeg",
    "-f", "lavfi",                 
    "-i", "testsrc=size=128x128:rate=30",
    "-t", "2",                      
    "-c:v", "mpeg4",                
    "-f", "null",                   
    "-"
])
```


Expected Output:
```
01-18 01:23:34.409 27559 27580 I python  : ======== Initializing P4A ==========
01-18 01:23:34.409 27559 27580 I python  : Setting additional env vars from p4a_env_vars.txt
01-18 01:23:34.409 27559 27573 I AdrenoGLES-0: PFP: 0x005ff114, ME: 0x005ff066
01-18 01:23:34.430 27559 27580 I python  : Changing directory to '/data/user/0/org.tdynamos.earthfm/files/app'
01-18 01:23:34.431 27559 27580 I python  : symlink: libffmpegbin.so -> ffmpeg
01-18 01:23:34.431 27559 27580 I python  : symlink: libpythonbin.so -> python
01-18 01:23:34.431 27559 27580 I python  : Preparing to initialize python
01-18 01:23:34.431 27559 27580 I python  : _python_bundle dir exists
01-18 01:23:34.431 27559 27580 I python  : set wchar paths...
01-18 01:23:34.454 27559 27573 I Gralloc2: Adding additional valid usage bits: 0x202000
01-18 01:23:34.559 27559 27580 I python  : Initialized python
01-18 01:23:34.560 27559 27580 I python  : testing python print redirection
01-18 01:23:34.564 27559 27580 I python  : Android kivy bootstrap done. __name__ is __main__
01-18 01:23:34.564 27559 27580 I python  : ======= Initialized in 0.155s =======
01-18 01:23:34.698 27559 27580 I python  : /data/user/0/org.tdynamos.earthfm/files/app/.bin/python
01-18 01:23:34.763 27559 27580 I python  : Python 3.14.2
01-18 01:23:34.763 27559 27580 I python  : 
01-18 01:23:34.763 27559 27580 I python  : 
01-18 01:23:34.943 27559 27580 I python  : The Zen of Python, by Tim Peters
01-18 01:23:34.943 27559 27580 I python  : 
01-18 01:23:34.943 27559 27580 I python  : Beautiful is better than ugly.
01-18 01:23:34.943 27559 27580 I python  : Explicit is better than implicit.
01-18 01:23:34.943 27559 27580 I python  : Simple is better than complex.
01-18 01:23:34.943 27559 27580 I python  : Complex is better than complicated.
01-18 01:23:34.943 27559 27580 I python  : Flat is better than nested.
01-18 01:23:34.943 27559 27580 I python  : Sparse is better than dense.
01-18 01:23:34.943 27559 27580 I python  : Readability counts.
01-18 01:23:34.943 27559 27580 I python  : Special cases aren't special enough to break the rules.
01-18 01:23:34.943 27559 27580 I python  : Although practicality beats purity.
01-18 01:23:34.943 27559 27580 I python  : Errors should never pass silently.
01-18 01:23:34.943 27559 27580 I python  : Unless explicitly silenced.
01-18 01:23:34.943 27559 27580 I python  : In the face of ambiguity, refuse the temptation to guess.
01-18 01:23:34.943 27559 27580 I python  : There should be one-- and preferably only one --obvious way to do it.
01-18 01:23:34.943 27559 27580 I python  : Although that way may not be obvious at first unless you're Dutch.
01-18 01:23:34.943 27559 27580 I python  : Now is better than never.
01-18 01:23:34.943 27559 27580 I python  : Although never is often better than *right* now.
01-18 01:23:34.943 27559 27580 I python  : If the implementation is hard to explain, it's a bad idea.
01-18 01:23:34.943 27559 27580 I python  : If the implementation is easy to explain, it may be a good idea.
01-18 01:23:34.943 27559 27580 I python  : Namespaces are one honking great idea -- let's do more of those!
01-18 01:23:34.944 27559 27580 I python  : 
01-18 01:23:34.944 27559 27580 I python  : 
01-18 01:23:35.333 27559 27580 I python  : ffmpeg version 8.0.1 Copyright (c) 2000-2025 the FFmpeg developers
01-18 01:23:35.333 27559 27580 I python  : built with Android (13624864, +pgo, +bolt, +lto, +mlgo, based on r530567e) clang version 19.0.1 (https://android.googlesource.com/toolchain/llvm-project 97a699bf4812a18fb657c2779f5296a4ab2694d2)
01-18 01:23:35.333 27559 27580 I python  : configuration: --enable-jni --enable-mediacodec --enable-version3 --enable-openssl --enable-nonfree --enable-protocol='https,tls_openssl' --enable-parser='aac,ac3,h261,h264,mpegaudio,mpeg4video,mpegvideo,vc1' --enable-decoder='aac,h264,mpeg4,mpegvideo' --enable-muxer='h264,mov,mp4,mpeg2video' --enable-demuxer='aac,h264,m4v,mov,mpegvideo,vc1,rtsp' --disable-symver --disable-doc --enable-filter='aresample,resample,crop,adelay,volume,scale' --enable-protocol='file,http,hls,udp,tcp' --enable-small --enable-hwaccels --enable-pic --disable-static --disable-debug --enable-shared --target-os=android --enable-cross-compile --cross-prefix=aarch64-linux-android24- --arch=aarch64 --strip=/home/tdynamos/.buildozer/android/platform/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --nm=/home/tdynamos/.buildozer/android/platform/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm --sysroot=/home/tdynamos/.buildozer/android/platform/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot --enable-neon --prefix=/home/tdynamos/EarthFM/.buildozer/android/platform/build-arm64-v8a/build/other_builds/ffmpeg-sdl3/arm64-v8a__ndk_target_24/ffmpeg
```

Edit:
*AI Disclosure*:
The `start.c` file was partially generated with AI assistance due to my limited experience in this area.