### PR TITLE
Fix order of  `setup.py` config.

### DIFF
--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -323,8 +323,12 @@ main.py that loads it.''')
         f.write("P4A_MINSDK=" + str(args.min_sdk_version) + "\n")
 
     # Package up the private data (public not supported).
-    use_setup_py = get_dist_info_for("use_setup_py",
-                                     error_if_missing=False) is True
+    use_setup_py = (
+        get_dist_info_for("use_setup_py", error_if_missing=False) is True
+        and
+        get_dist_info_for("ignore_setup_py", error_if_missing=False) is not True
+    )
+
     private_tar_dirs = [env_vars_tarpath]
     _temp_dirs_to_clean = []
     try:


### PR DESCRIPTION
When I have `setup.py` and `pyproject.toml` in my project and need to ignore them.