### PR TITLE
:fire: Drop EOL Python 3.7/3.8/3.9 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         os: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout python-for-android

--- a/pythonforandroid/pythonpackage.py
+++ b/pythonforandroid/pythonpackage.py
@@ -34,7 +34,6 @@
 
 
 import functools
-from io import open  # needed for python 2
 import os
 import shutil
 import subprocess
@@ -154,16 +153,12 @@ def _get_system_python_executable():
             # We should check file not found anyway trying to run it,
             # since it might be a dead symlink:
             try:
-                filenotfounderror = FileNotFoundError
-            except NameError:  # Python 2
-                filenotfounderror = OSError
-            try:
                 # Run it and see if version output works with no error:
                 subprocess.check_output([
                     os.path.join(path, python_bin), "--version"
                 ], stderr=subprocess.STDOUT)
                 return True
-            except (subprocess.CalledProcessError, filenotfounderror):
+            except (subprocess.CalledProcessError, FileNotFoundError):
                 return False
 
         python_name = "python" + sys.version
@@ -271,21 +266,10 @@ def get_package_as_folder(dependency):
     try:
         # Create a venv to install into:
         try:
-            if int(sys.version.partition(".")[0]) < 3:
-                # Python 2.x has no venv.
-                subprocess.check_output([
-                    sys.executable,  # no venv conflict possible,
-                                     # -> no need to use system python
-                    "-m", "virtualenv",
-                    "--python=" + _get_system_python_executable(),
-                    os.path.join(venv_parent, 'venv')
-                ], cwd=venv_parent)
-            else:
-                # On modern Python 3, use venv.
-                subprocess.check_output([
-                    _get_system_python_executable(), "-m", "venv",
-                    os.path.join(venv_parent, 'venv')
-                ], cwd=venv_parent)
+            subprocess.check_output([
+                _get_system_python_executable(), "-m", "venv",
+                os.path.join(venv_parent, 'venv')
+            ], cwd=venv_parent)
         except subprocess.CalledProcessError as e:
             output = e.output.decode('utf-8', 'replace')
             raise ValueError(
@@ -296,15 +280,11 @@ def get_package_as_folder(dependency):
 
         # Update pip and wheel in venv for latest feature support:
         try:
-            filenotfounderror = FileNotFoundError
-        except NameError:  # Python 2.
-            filenotfounderror = OSError
-        try:
             subprocess.check_output([
                 os.path.join(venv_path, "bin", "pip"),
                 "install", "-U", "pip", "wheel",
             ])
-        except filenotfounderror:
+        except FileNotFoundError:
             raise RuntimeError(
                 "venv appears to be missing pip. "
                 "did we fail to use a proper system python??\n"
@@ -322,12 +302,7 @@ def get_package_as_folder(dependency):
         with open(os.path.join(venv_path, "requirements.txt"),
                   "w", encoding="utf-8"
                  ) as f:
-            def to_unicode(s):  # Needed for Python 2.
-                try:
-                    return s.decode("utf-8")
-                except AttributeError:
-                    return s
-            f.write(to_unicode(transform_dep_for_pip(dependency)))
+            f.write(transform_dep_for_pip(dependency))
         try:
             subprocess.check_output(
                 [
@@ -451,10 +426,7 @@ def _extract_metainfo_files_from_package_unsafe(
         # distribution, and others get_package_as_folder() may support
         # in the future.
         with open(os.path.join(output_path, "metadata_source"), "w") as f:
-            try:
-                f.write(path_type)
-            except TypeError:  # in python 2 path_type may be str/bytes:
-                f.write(path_type.decode("utf-8", "replace"))
+            f.write(path_type)
 
         # Copy the metadata file:
         shutil.copyfile(metadata_path, os.path.join(output_path, "METADATA"))
@@ -585,19 +557,14 @@ package_name_cache = dict()
 
 def get_package_name(dependency,
                      use_cache=True):
-    def timestamp():
-        try:
-            return time.monotonic()
-        except AttributeError:
-            return time.time()  # Python 2.
     try:
         value = package_name_cache[dependency]
-        if value[0] + 600.0 > timestamp() and use_cache:
+        if value[0] + 600.0 > time.monotonic() and use_cache:
             return value[1]
     except KeyError:
         pass
     result = _extract_info_from_package(dependency, extract_type="name")
-    package_name_cache[dependency] = (timestamp(), result)
+    package_name_cache[dependency] = (time.monotonic(), result)
     return result
 
 

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -16,10 +16,7 @@ from sys import stdout
 from packaging.version import Version
 from multiprocessing import cpu_count
 import time
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import packaging.version
 

--- a/pythonforandroid/recipes/ifaddr/__init__.py
+++ b/pythonforandroid/recipes/ifaddr/__init__.py
@@ -5,7 +5,7 @@ class IfaddrRecipe(PythonRecipe):
     name = 'ifaddr'
     version = '0.1.7'
     url = 'https://pypi.python.org/packages/source/i/ifaddr/ifaddr-{version}.tar.gz'
-    depends = ['setuptools', 'ifaddrs', 'ipaddress;python_version<"3.3"']
+    depends = ['setuptools', 'ifaddrs']
     call_hostpython_via_targetpython = False
     patches = ["getifaddrs.patch"]
 

--- a/pythonforandroid/recipes/msgspec/__init__.py
+++ b/pythonforandroid/recipes/msgspec/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from pythonforandroid.archs import Arch

--- a/pythonforandroid/recipes/scipy/wrapper.py
+++ b/pythonforandroid/recipes/scipy/wrapper.py
@@ -5,7 +5,6 @@
 import os
 import subprocess
 import sys
-import typing
 
 """
 This wrapper is used to ignore or replace some unsupported flags for flang-new.
@@ -30,7 +29,7 @@ It will operate as follows:
 COMPLIER_PATH = "@COMPILER@"
 
 
-def main(argv: typing.List[str]):
+def main(argv: list[str]):
     cwd = os.getcwd()
     argv_new = []
     i = 0

--- a/pythonforandroid/recipes/zeroconf/__init__.py
+++ b/pythonforandroid/recipes/zeroconf/__init__.py
@@ -5,7 +5,7 @@ class ZeroconfRecipe(PythonRecipe):
     name = 'zeroconf'
     version = '0.24.5'
     url = 'https://pypi.python.org/packages/source/z/zeroconf/zeroconf-{version}.tar.gz'
-    depends = ['setuptools', 'ifaddr', 'typing;python_version<"3.5"']
+    depends = ['setuptools', 'ifaddr']
     call_hostpython_via_targetpython = False
 
 

--- a/pythonforandroid/recommendations.py
+++ b/pythonforandroid/recommendations.py
@@ -186,14 +186,10 @@ def check_ndk_api(ndk_api, android_api):
 
 
 MIN_PYTHON_MAJOR_VERSION = 3
-MIN_PYTHON_MINOR_VERSION = 6
+MIN_PYTHON_MINOR_VERSION = 10
 MIN_PYTHON_VERSION = packaging.version.Version(
     f"{MIN_PYTHON_MAJOR_VERSION}.{MIN_PYTHON_MINOR_VERSION}"
 )
-PY2_ERROR_TEXT = (
-    'python-for-android no longer supports running under Python 2. Either upgrade to '
-    'Python {min_version} or higher (recommended), or revert to python-for-android 2019.07.08.'
-).format(min_version=MIN_PYTHON_VERSION)
 
 PY_VERSION_ERROR_TEXT = (
     'Your Python version {user_major}.{user_minor} is not supported by python-for-android, '
@@ -205,11 +201,6 @@ PY_VERSION_ERROR_TEXT = (
 
 
 def check_python_version():
-    # Python 2 special cased because it's a major transition. In the
-    # future the major or minor versions can increment more quietly.
-    if sys.version_info.major == 2:
-        raise BuildInterruptingException(PY2_ERROR_TEXT)
-
     if (
         sys.version_info.major < MIN_PYTHON_MAJOR_VERSION or
         sys.version_info.minor < MIN_PYTHON_MINOR_VERSION

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -393,22 +393,11 @@ class ToolchainCL:
         subparsers = parser.add_subparsers(dest='subparser_name',
                                            help='The command to run')
 
-        def add_parser(subparsers, *args, **kwargs):
-            """
-            argparse in python2 doesn't support the aliases option,
-            so we just don't provide the aliases there.
-            """
-            if 'aliases' in kwargs and sys.version_info.major < 3:
-                kwargs.pop('aliases')
-            return subparsers.add_parser(*args, **kwargs)
-
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'recommendations',
             parents=[generic_parser],
             help='List recommended p4a dependencies')
-        parser_recipes = add_parser(
-            subparsers,
+        parser_recipes = subparsers.add_parser(
             'recipes',
             parents=[generic_parser],
             help='List the available recipes')
@@ -416,33 +405,33 @@ class ToolchainCL:
             "--compact",
             action="store_true", default=False,
             help="Produce a compact list suitable for scripting")
-        add_parser(
-            subparsers, 'bootstraps',
+        subparsers.add_parser(
+            'bootstraps',
             help='List the available bootstraps',
             parents=[generic_parser])
-        add_parser(
-            subparsers, 'clean_all',
+        subparsers.add_parser(
+            'clean_all',
             aliases=['clean-all'],
             help='Delete all builds, dists and caches',
             parents=[generic_parser])
-        add_parser(
-            subparsers, 'clean_dists',
+        subparsers.add_parser(
+            'clean_dists',
             aliases=['clean-dists'],
             help='Delete all dists',
             parents=[generic_parser])
-        add_parser(
-            subparsers, 'clean_bootstrap_builds',
+        subparsers.add_parser(
+            'clean_bootstrap_builds',
             aliases=['clean-bootstrap-builds'],
             help='Delete all bootstrap builds',
             parents=[generic_parser])
-        add_parser(
-            subparsers, 'clean_builds',
+        subparsers.add_parser(
+            'clean_builds',
             aliases=['clean-builds'],
             help='Delete all builds',
             parents=[generic_parser])
 
-        parser_clean = add_parser(
-            subparsers, 'clean',
+        parser_clean = subparsers.add_parser(
+            'clean',
             help='Delete build components.',
             parents=[generic_parser])
         parser_clean.add_argument(
@@ -451,8 +440,7 @@ class ToolchainCL:
                   'number of arguments from "all", "builds", "dists", '
                   '"distributions", "bootstrap_builds", "downloads".'))
 
-        parser_clean_recipe_build = add_parser(
-            subparsers,
+        parser_clean_recipe_build = subparsers.add_parser(
             'clean_recipe_build', aliases=['clean-recipe-build'],
             help=('Delete the build components of the given recipe. '
                   'By default this will also delete built dists'),
@@ -465,8 +453,7 @@ class ToolchainCL:
             action='store_true',
             help='If passed, do not delete existing dists')
 
-        parser_clean_download_cache = add_parser(
-            subparsers,
+        parser_clean_download_cache = subparsers.add_parser(
             'clean_download_cache', aliases=['clean-download-cache'],
             help='Delete cached downloads for requirement builds',
             parents=[generic_parser])
@@ -476,8 +463,7 @@ class ToolchainCL:
             help='The recipes to clean (space-separated). If no recipe name is'
                   ' provided, the entire cache is cleared.')
 
-        parser_export_dist = add_parser(
-            subparsers,
+        parser_export_dist = subparsers.add_parser(
             'export_dist', aliases=['export-dist'],
             help='Copy the named dist to the given path',
             parents=[generic_parser])
@@ -547,57 +533,46 @@ class ToolchainCL:
             '--signkeypw', dest='signkeypw', action='store', default=None,
             help='Password for key alias')
 
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'aar', help='Build an AAR',
             parents=[parser_packaging])
 
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'apk', help='Build an APK',
             parents=[parser_packaging])
 
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'aab', help='Build an AAB',
             parents=[parser_packaging])
 
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'create', help='Compile a set of requirements into a dist',
             parents=[generic_parser])
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'archs', help='List the available target architectures',
             parents=[generic_parser])
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'distributions', aliases=['dists'],
             help='List the currently available (compiled) dists',
             parents=[generic_parser])
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'delete_dist', aliases=['delete-dist'], help='Delete a compiled dist',
             parents=[generic_parser])
 
-        parser_sdk_tools = add_parser(
-            subparsers,
+        parser_sdk_tools = subparsers.add_parser(
             'sdk_tools', aliases=['sdk-tools'],
             help='Run the given binary from the SDK tools dis',
             parents=[generic_parser])
         parser_sdk_tools.add_argument(
             'tool', help='The binary tool name to run')
 
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'adb', help='Run adb from the given SDK',
             parents=[generic_parser])
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'logcat', help='Run logcat from the given SDK',
             parents=[generic_parser])
-        add_parser(
-            subparsers,
+        subparsers.add_parser(
             'build_status', aliases=['build-status'],
             help='Print some debug information about current built components',
             parents=[generic_parser])

--- a/pythonforandroid/util.py
+++ b/pythonforandroid/util.py
@@ -86,17 +86,11 @@ def walk_valid_filens(base_dir, invalid_dir_names, invalid_file_patterns, exclud
 
 
 def load_source(module, filename):
-    # Python 3.5+
     import importlib.util
-    if hasattr(importlib.util, 'module_from_spec'):
-        spec = importlib.util.spec_from_file_location(module, filename)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-    else:
-        # Python 3.3 and 3.4:
-        from importlib.machinery import SourceFileLoader
-        return SourceFileLoader(module, filename).load_module()
+    spec = importlib.util.spec_from_file_location(module, filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 class BuildInterruptingException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 
 import glob
-from io import open  # for open(..,encoding=...) parameter in python 2
 from os import walk
 from os.path import join, dirname, sep
 import re
@@ -95,7 +94,7 @@ setup(name='python-for-android',
       ),
       long_description=long_description,
       long_description_content_type='text/markdown',
-      python_requires=">=3.7.0",
+      python_requires=">=3.10.0",
       author='Kivy Team and other contributors',
       author_email='kivy-dev@googlegroups.com',
       url='https://github.com/kivy/python-for-android',
@@ -123,9 +122,6 @@ setup(name='python-for-android',
           'Operating System :: Android',
           'Programming Language :: C',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: 3.12',

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,6 +1,5 @@
 import unittest
 from os.path import join
-from sys import version as py_version
 
 import packaging.version
 from unittest import mock
@@ -33,13 +32,10 @@ from pythonforandroid.recommendations import (
     OLD_API_MESSAGE,
     MIN_PYTHON_MAJOR_VERSION,
     MIN_PYTHON_MINOR_VERSION,
-    PY2_ERROR_TEXT,
     PY_VERSION_ERROR_TEXT,
 )
 
 from pythonforandroid.util import BuildInterruptingException
-
-running_in_py2 = int(py_version[0]) < 3
 
 
 class TestRecommendations(unittest.TestCase):
@@ -51,7 +47,6 @@ class TestRecommendations(unittest.TestCase):
     def setUp(self):
         self.ndk_dir = "/opt/android/android-ndk"
 
-    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     @mock.patch("pythonforandroid.recommendations.read_ndk_version")
     def test_check_ndk_version_greater_than_recommended(self, mock_read_ndk):
         _version_string = f"{MIN_NDK_VERSION + 1}.0.5232133"
@@ -90,7 +85,6 @@ class TestRecommendations(unittest.TestCase):
         )
         mock_read_ndk.assert_called_once_with(self.ndk_dir)
 
-    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     def test_check_ndk_version_error(self):
         """
         Test that a fake ndk dir give us two messages:
@@ -131,7 +125,6 @@ class TestRecommendations(unittest.TestCase):
         assert version.minor == 2
         assert version.micro == 4988734
 
-    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     @mock.patch("pythonforandroid.recommendations.open")
     def test_read_ndk_version_error(self, mock_open_src_prop):
         mock_open_src_prop.side_effect = [
@@ -160,7 +153,6 @@ class TestRecommendations(unittest.TestCase):
             ),
         )
 
-    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     def test_check_target_api_warning_target_api(self):
 
         with self.assertLogs(level="INFO") as cm:
@@ -191,7 +183,6 @@ class TestRecommendations(unittest.TestCase):
             ),
         )
 
-    @unittest.skipIf(running_in_py2, "`assertLogs` requires Python 3.4+")
     def test_check_ndk_api_warning_old_ndk(self):
         """
         Given an `android api` lower than the supported by p4a, we should
@@ -216,17 +207,8 @@ class TestRecommendations(unittest.TestCase):
         """
         with mock.patch('sys.version_info') as fake_version_info:
 
-            # Major version is Python 2 => exception
-            fake_version_info.major = MIN_PYTHON_MAJOR_VERSION - 1
-            fake_version_info.minor = MIN_PYTHON_MINOR_VERSION
-            with self.assertRaises(BuildInterruptingException) as context:
-                check_python_version()
-            assert context.exception.message == PY2_ERROR_TEXT
-
             # Major version too low => exception
-            # Using a float valued major version just to test the logic and avoid
-            # clashing with the Python 2 check
-            fake_version_info.major = MIN_PYTHON_MAJOR_VERSION - 0.1
+            fake_version_info.major = MIN_PYTHON_MAJOR_VERSION - 1
             fake_version_info.minor = MIN_PYTHON_MINOR_VERSION
             with self.assertRaises(BuildInterruptingException) as context:
                 check_python_version()

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -1,6 +1,5 @@
 import io
 import os
-import sys
 import pytest
 from unittest import mock
 from pythonforandroid.recipe import Recipe
@@ -37,7 +36,6 @@ class TestToolchainCL:
         assert ex_info.value.code == 0
         assert m_print_help.call_args_list == [mock.call()]
 
-    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires python3")
     def test_unknown(self):
         """
         Calling with unknown args should print help and exit 1.
@@ -116,7 +114,6 @@ class TestToolchainCL:
         assert ex_info.value.message == (
             'Android SDK dir was not specified, exiting.')
 
-    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires python3")
     def test_recipes(self):
         """
         Checks the `recipes` command prints out recipes information without crashing.


### PR DESCRIPTION
Bump python_requires to >=3.10.0, drop the matching classifiers and CI matrix entries.

Align MIN_PYTHON_MINOR_VERSION to 10 and drop the now-unreachable Python 2 branch in check_python_version().

Remove the Python 2 compatibility shims anchored to the pre-3.10 floor (urlparse import, load_source Py3.3/3.4 fallback, FileNotFoundError shims, virtualenv branch, to_unicode wrapper, time.monotonic wrapper, path_type TypeError fallback, add_parser argparse aliases wrapper) and the permanently-inert Python 2 test markers.

Drop the `from __future__ import annotations` workaround in the msgspec recipe (PEP 585 generics are native since 3.9) and the PEP 508 `python_version<"3.3"` / `<"3.5"` markers in the ifaddr and zeroconf recipes (never satisfied under the new floor).

Modernize the remaining `typing.List` annotations to PEP 585 builtin generics (aiohttp, scipy/wrapper.py).
The aiohttp recipe is left untouched on purpose: editing it would trigger the rebuild_updated_recipes CI, which fails because aiohttp 3.8.3's pregenerated Cython C is incompatible with Python 3.14 hostpython -- fixing that needs a recipe bump and is out of scope here.