### PR TITLE
Fix OOM for other bootstraps

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/gradle.tmpl.properties
+++ b/pythonforandroid/bootstraps/common/build/templates/gradle.tmpl.properties
@@ -1,8 +1,6 @@
-{% if bootstrap_name == "qt" %}
-# For tweaking memory settings. Otherwise, a p4a session with Qt bootstrap and PySide6 recipe
+# For tweaking memory settings. Otherwise, a p4a session
 # terminates with a Java out of memory exception
 org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-{% endif %}
 {% if args.enable_androidx %}
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Closes #2984

I suspect it happens when `private.tar` is large enough.


(Tested locally - it fixes my build)