### PR TITLE
Fix hostpython dependencies not installed for CythonRecipe

### DIFF
--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -1133,6 +1133,7 @@ class CythonRecipe(PythonRecipe):
         '''Build any cython components, then install the Python module by
         calling pip install with the target Python dir.
         '''
+        self.install_hostpython_prerequisites()
         Recipe.build_arch(self, arch)
         self.build_cython_components(arch)
         self.install_python_package(arch)


### PR DESCRIPTION
Then "setup.py" depends on some hostpython's package, it won't be installed when placed in hostpython_prerequisites.

This causes recipe to fail during invoke of "setup.py" on first and on second build.
The first build in that case won't produce cython files and second build will fail because of that.

```
[INFO]:    Building pycodec2 for arm64-v8a
[INFO]:    pycodec2 apparently isn't already in site-packages
[INFO]:    Cythonizing anything necessary in pycodec2
[INFO]:    -> directory context /workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/pycodec2/arm64-v8a__ndk_target_24/pycodec2
[DEBUG]:   -> running python -c import sys; print(sys.path)
[DEBUG]:        ['', '/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/lib/python311.zip', '/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/lib/python3.11', '/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/lib/python3.11/lib-dynload', '/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/lib/python3.11/site-packages']
[DEBUG]:   cwd is /workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/pycodec2/arm64-v8a__ndk_target_24/pycodec2
[INFO]:    Trying first build of pycodec2 to get cython files: this is expected to fail
[DEBUG]:   -> running python setup.py build_ext -v
[DEBUG]:        Traceback (most recent call last):
[DEBUG]:          File "/workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/pycodec2/arm64-v8a__ndk_target_24/pycodec2/setup.py", line 4, in <module>
[DEBUG]:            import numpy as np
[DEBUG]:        ModuleNotFoundError: No module named 'numpy'
Exception in thread background thread for pid 139973:
Traceback (most recent call last):
  File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/sh.py", line 1642, in wrap
    fn(*rgs, **kwargs)
    ~~^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/sh.py", line 2647, in background_thread
    handle_exit_code(exit_code)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/sh.py", line 2338, in fn
    return self.command.handle_command_exit_code(exit_code)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/sh.py", line 823, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 

  RAN: /workdir/sideband/sbapp/.buildozer/android/platform/build-arm64-v8a/build/other_builds/hostpython3/desktop/hostpython3/native-build/root/usr/local/bin/python setup.py build_ext -v
```