### PR TITLE
:white_check_mark: tests: drop stale setuptools assertion

### DIFF
--- a/tests/test_pythonpackage.py
+++ b/tests/test_pythonpackage.py
@@ -41,11 +41,8 @@ def test_get_package_dependencies():
         dep for dep in deps_recursive
         if "MarkupSafe" in dep
     ]
-    # Check setuptools not being in non-recursive deps:
-    # (It will be in recursive ones due to p4a's build dependency)
-    assert "setuptools" not in deps_nonrecursive
-    # Check setuptools is present in non-recursive deps,
-    # if we also add build requirements:
+    # Check setuptools is present in non-recursive deps when we add
+    # build requirements:
     assert "setuptools" in get_package_dependencies(
         local_repo_folder(), recursive=False,
         include_build_requirements=True,


### PR DESCRIPTION
setuptools was added to setup.py install_reqs in #3007 (May 2024), so it now appears as a direct (non-recursive) dependency. The assertion at test_pythonpackage.py:46 ("setuptools not in deps_nonrecursive") has been wrong since then but went unnoticed because the file is skipped in CI (`make test` uses `--ignore tests/test_pythonpackage.py`).

The remaining `include_build_requirements=True` assertion still exercises the build-deps code path.

Note this test is skipped by the CI but was ran manually upon during pre-release checks. This can be reproduced via:
```
pytest tests/test_pythonpackage.py::test_get_package_dependencies
```
The error was:
````
>       assert "setuptools" not in deps_nonrecursive
E       AssertionError: assert 'setuptools' not in {'appdirs', 'build', 'colorama>=0.3.3', 'jinja2', 'meson', 'ninja', ...}
```