### PR TITLE
:bug: Fix msgspec recipe import on Python 3.8/3.9

### DIFF
--- a/pythonforandroid/recipes/msgspec/__init__.py
+++ b/pythonforandroid/recipes/msgspec/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from pythonforandroid.archs import Arch


### PR DESCRIPTION
The msgspec recipe added in #3316 uses PEP 585 generic syntax (dict[str, Any]) in function signatures. Python 3.8 raises "TypeError: 'type' object is not subscriptable" at import time because dict only became subscriptable at runtime in Python 3.9.

Adding `from __future__ import annotations` defers annotation evaluation to strings (PEP 563), restoring 3.8 compatibility. This release still officially supports Python 3.8 / 3.9.