### PR TITLE
Fix SciPy pybind11 build dependency

### DIFF
--- a/pythonforandroid/recipes/scipy/__init__.py
+++ b/pythonforandroid/recipes/scipy/__init__.py
@@ -12,7 +12,11 @@ class ScipyRecipe(MesonRecipe):
     depends = ["numpy", "libopenblas", "fortran"]
     need_stl_shared = True
     meson_version = "1.5.0"
-    hostpython_prerequisites = ["numpy", "Cython>=3.0.8"]
+    hostpython_prerequisites = [
+        "numpy",
+        "Cython>=3.0.8",
+        "pybind11>=2.13.2,<3.1.0",
+    ]
     patches = ["meson.patch"]
 
     def get_recipe_meson_options(self, arch):


### PR DESCRIPTION
## Summary

- add SciPy's pybind11 build dependency to `hostpython_prerequisites`

## Rationale

SciPy 1.16.2 declares `pybind11>=2.13.2,<3.1.0` in `pyproject.toml` and uses `dependency('pybind11', version: '>=2.13.2')` in its Meson build. The recipe already installs NumPy and Cython as host Python prerequisites, but pybind11 was missing, so Meson could fail to resolve the pybind11 dependency during the isolated wheel build.

This keeps the fix local to the SciPy recipe and avoids changing the shared `MesonRecipe` flow.

## Validation

- `python3 -m py_compile pythonforandroid/recipes/scipy/__init__.py pythonforandroid/recipe.py`
- `git diff --check`
