### PR TITLE
Fix numpy compilation when Python != 3.14

### DIFF
--- a/pythonforandroid/meson_python.py
+++ b/pythonforandroid/meson_python.py
@@ -18,7 +18,7 @@ def handle_python_info():
 
     prefix = C.TARGET_PYTHON_PREFIX
 
-    sysconfig_file = glob(join(prefix, "lib/python3.14/_sysconfigdata*.py"))[0]
+    sysconfig_file = glob(join(prefix, f"lib/python{C.PYTHON_MAJOR_VERSION}.{C.PYTHON_MINOR_VERSION}/_sysconfigdata*.py"))[0]
 
     spec = importlib.util.spec_from_file_location("_android_cfg", sysconfig_file)
     cfg = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
The python version was hardcoded. This caused the error during compilation of numpy:
```
Program stderr:

Traceback (most recent call last):
  File "/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/numpy/arm64-v8a__ndk_target_24/numpy/p4a_wrappers/python", line 80, in <module>
    sys.exit(WHITELIST[name]())
             ^^^^^^^^^^^^^^^^^
  File "/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/numpy/arm64-v8a__ndk_target_24/numpy/p4a_wrappers/python", line 27, in handle_python_info
    sysconfig_file = glob(join(prefix, "lib/python3.14/_sysconfigdata*.py"))[0]
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range


../meson.build:40:22: ERROR: <PythonExternalProgram 'python' -> ['/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/numpy/arm64-v8a__ndk_target_24/numpy/p4a_wrappers/python']> is not a valid python or it is missing distutils
```