### PR TITLE
Make no-ast-str.patch conditional on Kivy version.

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -43,7 +43,7 @@ class KivyRecipe(PyProjectRecipe):
     patches = [
         ("sdl-gl-swapwindow-nogil.patch", is_kivy_affected_by_deadlock_issue),
         ("use_cython.patch", is_kivy_less_than_3),
-        "no-ast-str.patch"
+        ("no-ast-str.patch", is_kivy_less_than_3),
     ]
 
     @property


### PR DESCRIPTION

This pull request makes a small change to the `KivyRecipe` class in the `pythonforandroid/recipes/kivy/__init__.py` file. The change updates the way the `"no-ast-str.patch"` patch is specified, making it conditional on the Kivy version being less than 3, similar to the other patches.

* Updated the `patches` list so that `"no-ast-str.patch"` is only applied when Kivy is less than version 3, by pairing it with the `is_kivy_less_than_3` condition.