### PR TITLE
Fix pyjnius linking with Qt bootstrap libmain

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -2,7 +2,7 @@ from pythonforandroid.recipe import PyProjectRecipe
 from pythonforandroid.toolchain import shprint, current_directory, info
 from pythonforandroid.patching import will_build
 import sh
-from os.path import join
+from os.path import exists, join
 
 
 class PyjniusRecipe(PyProjectRecipe):
@@ -21,12 +21,24 @@ class PyjniusRecipe(PyProjectRecipe):
     def get_recipe_env(self, arch, **kwargs):
         env = super().get_recipe_env(arch, **kwargs)
 
+        generic_main_libs = (
+            join(self.ctx.bootstrap.build_dir, 'libs', arch.arch,
+                 'libmain_{}.so'.format(arch.arch)),
+            join(self.ctx.bootstrap.build_dir, 'obj', 'local', arch.arch,
+                 'libmain_{}.so'.format(arch.arch)),
+        )
+        if any(exists(lib) for lib in generic_main_libs):
+            env['PYJNIUS_ANDROID_LIBMAIN'] = 'main_{}'.format(arch.arch)
+
         # Taken from CythonRecipe
-        env['LDFLAGS'] = env['LDFLAGS'] + ' -L{} '.format(
-            self.ctx.get_libs_dir(arch.arch) +
-            ' -L{} '.format(self.ctx.libs_dir) +
-            ' -L{}'.format(join(self.ctx.bootstrap.build_dir, 'obj', 'local',
-                                arch.arch)))
+        env['LDFLAGS'] = env['LDFLAGS'] + ' ' + ' '.join([
+            '-L{}'.format(self.ctx.get_libs_dir(arch.arch)),
+            '-L{}'.format(self.ctx.libs_dir),
+            '-L{}'.format(join(self.ctx.bootstrap.build_dir, 'libs',
+                               arch.arch)),
+            '-L{}'.format(join(self.ctx.bootstrap.build_dir, 'obj', 'local',
+                               arch.arch)),
+        ])
         env['LDSHARED'] = env['CC'] + ' -shared'
         env['LIBLINK'] = 'NOTNONE'
 

--- a/pythonforandroid/recipes/pyjnius/genericndkbuild_jnienv_getter.patch
+++ b/pythonforandroid/recipes/pyjnius/genericndkbuild_jnienv_getter.patch
@@ -6,7 +6,7 @@ diff -Naur pyjnius.orig/jnius/env.py pyjnius/jnius/env.py
  class AndroidJavaLocation(UnixJavaLocation):
      def get_libraries(self):
 -        return ['SDL2', 'log']
-+        return ['main', 'log']
++        return [getenv('PYJNIUS_ANDROID_LIBMAIN', 'main'), 'log']
  
      def get_include_dirs(self):
          # When cross-compiling for Android, we should not use the include dirs


### PR DESCRIPTION
When using the Qt bootstrap, ndk-build generates the main library as libmain_<abi>.so, for example libmain_arm64-v8a.so. pyjnius links with -lmain, so the linker cannot find the ABI-suffixed library.

This change creates a libmain.so alias before building pyjnius and adds the bootstrap libs/<abi> directory to LDFLAGS.

Tested with Buildozer / python-for-android on arm64-v8a.