### PR TITLE
:recycle: Deduplicate Java service intent setup

### DIFF
--- a/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonServiceIntent.java
+++ b/pythonforandroid/bootstraps/common/build/src/main/java/org/kivy/android/PythonServiceIntent.java
@@ -1,0 +1,173 @@
+package org.kivy.android;
+
+import android.content.Context;
+import android.content.Intent;
+
+public class PythonServiceIntent {
+
+    private PythonServiceIntent() {}
+
+    public static Intent build(
+            Context ctx,
+            Class<?> serviceClass,
+            String serviceEntrypoint,
+            String serviceTitle,
+            String pythonName,
+            String serviceStartAsForeground,
+            String pythonServiceArgument,
+            String smallIconName,
+            String contentTitle,
+            String contentText) {
+        String appRoot = PythonUtil.getAppRoot(ctx);
+        return buildWithPaths(
+                ctx,
+                serviceClass,
+                ctx.getFilesDir().getAbsolutePath(),
+                appRoot,
+                null,
+                serviceEntrypoint,
+                serviceTitle,
+                null,
+                pythonName,
+                serviceStartAsForeground,
+                pythonServiceArgument,
+                smallIconName,
+                contentTitle,
+                contentText);
+    }
+
+    public static Intent build(
+            Context ctx,
+            Class<?> serviceClass,
+            String serviceEntrypoint,
+            String serviceTitle,
+            String pythonName,
+            boolean serviceStartAsForeground,
+            String pythonServiceArgument,
+            String smallIconName,
+            String contentTitle,
+            String contentText) {
+        return build(
+                ctx,
+                serviceClass,
+                serviceEntrypoint,
+                serviceTitle,
+                pythonName,
+                booleanToString(serviceStartAsForeground),
+                pythonServiceArgument,
+                smallIconName,
+                contentTitle,
+                contentText);
+    }
+
+    public static Intent buildActivityService(
+            Context ctx,
+            Class<?> serviceClass,
+            String serviceEntrypoint,
+            String serviceTitle,
+            String serviceDescription,
+            boolean serviceStartAsForeground,
+            String pythonServiceArgument) {
+        String appRoot = PythonUtil.getAppRoot(ctx);
+        return buildWithPaths(
+                ctx,
+                serviceClass,
+                ctx.getFilesDir().getAbsolutePath(),
+                appRoot,
+                null,
+                serviceEntrypoint,
+                serviceTitle,
+                serviceDescription,
+                "python",
+                booleanToString(serviceStartAsForeground),
+                pythonServiceArgument,
+                null,
+                null,
+                null);
+    }
+
+    public static Intent buildWithPaths(
+            Context ctx,
+            Class<?> serviceClass,
+            String androidPrivate,
+            String androidArgument,
+            String androidUnpack,
+            String serviceEntrypoint,
+            String serviceTitle,
+            String serviceDescription,
+            String pythonName,
+            String serviceStartAsForeground,
+            String pythonServiceArgument,
+            String smallIconName,
+            String contentTitle,
+            String contentText) {
+        Intent intent = new Intent(ctx, serviceClass);
+        intent.putExtra("androidPrivate", androidPrivate);
+        intent.putExtra("androidArgument", androidArgument);
+        intent.putExtra("serviceEntrypoint", serviceEntrypoint);
+        intent.putExtra("pythonName", pythonName);
+        intent.putExtra("serviceStartAsForeground", serviceStartAsForeground);
+        intent.putExtra("pythonHome", androidArgument);
+        intent.putExtra("pythonPath", androidArgument + ":" + androidArgument + "/lib");
+        intent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        intent.putExtra("serviceTitle", serviceTitle);
+
+        if (androidUnpack != null) {
+            intent.putExtra("androidUnpack", androidUnpack);
+        }
+        if (serviceDescription != null) {
+            intent.putExtra("serviceDescription", serviceDescription);
+        }
+        if (smallIconName != null) {
+            intent.putExtra("smallIconName", smallIconName);
+        }
+        if (contentTitle != null) {
+            intent.putExtra("contentTitle", contentTitle);
+        }
+        if (contentText != null) {
+            intent.putExtra("contentText", contentText);
+        }
+
+        return intent;
+    }
+
+    public static Intent buildWithPaths(
+            Context ctx,
+            Class<?> serviceClass,
+            String androidPrivate,
+            String androidArgument,
+            String androidUnpack,
+            String serviceEntrypoint,
+            String serviceTitle,
+            String serviceDescription,
+            String pythonName,
+            boolean serviceStartAsForeground,
+            String pythonServiceArgument,
+            String smallIconName,
+            String contentTitle,
+            String contentText) {
+        return buildWithPaths(
+                ctx,
+                serviceClass,
+                androidPrivate,
+                androidArgument,
+                androidUnpack,
+                serviceEntrypoint,
+                serviceTitle,
+                serviceDescription,
+                pythonName,
+                booleanToString(serviceStartAsForeground),
+                pythonServiceArgument,
+                smallIconName,
+                contentTitle,
+                contentText);
+    }
+
+    public static void stop(Context ctx, Class<?> serviceClass) {
+        ctx.stopService(new Intent(ctx, serviceClass));
+    }
+
+    private static String booleanToString(boolean value) {
+        return value ? "true" : "false";
+    }
+}

--- a/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/common/build/templates/Service.tmpl.java
@@ -3,6 +3,7 @@ package {{ args.package }};
 import android.content.Intent;
 import android.content.Context;
 import {{ args.service_class_name }};
+import org.kivy.android.PythonServiceIntent;
 
 
 public class Service{{ name|capitalize }} extends {{ base_service_class }} {
@@ -39,21 +40,17 @@ public class Service{{ name|capitalize }} extends {{ base_service_class }} {
     static public Intent getDefaultIntent(Context ctx, String smallIconName,
                                           String contentTitle, String contentText,
                                           String pythonServiceArgument) {
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
-        intent.putExtra("androidPrivate", ctx.getFilesDir().getAbsolutePath());
-        intent.putExtra("androidArgument", argument);
-        intent.putExtra("serviceTitle", "{{ args.name }}");
-        intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
-        intent.putExtra("pythonName", "{{ name }}");
-        intent.putExtra("serviceStartAsForeground", "{{ foreground|lower }}");
-        intent.putExtra("pythonHome", argument);
-        intent.putExtra("pythonPath", argument + ":" + argument + "/lib");
-        intent.putExtra("pythonServiceArgument", pythonServiceArgument);
-        intent.putExtra("smallIconName", smallIconName);
-        intent.putExtra("contentTitle", contentTitle);
-        intent.putExtra("contentText", contentText);
-        return intent;
+        return PythonServiceIntent.build(
+            ctx,
+            Service{{ name|capitalize }}.class,
+            "{{ entrypoint }}",
+            "{{ args.name }}",
+            "{{ name }}",
+            "{{ foreground|lower }}",
+            pythonServiceArgument,
+            smallIconName,
+            contentTitle,
+            contentText);
     }
 
     @Override
@@ -63,7 +60,6 @@ public class Service{{ name|capitalize }} extends {{ base_service_class }} {
     }
 
     static public void stop(Context ctx) {
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        ctx.stopService(intent);
+        PythonServiceIntent.stop(ctx, Service{{ name|capitalize }}.class);
     }
 }

--- a/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -216,26 +216,21 @@ public class PythonActivity extends QtActivity {
             String serviceDescription,
             String pythonServiceArgument,
             boolean showForegroundNotification) {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
-        serviceIntent.putExtra("androidPrivate", argument);
-        serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
-        serviceIntent.putExtra("pythonName", "python");
-        serviceIntent.putExtra("pythonHome", app_root_dir);
-        serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
-        serviceIntent.putExtra(
-                "serviceStartAsForeground", (showForegroundNotification ? "true" : "false"));
-        serviceIntent.putExtra("serviceTitle", serviceTitle);
-        serviceIntent.putExtra("serviceDescription", serviceDescription);
-        serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        Intent serviceIntent =
+                PythonServiceIntent.buildActivityService(
+                        PythonActivity.mActivity,
+                        PythonService.class,
+                        "service/" + entry_point,
+                        serviceTitle,
+                        serviceDescription,
+                        showForegroundNotification,
+                        pythonServiceArgument);
         PythonActivity.mActivity.startService(serviceIntent);
     }
 
     public static void stop_service() {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        PythonActivity.mActivity.stopService(serviceIntent);
+        PythonServiceIntent.stop(PythonActivity.mActivity, PythonService.class);
     }
 }

--- a/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl2/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -302,27 +302,22 @@ public class PythonActivity extends SDLActivity {
             String serviceDescription,
             String pythonServiceArgument,
             boolean showForegroundNotification) {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
-        serviceIntent.putExtra("androidPrivate", argument);
-        serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
-        serviceIntent.putExtra("pythonName", "python");
-        serviceIntent.putExtra("pythonHome", app_root_dir);
-        serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
-        serviceIntent.putExtra(
-                "serviceStartAsForeground", (showForegroundNotification ? "true" : "false"));
-        serviceIntent.putExtra("serviceTitle", serviceTitle);
-        serviceIntent.putExtra("serviceDescription", serviceDescription);
-        serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        Intent serviceIntent =
+                PythonServiceIntent.buildActivityService(
+                        PythonActivity.mActivity,
+                        PythonService.class,
+                        "service/" + entry_point,
+                        serviceTitle,
+                        serviceDescription,
+                        showForegroundNotification,
+                        pythonServiceArgument);
         PythonActivity.mActivity.startService(serviceIntent);
     }
 
     public static void stop_service() {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        PythonActivity.mActivity.stopService(serviceIntent);
+        PythonServiceIntent.stop(PythonActivity.mActivity, PythonService.class);
     }
 
     /** Loading screen view * */

--- a/pythonforandroid/bootstraps/sdl3/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/sdl3/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -301,27 +301,22 @@ public class PythonActivity extends SDLActivity {
             String serviceDescription,
             String pythonServiceArgument,
             boolean showForegroundNotification) {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
-        serviceIntent.putExtra("androidPrivate", argument);
-        serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
-        serviceIntent.putExtra("pythonName", "python");
-        serviceIntent.putExtra("pythonHome", app_root_dir);
-        serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
-        serviceIntent.putExtra(
-                "serviceStartAsForeground", (showForegroundNotification ? "true" : "false"));
-        serviceIntent.putExtra("serviceTitle", serviceTitle);
-        serviceIntent.putExtra("serviceDescription", serviceDescription);
-        serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        Intent serviceIntent =
+                PythonServiceIntent.buildActivityService(
+                        PythonActivity.mActivity,
+                        PythonService.class,
+                        "service/" + entry_point,
+                        serviceTitle,
+                        serviceDescription,
+                        showForegroundNotification,
+                        pythonServiceArgument);
         PythonActivity.mActivity.startService(serviceIntent);
     }
 
     public static void stop_service() {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        PythonActivity.mActivity.stopService(serviceIntent);
+        PythonServiceIntent.stop(PythonActivity.mActivity, PythonService.class);
     }
 
     /** Loading screen view * */

--- a/pythonforandroid/bootstraps/service_library/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_library/build/templates/Service.tmpl.java
@@ -9,6 +9,7 @@ import android.content.res.Resources;
 import android.util.Log;
 
 import org.kivy.android.PythonService;
+import org.kivy.android.PythonServiceIntent;
 import org.kivy.android.PythonUtil;
 
 public class Service{{ name|capitalize }} extends PythonService {
@@ -69,21 +70,21 @@ public class Service{{ name|capitalize }} extends PythonService {
 					  String contentText,
 					  String pythonServiceArgument) {
         String appRoot = PythonUtil.getAppRoot(ctx);
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        intent.putExtra("androidPrivate", appRoot);
-        intent.putExtra("androidArgument", appRoot);
-        intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
-        intent.putExtra("serviceTitle", "{{ name|capitalize }}");
-        intent.putExtra("pythonName", "{{ name }}");
-        intent.putExtra("serviceStartAsForeground", "{{ foreground|lower }}");
-        intent.putExtra("pythonHome", appRoot);
-        intent.putExtra("androidUnpack", appRoot);
-        intent.putExtra("pythonPath", appRoot + ":" + appRoot + "/lib");
-        intent.putExtra("pythonServiceArgument", pythonServiceArgument);
-        intent.putExtra("smallIconName", smallIconName);
-        intent.putExtra("contentTitle", contentTitle);
-        intent.putExtra("contentText", contentText);
-        return intent;
+        return PythonServiceIntent.buildWithPaths(
+            ctx,
+            Service{{ name|capitalize }}.class,
+            appRoot,
+            appRoot,
+            appRoot,
+            "{{ entrypoint }}",
+            "{{ name|capitalize }}",
+            null,
+            "{{ name }}",
+            "{{ foreground|lower }}",
+            pythonServiceArgument,
+            smallIconName,
+            contentTitle,
+            contentText);
     }
 
     @Override
@@ -95,8 +96,7 @@ public class Service{{ name|capitalize }} extends PythonService {
 
 
     static public void stop(Context ctx) {
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        ctx.stopService(intent);
+        PythonServiceIntent.stop(ctx, Service{{ name|capitalize }}.class);
     }
 
 }

--- a/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/service_only/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -286,27 +286,22 @@ public class PythonActivity extends Activity {
             String serviceDescription,
             String pythonServiceArgument,
             boolean showForegroundNotification) {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
-        serviceIntent.putExtra("androidPrivate", argument);
-        serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
-        serviceIntent.putExtra("pythonName", "python");
-        serviceIntent.putExtra("pythonHome", app_root_dir);
-        serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
-        serviceIntent.putExtra(
-                "serviceStartAsForeground", (showForegroundNotification ? "true" : "false"));
-        serviceIntent.putExtra("serviceTitle", serviceTitle);
-        serviceIntent.putExtra("serviceDescription", serviceDescription);
-        serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        Intent serviceIntent =
+                PythonServiceIntent.buildActivityService(
+                        PythonActivity.mActivity,
+                        PythonService.class,
+                        "service/" + entry_point,
+                        serviceTitle,
+                        serviceDescription,
+                        showForegroundNotification,
+                        pythonServiceArgument);
         PythonActivity.mActivity.startService(serviceIntent);
     }
 
     public static void stop_service() {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        PythonActivity.mActivity.stopService(serviceIntent);
+        PythonServiceIntent.stop(PythonActivity.mActivity, PythonService.class);
     }
 
     public static native void nativeSetenv(String name, String value);

--- a/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
+++ b/pythonforandroid/bootstraps/service_only/build/templates/Service.tmpl.java
@@ -5,6 +5,8 @@ import android.os.IBinder;
 import android.content.Intent;
 import android.content.Context;
 import org.kivy.android.PythonService;
+import org.kivy.android.PythonServiceIntent;
+import org.kivy.android.PythonUtil;
 
 public class Service{{ name|capitalize }} extends PythonService {
 	/**
@@ -28,21 +30,8 @@ public class Service{{ name|capitalize }} extends PythonService {
     }
 
     public static void start(Context ctx, String pythonServiceArgument) {
-        String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        intent.putExtra("androidPrivate", argument);
-        intent.putExtra("androidArgument", argument);
-        intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
-        intent.putExtra("serviceTitle", "{{ name|capitalize }}");
-        intent.putExtra("pythonName", "{{ name }}");
-        intent.putExtra("serviceStartAsForeground", "{{ foreground|lower }}");
-        intent.putExtra("pythonHome", argument);
-        intent.putExtra("androidUnpack", argument);
-        intent.putExtra("pythonPath", argument + ":" + argument + "/lib");
-        intent.putExtra("pythonServiceArgument", pythonServiceArgument);
-        intent.putExtra("smallIconName", "");
-        intent.putExtra("contentTitle", "{{ name|capitalize }}");
-        intent.putExtra("contentText", "");	    
+        Intent intent = getDefaultIntent(ctx, "", "{{ name|capitalize }}", "",
+            pythonServiceArgument);
         ctx.startService(intent);
     }
 	
@@ -50,27 +39,34 @@ public class Service{{ name|capitalize }} extends PythonService {
 			     String contentTitle,
 			     String contentText,
 			     String pythonServiceArgument) {	
-        String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        intent.putExtra("androidPrivate", argument);
-        intent.putExtra("androidArgument", argument);
-        intent.putExtra("serviceEntrypoint", "{{ entrypoint }}");
-        intent.putExtra("serviceTitle", "{{ name|capitalize }}");
-        intent.putExtra("pythonName", "{{ name }}");
-        intent.putExtra("serviceStartAsForeground", "{{ foreground|lower }}");
-        intent.putExtra("pythonHome", argument);
-        intent.putExtra("androidUnpack", argument);
-        intent.putExtra("pythonPath", argument + ":" + argument + "/lib");
-        intent.putExtra("pythonServiceArgument", pythonServiceArgument);
-        intent.putExtra("smallIconName", smallIconName);
-        intent.putExtra("contentTitle", contentTitle);
-        intent.putExtra("contentText", contentText);	    
+        Intent intent = getDefaultIntent(ctx, smallIconName, contentTitle,
+            contentText, pythonServiceArgument);
         ctx.startService(intent);
+    }
+
+    public static Intent getDefaultIntent(Context ctx, String smallIconName,
+                                          String contentTitle, String contentText,
+                                          String pythonServiceArgument) {
+        String appRoot = PythonUtil.getAppRoot(ctx);
+        return PythonServiceIntent.buildWithPaths(
+            ctx,
+            Service{{ name|capitalize }}.class,
+            appRoot,
+            appRoot,
+            appRoot,
+            "{{ entrypoint }}",
+            "{{ name|capitalize }}",
+            null,
+            "{{ name }}",
+            "{{ foreground|lower }}",
+            pythonServiceArgument,
+            smallIconName,
+            contentTitle,
+            contentText);
     }
 	
     public static void stop(Context ctx) {
-        Intent intent = new Intent(ctx, Service{{ name|capitalize }}.class);
-        ctx.stopService(intent);
+        PythonServiceIntent.stop(ctx, Service{{ name|capitalize }}.class);
     }
 
     /**

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -463,27 +463,22 @@ public class PythonActivity extends Activity {
             String serviceDescription,
             String pythonServiceArgument,
             boolean showForegroundNotification) {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        String argument = PythonActivity.mActivity.getFilesDir().getAbsolutePath();
         String app_root_dir = PythonActivity.mActivity.getAppRoot();
         String entry_point = PythonActivity.mActivity.getEntryPoint(app_root_dir + "/service");
-        serviceIntent.putExtra("androidPrivate", argument);
-        serviceIntent.putExtra("androidArgument", app_root_dir);
-        serviceIntent.putExtra("serviceEntrypoint", "service/" + entry_point);
-        serviceIntent.putExtra("pythonName", "python");
-        serviceIntent.putExtra("pythonHome", app_root_dir);
-        serviceIntent.putExtra("pythonPath", app_root_dir + ":" + app_root_dir + "/lib");
-        serviceIntent.putExtra(
-                "serviceStartAsForeground", (showForegroundNotification ? "true" : "false"));
-        serviceIntent.putExtra("serviceTitle", serviceTitle);
-        serviceIntent.putExtra("serviceDescription", serviceDescription);
-        serviceIntent.putExtra("pythonServiceArgument", pythonServiceArgument);
+        Intent serviceIntent =
+                PythonServiceIntent.buildActivityService(
+                        PythonActivity.mActivity,
+                        PythonService.class,
+                        "service/" + entry_point,
+                        serviceTitle,
+                        serviceDescription,
+                        showForegroundNotification,
+                        pythonServiceArgument);
         PythonActivity.mActivity.startService(serviceIntent);
     }
 
     public static void stop_service() {
-        Intent serviceIntent = new Intent(PythonActivity.mActivity, PythonService.class);
-        PythonActivity.mActivity.stopService(serviceIntent);
+        PythonServiceIntent.stop(PythonActivity.mActivity, PythonService.class);
     }
 
     public static native void nativeSetenv(String name, String value);


### PR DESCRIPTION
Add a shared PythonServiceIntent helper for building Python service intents and stopping services.
Migrate activity service-start methods and generated service templates to delegate intent construction while preserving public APIs, service-only Binder behavior, and service-library foreground startup behavior.