### PR TITLE
Fix Qt bootstrap handling of non-back key events

### DIFF
--- a/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -123,8 +123,10 @@ public class PythonActivity extends QtActivity {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // If it wasn't the Back key or there's no web page history, bubble up to the default
-        // system behavior (probably exit the activity)
+        if (keyCode != KeyEvent.KEYCODE_BACK) {
+            return super.onKeyDown(keyCode, event);
+        }
+
         if (SystemClock.elapsedRealtime() - lastBackClick > 2000) {
             lastBackClick = SystemClock.elapsedRealtime();
             Toast.makeText(this, "Click again to close the app", Toast.LENGTH_LONG).show();


### PR DESCRIPTION
## Summary
- handle only Android Back key events in the Qt bootstrap double-tap-to-exit logic
- pass all other key events through to Qt via `super.onKeyDown`
- checked the other bootstraps: webview/service_only already guard KEYCODE_BACK, and the remaining bootstraps do not use this double-back exit logic

## Testing
- `git diff --check`
- fork GitHub Actions workflow `Unit tests & build apps` run 26929233140 completed successfully, including Flake8, Java Spotless, pytest matrix, recipe tests, emulator run, and Qt app build