### PR TITLE
Fixed Python version support.

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -59,8 +59,8 @@ public class PythonUtil {
             addLibraryIfExists(libsList, name, libsDir);
         }
 
-        for (int v = 14; v >= 5; v--) {
-            libsList.add("python3." + v + (v <= 7 ? "m" : ""));
+        for (int v = 14; v >= 8; v--) {
+            libsList.add("python3." + v);
         }
 
         libsList.add("main");
@@ -85,7 +85,7 @@ public class PythonUtil {
                 // load, and it has failed, give a more
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
-                if (lib.startsWith("python3.5") && !foundPython) {
+                if (lib.startsWith("python3.8") && !foundPython) {
                     throw new RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -59,7 +59,7 @@ public class PythonUtil {
             addLibraryIfExists(libsList, name, libsDir);
         }
 
-        for (int v = 14; v >= 5; v--) {
+        for (int v = 5; v <= 3.14; v++) {
             libsList.add("python3." + v + (v <= 7 ? "m" : ""));
         }
 

--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonUtil.java
@@ -59,7 +59,7 @@ public class PythonUtil {
             addLibraryIfExists(libsList, name, libsDir);
         }
 
-        for (int v = 5; v <= 3.14; v++) {
+        for (int v = 14; v >= 5; v--) {
             libsList.add("python3." + v + (v <= 7 ? "m" : ""));
         }
 
@@ -85,7 +85,7 @@ public class PythonUtil {
                 // load, and it has failed, give a more
                 // general error
                 Log.v(TAG, "Library loading error: " + e.getMessage());
-                if (lib.startsWith("python3.14") && !foundPython) {
+                if (lib.startsWith("python3.5") && !foundPython) {
                     throw new RuntimeException("Could not load any libpythonXXX.so");
                 } else if (lib.startsWith("python")) {
                     continue;

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -206,7 +206,7 @@ class Python3Recipe(TargetPythonRecipe):
                 self.patches.append("patches/py3.7.1_fix_cortex_a8.patch")
             elif _p_version.minor >= 8:
                 self.patches.append("patches/py3.8.1_fix_cortex_a8.patch")
-        super().__init__(arch, build_dir)
+        super().apply_patches(arch, build_dir)
 
     def include_root(self, arch_name):
         return join(self.get_build_dir(arch_name), 'Include')

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -317,7 +317,7 @@ class Python3Recipe(TargetPythonRecipe):
 
         _p_version = Version(self.version)
         if _p_version.minor >= 11:
-            configure_args.extend([
+            self.configure_args.extend([
                 '--with-build-python={python_host_bin}',
             ])
 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -206,6 +206,8 @@ class Python3Recipe(TargetPythonRecipe):
                 self.patches.append("patches/py3.7.1_fix_cortex_a8.patch")
             elif _p_version.minor >= 8:
                 self.patches.append("patches/py3.8.1_fix_cortex_a8.patch")
+
+        self.patches = list(set(self.patches))
         super().apply_patches(arch, build_dir)
 
     def include_root(self, arch_name):
@@ -321,6 +323,8 @@ class Python3Recipe(TargetPythonRecipe):
 
         if _p_version.minor >= 13 and self.disable_gil:
             self.configure_args.append("--disable-gil")
+
+        self.configure_args = list(set(self.configure_args))
 
         return env
 

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -55,7 +55,6 @@ class Python3Recipe(TargetPythonRecipe):
     '''
 
     version = '3.14.2'
-    _p_version = Version(version)
     url = 'https://github.com/python/cpython/archive/refs/tags/v{version}.tar.gz'
     name = 'python3'
 
@@ -63,28 +62,6 @@ class Python3Recipe(TargetPythonRecipe):
         'patches/pyconfig_detection.patch',
         'patches/reproducible-buildinfo.diff',
     ]
-
-    if _p_version.major == 3 and _p_version.minor == 7:
-        patches += [
-            'patches/py3.7.1_fix-ctypes-util-find-library.patch',
-            'patches/py3.7.1_fix-zlib-version.patch',
-        ]
-
-    if 8 <= _p_version.minor <= 10:
-        patches.append('patches/py3.8.1.patch')
-
-    if _p_version.minor >= 11:
-        patches.append('patches/cpython-311-ctypes-find-library.patch')
-
-    if _p_version.minor >= 14:
-        patches.append('patches/3.14_armv7l_fix.patch')
-        patches.append('patches/3.14_fix_remote_debug.patch')
-
-    if shutil.which('lld') is not None:
-        if _p_version.minor == 7:
-            patches.append("patches/py3.7.1_fix_cortex_a8.patch")
-        elif _p_version.minor >= 8:
-            patches.append("patches/py3.8.1_fix_cortex_a8.patch")
 
     depends = ['hostpython3', 'sqlite3', 'openssl', 'libffi']
     # those optional depends allow us to build python compression modules:
@@ -210,6 +187,32 @@ class Python3Recipe(TargetPythonRecipe):
             flags=flags
         )
 
+    def apply_patches(self, arch, build_dir=None):
+
+        _p_version = Version(self.version)
+        if _p_version.major == 3 and _p_version.minor == 7:
+            self.patches += [
+                'patches/py3.7.1_fix-ctypes-util-find-library.patch',
+                'patches/py3.7.1_fix-zlib-version.patch',
+            ]
+    
+        if 8 <= _p_version.minor <= 10:
+            self.patches.append('patches/py3.8.1.patch')
+    
+        if _p_version.minor >= 11:
+            self.patches.append('patches/cpython-311-ctypes-find-library.patch')
+    
+        if _p_version.minor >= 14:
+            self.patches.append('patches/3.14_armv7l_fix.patch')
+            self.patches.append('patches/3.14_fix_remote_debug.patch')
+    
+        if shutil.which('lld') is not None:
+            if _p_version.minor == 7:
+                self.patches.append("patches/py3.7.1_fix_cortex_a8.patch")
+            elif _p_version.minor >= 8:
+                self.patches.append("patches/py3.8.1_fix_cortex_a8.patch")
+        super().__init__(arch, build_dir)
+
     def include_root(self, arch_name):
         return join(self.get_build_dir(arch_name), 'Include')
 
@@ -317,7 +320,13 @@ class Python3Recipe(TargetPythonRecipe):
         env['ZLIB_VERSION'] = line.replace('#define ZLIB_VERSION ', '')
         add_flags(' -I' + zlib_includes, ' -L' + zlib_lib_path, ' -lz')
 
-        if self._p_version.minor >= 13 and self.disable_gil:
+        _p_version = Version(self.version)
+        if _p_version.minor >= 11:
+            configure_args.extend([
+                '--with-build-python={python_host_bin}',
+            ])
+
+        if _p_version.minor >= 13 and self.disable_gil:
             self.configure_args.append("--disable-gil")
 
         return env

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -190,17 +190,17 @@ class Python3Recipe(TargetPythonRecipe):
                 'patches/py3.7.1_fix-ctypes-util-find-library.patch',
                 'patches/py3.7.1_fix-zlib-version.patch',
             ]
-    
+
         if 8 <= _p_version.minor <= 10:
             self.patches.append('patches/py3.8.1.patch')
-    
+
         if _p_version.minor >= 11:
             self.patches.append('patches/cpython-311-ctypes-find-library.patch')
-    
+
         if _p_version.minor >= 14:
             self.patches.append('patches/3.14_armv7l_fix.patch')
             self.patches.append('patches/3.14_fix_remote_debug.patch')
-    
+
         if shutil.which('lld') is not None:
             if _p_version.minor == 7:
                 self.patches.append("patches/py3.7.1_fix_cortex_a8.patch")

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -317,9 +317,7 @@ class Python3Recipe(TargetPythonRecipe):
 
         _p_version = Version(self.version)
         if _p_version.minor >= 11:
-            self.configure_args.extend([
-                '--with-build-python={python_host_bin}',
-            ])
+            self.configure_args.append('--with-build-python={python_host_bin}')
 
         if _p_version.minor >= 13 and self.disable_gil:
             self.configure_args.append("--disable-gil")

--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -93,11 +93,6 @@ class Python3Recipe(TargetPythonRecipe):
         'ac_cv_header_bzlib_h=no',
     ]
 
-    if _p_version.minor >= 11:
-        configure_args.extend([
-            '--with-build-python={python_host_bin}',
-        ])
-
     '''The configure arguments needed to build the python recipe. Those are
     used in method :meth:`build_arch` (if not overwritten like python3's
     recipe does).


### PR DESCRIPTION
Fixed a bug when selecting libpythonХХХ.so version is decreasing (3.14 -> 3.5), but the check for the absence of the Python library ends at version 3.14, I changed it to 3.5. I also slightly changed the Python recipe to return support for version selection via buildozer