### PR TITLE
numpy: enable openblas

### DIFF
--- a/doc/source/apis.rst
+++ b/doc/source/apis.rst
@@ -80,6 +80,17 @@ https://developer.android.com/reference/android/Manifest.permission
 Other common tasks
 ------------------
 
+Using NumPY
+~~~~~~~~~~~
+
+It should work out of the box; just ensure `numpy` is included in your requirements.
+If you want better performance, you can also add `libopenblas` to the requirements.
+This allows NumPy to use BLAS/LAPACK acceleration, which can significantly improve linear algebra operations.
+
+Keep in mind that `libopenblas` is a fairly large library (~12 MB per architecture),
+so it will increase your app size. For example, if you build for 4 architectures,
+the APK size may increase by roughly `12 × 4 = 48 MB` (before compression).
+
 Running executables
 ~~~~~~~~~~~~~~~~~~~
 

--- a/pythonforandroid/recipes/libopenblas/__init__.py
+++ b/pythonforandroid/recipes/libopenblas/__init__.py
@@ -33,6 +33,7 @@ class LibOpenBlasRecipe(Recipe):
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DBUILD_SHARED_LIBS=ON",
                 "-DC_LAPACK=ON",
+                "-DDYNAMIC_ARCH=0",
                 "-DTARGET={target}".format(
                     target={
                         "arm64-v8a": "ARMV8",

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -10,7 +10,12 @@ NUMPY_NDK_MESSAGE = (
 class NumpyRecipe(MesonRecipe):
     version = "v2.3.0"
     url = "git+https://github.com/numpy/numpy"
-    extra_build_args = ["-Csetup-args=-Dblas=none", "-Csetup-args=-Dlapack=none"]
+    depends = ["libopenblas"]
+    extra_build_args = [
+        "-Csetup-args=-Dblas=auto",
+        "-Csetup-args=-Dlapack=auto",
+        "-Csetup-args=-Dallow-noblas=False",
+    ]
     need_stl_shared = True
     min_ndk_api_support = 24
 
@@ -41,6 +46,11 @@ class NumpyRecipe(MesonRecipe):
             "android-build",
             "python",
         )
+        blas_dir = join(Recipe.get_recipe("libopenblas", self.ctx
+        ).get_build_dir(arch.arch), "build")
+        blas_incdir = blas_dir
+        blas_libdir = join(blas_dir, "lib")
+        env["CXXFLAGS"] += f" -I{blas_incdir} -L{blas_libdir}"
         return env
 
     def get_hostrecipe_env(self, arch=None):

--- a/pythonforandroid/recipes/numpy/__init__.py
+++ b/pythonforandroid/recipes/numpy/__init__.py
@@ -10,12 +10,8 @@ NUMPY_NDK_MESSAGE = (
 class NumpyRecipe(MesonRecipe):
     version = "v2.3.0"
     url = "git+https://github.com/numpy/numpy"
-    depends = ["libopenblas"]
-    extra_build_args = [
-        "-Csetup-args=-Dblas=auto",
-        "-Csetup-args=-Dlapack=auto",
-        "-Csetup-args=-Dallow-noblas=False",
-    ]
+    extra_build_args = ["-Csetup-args=-Dblas=none", "-Csetup-args=-Dlapack=none"]
+    opt_depends = ["libopenblas"]
     need_stl_shared = True
     min_ndk_api_support = 24
 
@@ -51,6 +47,14 @@ class NumpyRecipe(MesonRecipe):
         blas_incdir = blas_dir
         blas_libdir = join(blas_dir, "lib")
         env["CXXFLAGS"] += f" -I{blas_incdir} -L{blas_libdir}"
+
+        if 'libopenblas' in self.ctx.recipe_build_order:
+            self.extra_build_args = [
+                "-Csetup-args=-Dblas=auto",
+                "-Csetup-args=-Dlapack=auto",
+                "-Csetup-args=-Dallow-noblas=False",
+            ]
+
         return env
 
     def get_hostrecipe_env(self, arch=None):


### PR DESCRIPTION
Pros:
 * This speeds up calculations - [SOURCE](https://github.com/chaquo/chaquopy/blob/d34d4342f8e01f0092caaa76037298e91e0ea78d/server/pypi/packages/numpy/test.py#L31)
 
Cons:
 * Build complexity + time for building numpy increases.
 * `+11MB` At least increase in app size as `libopenblas.so` is big.
