### PR TITLE
android: implement Kivy 3's bootstrap contract (`_kivy_bootstrap`)

### DIFF
--- a/doc/source/bootstraps.rst
+++ b/doc/source/bootstraps.rst
@@ -4,7 +4,9 @@ Bootstraps
 
 This page is about creating new bootstrap backends. For build options
 of existing bootstraps (i.e. with SDL2, Webview, etc.), see
-:ref:`build options <bootstrap_build_options>`.
+:ref:`build options <bootstrap_build_options>`. If your bootstrap is
+to run Kivy 3 apps, it must also satisfy
+:ref:`Kivy's bootstrap contract <kivy_bootstrap_contract>`.
 
 python-for-android (p4a) supports multiple *bootstraps*. These fulfill a
 similar role to recipes, but instead of describing how to compile a

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,7 @@ Contents
    distutils
    recipes
    bootstraps
+   kivy_bootstrap
    services
    troubleshooting
    docker

--- a/doc/source/kivy_bootstrap.rst
+++ b/doc/source/kivy_bootstrap.rst
@@ -8,9 +8,9 @@ reflecting a class name of its own. Any tool that builds Android APKs — this
 project, another build tool, or a bootstrap you write yourself — makes Kivy 3
 work by answering that question.
 
-This page is the implementer's guide: what to ship, the rules it must obey, and
-a working example to copy. p4a's own implementation is
-``pythonforandroid/recipes/android/src/_kivy_bootstrap.py``, reproduced below.
+This page is the implementer's guide: what to ship, the rules it must obey.
+p4a's own implementation is
+``pythonforandroid/recipes/android/src/_kivy_bootstrap.py``.
 
 Kivy 2.3.1 does not use this contract and is unaffected; see
 `Supporting Kivy 2.3.1 as well`_ if you need both.
@@ -54,8 +54,7 @@ Return an ``android.content.Context``, or ``None``.
 Implement this only if your bootstrap runs processes that never have an
 Activity and still need a Context. When it is absent — or returns ``None`` —
 Kivy derives the Application context from the current Activity, which is
-equivalent for everything Kivy uses a Context for. Neither p4a nor kivyforge
-implements it.
+equivalent for everything Kivy uses a Context for. p4a does not implement it.
 
 ``remove_presplash()`` (optional)
 ---------------------------------
@@ -122,120 +121,6 @@ Useful when debugging your implementation:
   otherwise calls ``getApplicationContext()`` on the current Activity.
 * ``kivy.mobile.get_activity()`` returns exactly what your function returned,
   ``None`` included.
-
-Minimal implementation
-----------------------
-
-Enough to satisfy the contract, if your activity class is fixed at build time:
-
-.. code-block:: python
-
-    from jnius import autoclass
-
-    _ACTIVITY_CLASS = "com.example.MyActivity"  # your class; Kivy never sees it
-
-    _activity_class = None
-
-
-    def get_activity():
-        global _activity_class
-        if _activity_class is None:
-            _activity_class = autoclass(_ACTIVITY_CLASS)
-        return _activity_class.mActivity
-
-Your activity needs some way to expose the running instance. p4a and kivyforge
-both use a ``public static`` field assigned in ``onCreate``; anything reachable
-by reflection will do.
-
-Worked example: python-for-android
-----------------------------------
-
-The complete p4a implementation, from
-``pythonforandroid/recipes/android/src/_kivy_bootstrap.py`` (docstrings
-trimmed here; the file explains each decision at length):
-
-.. code-block:: python
-
-    from jnius import autoclass
-
-    from android.config import ACTIVITY_CLASS_NAME
-
-    _activity_class = None
-
-
-    def get_activity():
-        """The current android.app.Activity, or None if there is none."""
-        global _activity_class
-        if _activity_class is None:
-            # Resolved on first use rather than at import so that reflection
-            # failures surface from the call, not from Kivy's discovery import.
-            _activity_class = autoclass(ACTIVITY_CLASS_NAME)
-        return _activity_class.mActivity
-
-
-    def remove_presplash():
-        """Dismiss the loading screen, if this build has one."""
-        activity = get_activity()
-        if activity is None:
-            return
-        remove = getattr(activity, "removeLoadingScreen", None)
-        if remove is not None:
-            remove()
-
-Two things there are worth imitating.
-
-The class name comes from the build-time generated ``android.config`` rather
-than a literal, so a custom activity passed to ``--activity-class-name`` is
-honoured: Kivy gets the class *this build* chose. If your tool lets users
-override the activity, resolve the name the same way.
-
-``remove_presplash()`` asks the activity for ``removeLoadingScreen`` instead of
-consulting a list of bootstraps that have one. Not every p4a build does —
-``service_only`` has no such method, and a custom activity need not inherit
-one — and a hardcoded list has already drifted once in this codebase.
-
-A second example: kivyforge
----------------------------
-
-kivyforge, a Gradle- and wheel-based Android builder, implements the same
-contract in its own ``_kivy_bootstrap.py`` against an unmodified Kivy. It
-differs in exactly the ways the contract allows: the activity class is a
-constant it owns, since it has no ``android.config``; and it omits
-``remove_presplash()`` entirely, because it uses the androidx
-core-splashscreen system splash, which the framework dismisses itself and which
-exposes no view for anyone to tear down.
-
-That two bootstraps this different need no cooperation from each other, and no
-change in Kivy, is the contract working as intended.
-
-Verifying on a device
----------------------
-
-The failure this contract guards against is a build that starts fine and dies
-the moment Kivy first needs the Activity, so check it on a device or emulator
-rather than in a unit test:
-
-.. code-block:: python
-
-    import _kivy_bootstrap
-
-    activity = _kivy_bootstrap.get_activity()
-    assert activity is not None
-    assert activity.getPackageName()      # answers as a Context: it is live
-
-Then, from inside a running Kivy app, confirm Kivy agrees with you:
-
-.. code-block:: python
-
-    from kivy.mobile import get_activity, get_app_context
-
-    assert get_activity().equals(_kivy_bootstrap.get_activity())
-    assert get_app_context() is not None
-
-Beyond that, the contract is exercised by anything in Kivy that needs the
-Activity: display metrics (``kivy.metrics``), ``App.user_data_dir``, the
-clipboard provider, and the splash removal after the first frame. If those work,
-your implementation is complete.
 
 Supporting Kivy 2.3.1 as well
 -----------------------------

--- a/doc/source/kivy_bootstrap.rst
+++ b/doc/source/kivy_bootstrap.rst
@@ -1,0 +1,248 @@
+.. _kivy_bootstrap_contract:
+
+Supporting Kivy 3 (the Kivy bootstrap contract)
+===============================================
+
+Kivy 3 asks the bootstrap for the current Android ``Activity`` instead of
+reflecting a class name of its own. Any tool that builds Android APKs — this
+project, another build tool, or a bootstrap you write yourself — makes Kivy 3
+work by answering that question.
+
+This page is the implementer's guide: what to ship, the rules it must obey, and
+a working example to copy. p4a's own implementation is
+``pythonforandroid/recipes/android/src/_kivy_bootstrap.py``, reproduced below.
+
+Kivy 2.3.1 does not use this contract and is unaffected; see
+`Supporting Kivy 2.3.1 as well`_ if you need both.
+
+What you ship
+-------------
+
+One pure-Python module named ``_kivy_bootstrap``, importable at the **top
+level** of the running app's ``sys.path``. Nothing else: no registration call,
+no import order to arrange, no Kivy dependency.
+
+The name is Kivy's, not any bootstrap's. That is the point of the arrangement —
+Kivy depends on the name, so it depends on no particular bootstrap, and an
+unmodified Kivy runs on an APK built by any of them.
+
+Kivy imports the module the first time it needs the Activity, so it must be on
+``sys.path`` before the application's ``main.py`` runs. In p4a it is a
+``py_modules`` entry of the ``android`` recipe, so it lands beside the app's
+other top-level modules in ``site-packages``.
+
+``get_activity()`` (required)
+-----------------------------
+
+Return the current ``android.app.Activity``, or ``None`` where there is none.
+
+.. code-block:: python
+
+    def get_activity():
+        return SomeActivityClass.mActivity
+
+Kivy calls this **live on every access** and never caches the result, so your
+implementation must not cache it either (see rule 2 below). ``None`` is a
+legitimate answer, not a failure: a background service runs with no Activity,
+and Kivy treats that as the ordinary case it is.
+
+``get_context()`` (optional)
+----------------------------
+
+Return an ``android.content.Context``, or ``None``.
+
+Implement this only if your bootstrap runs processes that never have an
+Activity and still need a Context. When it is absent — or returns ``None`` —
+Kivy derives the Application context from the current Activity, which is
+equivalent for everything Kivy uses a Context for. Neither p4a nor kivyforge
+implements it.
+
+``remove_presplash()`` (optional)
+---------------------------------
+
+Dismiss your boot splash. Kivy calls this once it has drawn its first frame,
+which is the one thing about a splash screen that only Kivy knows.
+
+*How* a splash is dismissed is entirely yours, and the mechanisms differ
+fundamentally: p4a overlays a ``View`` and removes it, while a bootstrap using
+the Android 12 system splash releases a keep-on-screen condition instead — not
+a method on the Activity at all. That is why this is an optional function on
+your module rather than a method Kivy calls on the Activity.
+
+If you have no splash to dismiss, omit the function. Kivy treats its absence as
+the no-op it is, with no warning.
+
+Rules
+-----
+
+1. **Never import Kivy from this module.** Kivy reads its ``KIVY_*``
+   environment and builds its configuration at import time, so importing it
+   before the application runs would freeze that configuration before the app's
+   ``main.py`` could set it. Kivy pulls from you precisely so that you never
+   have to import it.
+
+2. **Never cache the Activity.** Android destroys and recreates the Activity on
+   configuration changes (rotation, dark mode, locale, multi-window) and after
+   process death. A stored instance goes stale, and holding one in a Python
+   global pins a JNI reference to a dead Activity. Read it fresh on every call
+   and staleness stops being your problem.
+
+3. **Resolve reflection inside the call, not at import.** Resolve the Java
+   class on first call and cache *the class* if you like, but do not do it at
+   module import: a reflection failure would then surface from Kivy's discovery
+   import, where it looks like a missing module rather than the real fault.
+
+4. **Fail at import only with an ImportError, and only if you mean it.** Kivy
+   treats ``ImportError`` as "this bootstrap does not implement the contract"
+   and moves on to raise a diagnostic. Any *other* exception escaping your
+   module's import is treated as a fault in your module and propagates
+   unchanged, so it is not mistaken for an absent bootstrap.
+
+5. **A presplash hook must not raise, and must tolerate repeat calls.**
+   Kivy does not guard the call and makes no promise about calling it exactly
+   once. Doing nothing is a correct outcome; raising is not.
+
+6. **Hold no state beyond the resolved class.** Kivy may call these from more
+   than one thread. A stateless module is thread-safe without a lock, and the
+   contract is designed so that statelessness costs nothing.
+
+What Kivy does with it
+----------------------
+
+Useful when debugging your implementation:
+
+* The module is imported lazily, on first use, and the outcome is cached —
+  including failure, so a build with no such module does not pay for a failed
+  import on every geometry read.
+* If the module is missing (or exposes no callable ``get_activity``) **while an
+  Android runtime is present**, Kivy raises ``ActivityProviderMissing``. This
+  is deliberately not caught by Kivy's display-geometry getters, which would
+  otherwise mask a broken build as plausible-looking defaults.
+* ``kivy.mobile.get_app_context()`` prefers your ``get_context()`` and
+  otherwise calls ``getApplicationContext()`` on the current Activity.
+* ``kivy.mobile.get_activity()`` returns exactly what your function returned,
+  ``None`` included.
+
+Minimal implementation
+----------------------
+
+Enough to satisfy the contract, if your activity class is fixed at build time:
+
+.. code-block:: python
+
+    from jnius import autoclass
+
+    _ACTIVITY_CLASS = "com.example.MyActivity"  # your class; Kivy never sees it
+
+    _activity_class = None
+
+
+    def get_activity():
+        global _activity_class
+        if _activity_class is None:
+            _activity_class = autoclass(_ACTIVITY_CLASS)
+        return _activity_class.mActivity
+
+Your activity needs some way to expose the running instance. p4a and kivyforge
+both use a ``public static`` field assigned in ``onCreate``; anything reachable
+by reflection will do.
+
+Worked example: python-for-android
+----------------------------------
+
+The complete p4a implementation, from
+``pythonforandroid/recipes/android/src/_kivy_bootstrap.py`` (docstrings
+trimmed here; the file explains each decision at length):
+
+.. code-block:: python
+
+    from jnius import autoclass
+
+    from android.config import ACTIVITY_CLASS_NAME
+
+    _activity_class = None
+
+
+    def get_activity():
+        """The current android.app.Activity, or None if there is none."""
+        global _activity_class
+        if _activity_class is None:
+            # Resolved on first use rather than at import so that reflection
+            # failures surface from the call, not from Kivy's discovery import.
+            _activity_class = autoclass(ACTIVITY_CLASS_NAME)
+        return _activity_class.mActivity
+
+
+    def remove_presplash():
+        """Dismiss the loading screen, if this build has one."""
+        activity = get_activity()
+        if activity is None:
+            return
+        remove = getattr(activity, "removeLoadingScreen", None)
+        if remove is not None:
+            remove()
+
+Two things there are worth imitating.
+
+The class name comes from the build-time generated ``android.config`` rather
+than a literal, so a custom activity passed to ``--activity-class-name`` is
+honoured: Kivy gets the class *this build* chose. If your tool lets users
+override the activity, resolve the name the same way.
+
+``remove_presplash()`` asks the activity for ``removeLoadingScreen`` instead of
+consulting a list of bootstraps that have one. Not every p4a build does —
+``service_only`` has no such method, and a custom activity need not inherit
+one — and a hardcoded list has already drifted once in this codebase.
+
+A second example: kivyforge
+---------------------------
+
+kivyforge, a Gradle- and wheel-based Android builder, implements the same
+contract in its own ``_kivy_bootstrap.py`` against an unmodified Kivy. It
+differs in exactly the ways the contract allows: the activity class is a
+constant it owns, since it has no ``android.config``; and it omits
+``remove_presplash()`` entirely, because it uses the androidx
+core-splashscreen system splash, which the framework dismisses itself and which
+exposes no view for anyone to tear down.
+
+That two bootstraps this different need no cooperation from each other, and no
+change in Kivy, is the contract working as intended.
+
+Verifying on a device
+---------------------
+
+The failure this contract guards against is a build that starts fine and dies
+the moment Kivy first needs the Activity, so check it on a device or emulator
+rather than in a unit test:
+
+.. code-block:: python
+
+    import _kivy_bootstrap
+
+    activity = _kivy_bootstrap.get_activity()
+    assert activity is not None
+    assert activity.getPackageName()      # answers as a Context: it is live
+
+Then, from inside a running Kivy app, confirm Kivy agrees with you:
+
+.. code-block:: python
+
+    from kivy.mobile import get_activity, get_app_context
+
+    assert get_activity().equals(_kivy_bootstrap.get_activity())
+    assert get_app_context() is not None
+
+Beyond that, the contract is exercised by anything in Kivy that needs the
+Activity: display metrics (``kivy.metrics``), ``App.user_data_dir``, the
+clipboard provider, and the splash removal after the first frame. If those work,
+your implementation is complete.
+
+Supporting Kivy 2.3.1 as well
+-----------------------------
+
+Kivy 2.3.1 predates this contract. It reaches p4a's Python ``android`` module
+directly — ``android.remove_presplash()`` and friends — and hardcodes
+``org.kivy.android.PythonActivity``. A bootstrap that wants to run both Kivy
+2.3.1 and Kivy 3 therefore has to satisfy both: ship ``_kivy_bootstrap`` for
+Kivy 3, and provide the ``android`` module (and an activity of that class name)
+for 2.3.1. A bootstrap targeting Kivy 3 alone needs only this contract.

--- a/pythonforandroid/recipes/android/src/_kivy_bootstrap.py
+++ b/pythonforandroid/recipes/android/src/_kivy_bootstrap.py
@@ -1,0 +1,64 @@
+"""python-for-android's implementation of Kivy's Android bootstrap contract.
+
+Kivy 3 holds no bootstrap class name of its own: it imports ``_kivy_bootstrap``
+and asks it for the current ``android.app.Activity`` instead.  Kivy pulls on
+first use rather than having the bootstrap register at startup, which suits p4a:
+``start.c`` runs the user's ``main.py`` as the process entry point, so there is
+no p4a-owned Python before the app to register from.  It also means p4a never
+imports Kivy, which would otherwise fix Kivy's ``KIVY_*`` environment and config
+before the app had a chance to set them.
+
+The activity class comes from the build-time generated ``android.config``, so a
+custom activity set with ``--activity-class-name`` is honoured rather than
+assumed to be the default.
+
+Besides the required ``get_activity()``, this implements the contract's optional
+``remove_presplash()``.  ``get_context()`` is not implemented: p4a's Activity can
+always supply the Application context, and Kivy falls back to deriving it.
+
+This module deliberately holds no state beyond the resolved class: the Activity
+is read fresh on every call, so it stays correct across the recreation Android
+performs on rotation, configuration changes and process death.
+"""
+
+from jnius import autoclass
+
+from android.config import ACTIVITY_CLASS_NAME
+
+_activity_class = None
+
+
+def get_activity():
+    """Return the current ``android.app.Activity``, or ``None`` if there is none.
+
+    ``None`` is a legitimate answer — a p4a service runs without an Activity.
+    """
+    global _activity_class
+    if _activity_class is None:
+        # Resolved on first use rather than at import so that reflection
+        # failures surface from the call, not from Kivy's discovery import.
+        _activity_class = autoclass(ACTIVITY_CLASS_NAME)
+    return _activity_class.mActivity
+
+
+def remove_presplash():
+    """Dismiss the loading screen, if this build has one.
+
+    Kivy calls this once it has drawn its first frame — the moment only Kivy
+    knows.  How the splash goes away is p4a's business: here it means removing
+    the View that ``PythonActivity`` laid over the app, which the Java method
+    marshals onto the UI thread itself, so there is nothing to arrange here.
+
+    Not every p4a build has a splash to remove: ``service_only`` has no
+    ``removeLoadingScreen`` at all, and a custom ``--activity-class-name`` need
+    not inherit one.  So the activity is asked, rather than a hardcoded list of
+    bootstraps consulted — that list has already drifted once, ``android``'s own
+    ``remove_presplash`` being gated to sdl2/sdl3 though the webview activity has
+    the method too.  Doing nothing is a valid outcome and Kivy treats it as one.
+    """
+    activity = get_activity()
+    if activity is None:
+        return
+    remove = getattr(activity, "removeLoadingScreen", None)
+    if remove is not None:
+        remove()

--- a/pythonforandroid/recipes/android/src/setup.py
+++ b/pythonforandroid/recipes/android/src/setup.py
@@ -34,5 +34,8 @@ setup(name='android',
       version='1.0',
       packages=['android'],
       package_dir={'android': 'android'},
+      # Top-level, not under `android`: the name is Kivy's, and Kivy imports it
+      # without knowing which bootstrap built the app.
+      py_modules=['_kivy_bootstrap'],
       ext_modules=cythonized_modules
       )


### PR DESCRIPTION
## The problem

Kivy reaches the Android Activity by reflecting a class name it hardcodes,
`org.kivy.android.PythonActivity`. That makes Kivy depend on a p4a
implementation detail, and it silently breaks any build whose activity is named
something else — including p4a's own `--activity-class-name`.

Kivy 3 inverts it: Kivy names no activity class and asks the bootstrap that
built the APK instead. This PR is p4a's half, making p4a a bootstrap that
satisfies Kivy's contract rather than the source of truth Kivy is written
against. It is inert for every existing build — nothing imports the new module
unless Kivy 3 does, and Kivy 2.3.1 keeps using the `android` module exactly as
it does today.

## The contract

A bootstrap ships a top-level module named `_kivy_bootstrap`. The name is
Kivy's, not any bootstrap's, which is the point: Kivy depends on the name
without depending on who implements it.

| member | required | meaning |
| --- | --- | --- |
| `get_activity()` | yes | the current `android.app.Activity`, or `None` where none exists |
| `get_context()` | no | a `Context` for processes that never have an Activity |
| `remove_presplash()` | no | dismiss the boot splash; Kivy calls it after the first frame |

Kivy imports the module on first use and calls `get_activity()` live on every
access. Nothing is cached, so nothing goes stale when Android recreates the
Activity on rotation, configuration change or process death. `None` is a
legitimate answer — a service runs without an Activity — while a *missing
module* on a real device raises rather than degrading to a plausible default.

Kivy pulls instead of the bootstrap pushing a provider at startup, for two
p4a-specific reasons. `start.c` runs the user's `main.py` as the process entry
point, so there is no p4a-owned Python to register from without adding a new
C-level seam to every bootstrap. And pushing would mean importing Kivy before
the app runs, which would freeze Kivy's `KIVY_*` environment and config before
`main.py` could set them. Pulling means p4a never imports Kivy at all.

## What this PR adds

- **`pythonforandroid/recipes/android/src/_kivy_bootstrap.py`** (new, 64 lines,
  mostly docstrings explaining the reasoning). The class name comes from the
  build-time generated `android.config`, so `--activity-class-name` is honoured
  rather than assumed; it is resolved on first call rather than at import, so a
  reflection failure surfaces from the call that needs the Activity instead of
  from Kivy's discovery import. `remove_presplash()` asks the activity for
  `removeLoadingScreen` rather than branching on the bootstrap name — that list
  has already drifted once, `android`'s own `remove_presplash` being gated to
  sdl2/sdl3 though the webview activity has the method too.
- **`recipes/android/src/setup.py`** — one `py_modules` line.
- **`doc/source/kivy_bootstrap.rst`** (new) — the contract documented for
  bootstrap authors: what to ship, the rules it must obey, and this file as the
  worked example. Added to the toctree and cross-linked from `bootstraps.rst`.

No changes to `start.c`, to any bootstrap, or to the build. The `android` recipe
is the natural home: it is already a hard dependency of the `kivy` recipe, so
every Kivy app has it, and it is the recipe that already knows
`ACTIVITY_CLASS_NAME`.

## Verified on device

Built with this repo's `sdl3` bootstrap and Kivy 3.0.0.dev0 from a local
checkout (NDK r28c, SDL3 3.4.2, python3 3.14.2), then run on an x86_64 emulator:

```
P4A_kivy_DIR=~/src/kivy3-src p4a apk --private ~/src/kivy3-contract-demo \
  --package=org.kivy.contract3 --name="Kivy3 Contract" --version=0.1 \
  --bootstrap=sdl3 --requirements=kivy \
  --arch=x86_64 --android-api=35 --ndk-api=24 --save-wheel-dir=~/kivy3-wheels
```

p4a picked the Kivy 3 path by itself: it read `3.0.0.dev0` from the checkout,
skipped `use_cython.patch`, and set `KIVY_CROSS_PLATFORM=android`. A
purpose-built app then exercised each part of the contract:

```
CONTRACT: ACTIVITY_OK package=org.kivy.contract3
CONTRACT: PULLED_FROM_BOOTSTRAP_OK kivy.get_activity() is the bootstrap's Activity
CONTRACT: NO_CLASS_NAME_IN_KIVY_OK kivy asked _kivy_bootstrap; build chose org.kivy.android.PythonActivity
CONTRACT: APP_CONTEXT_OK package=org.kivy.contract3
CONTRACT: GEOMETRY_OK dpi=160.0 scale=1.00 density=1.00 fontscale=1.00 keyboard=0 ...
CONTRACT: STORAGE_OK user_data_dir=/data/user/0/org.kivy.contract3/files
CONTRACT: CLIPBOARD_OK provider=ClipboardAndroid round-trip exact
CONTRACT: PRESPLASH_OK bootstrap implements remove_presplash
CONTRACT: ALL_OK 8/8
```

`PULLED_FROM_BOOTSTRAP` asserts that `kivy.get_activity()` and
`_kivy_bootstrap.get_activity()` return the same Java object.
`NO_CLASS_NAME_IN_KIVY` asserts that the live Activity's Java class equals
`android.config.ACTIVITY_CLASS_NAME` — the build's choice, not Kivy's.
`CLIPBOARD` exercises the coupling that started this. Kivy's log carries no
"Could not remove android presplash" warning, which is what a bootstrap failing
this contract produces today.

As a by-product, `--save-wheel-dir` on that build emitted
`kivy-3.0.0.dev0-cp314-cp314-android_24_x86_64.whl` alongside the APK, with
`_kivy_bootstrap.py` riding along at the top level of the `android` wheel.

The Kivy side is kivy/kivy#9352, for Kivy 3.0 (`kivy.mobile`, `app.py`,
`clipboard_android.py`, `base.py`, plus contract tests); after it,
`grep -rn "PythonActivity\|mActivity" kivy/` matches nothing outside the test
harness, and the only code that knows the class name is p4a's file above.

A second, Gradle- and wheel-based Android builder I
am working on implements the same contract against an unmodified Kivy, differing
only in the ways the contract allows — its own activity constant, and no
`remove_presplash()` because it uses the androidx core-splashscreen system
splash.
