### PR TITLE
Fix kivy compilation error incompatible function pointer types for

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -64,6 +64,7 @@ class KivyRecipe(PyProjectRecipe):
                                 arch.arch)))
         env['LDSHARED'] = env['CC'] + ' -shared'
         env['LIBLINK'] = 'NOTNONE'
+        env['CFLAGS'] = env['CFLAGS'] + ' -Wno-incompatible-function-pointer-types'
 
         # NDKPLATFORM is our switch for detecting Android platform, so can't be None
         env['NDKPLATFORM'] = "NOTNONE"


### PR DESCRIPTION
Fixes (workaround) the error during kivy compilation:
```
[DEBUG]:        [INFO   ] building 'kivy.graphics.cgl_backend.cgl_gl' extension
[DEBUG]:        [INFO   ] /home/user/.buildozer/android/platform/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/bin/clang -target aarch64-linux-android24 -fomit-frame-pointer -march=armv8-a -fPIC -target aarch64-linux-android24 -fomit-frame-pointer -march=armv8-a -fPIC -I/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/python3-libbz2/arm64-v8a__ndk_target_24/python3/android-build/android-root/include/python3.11 -DANDROID -I/home/user/.buildozer/android/platform/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include -I/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/python3-libbz2/arm64-v8a__ndk_target_24/python3/android-build/android-root/include/python3.11 -fPIC -I/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy-sdl2/arm64-v8a__ndk_target_24/kivy/kivy/include -INOTNONE/usr/include -I/tmp/build-env-991f9kwm/include -I/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/include/python3.11 -c /workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy-sdl2/arm64-v8a__ndk_target_24/kivy/kivy/graphics/cgl_backend/cgl_gl.c -o build/temp.linux-x86_64-cpython-311/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy-sdl2/arm64-v8a__ndk_target_24/kivy/kivy/graphics/cgl_backend/cgl_gl.o
[DEBUG]:        /workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy-sdl2/arm64-v8a__ndk_target_24/kivy/kivy/graphics/cgl_backend/cgl_gl.c:4382:52: error: incompatible 
function pointer types assigning to 'void (*)(GLuint, GLsizei, const GLchar **, const GLint *)' (aka 'void (*)(unsigned int, int, const char **, const int *)') from 'void (GLuint, GLsizei, const GLchar *const *, const GLint *)' (aka 'void (unsigned int, int, const char *const *, const int *)') [-Wincompatible-function-pointer-types]
[DEBUG]:         4382 |   __pyx_v_4kivy_8graphics_3cgl_cgl->glShaderSource = glShaderSource;
[DEBUG]:              |                                                    ^ ~~~~~~~~~~~~~~
[DEBUG]:        1 error generated.
```

The functions differ only by const qualifier:
`const char **` vs `const char *const *`
