### PR TITLE
build: clear venv and skip pip self-upgrade to avoid stale pip corruption

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -868,15 +868,11 @@ def run_pymodules_install(ctx, arch, modules, project_dir=None,
     # Use our hostpython to create the virtualenv
     host_python = sh.Command(ctx.hostpython)
     with current_directory(join(ctx.build_dir)):
-        shprint(host_python, '-m', 'venv', 'venv')
+        shprint(host_python, '-m', 'venv', '--clear', 'venv')
 
-        # Prepare base environment and upgrade pip:
+        # Prepare base environment:
         base_env = dict(copy.copy(os.environ))
         base_env["PYTHONPATH"] = ctx.get_site_packages_dir(arch)
-        info('Upgrade pip to latest version')
-        shprint(sh.bash, '-c', (
-            "source venv/bin/activate && pip install -U pip"
-        ), _env=copy.copy(base_env))
 
         # Install Cython in case modules need it to build:
         info('Install Cython in case one of the modules needs it to build')


### PR DESCRIPTION
Closes #3339

## Problem

`run_pymodules_install` creates a build venv with `python -m venv venv`.
If the build directory already exists from a previous failed run, the
venv can contain a mixed pip installation with files from two different
pip versions — `pip install -U pip` replaces files one by one, and if
the process is interrupted mid-upgrade, the old and new files get
interleaved. On re-run, `python -m venv venv` happily reuses the
existing directory without cleaning it, so the corrupted state sticks
around permanently.

This showed up as:

ImportError: cannot import name 'BuildDependencyInstallError'
from 'pip._internal.exceptions'

Or, as reported in #3339:

ImportError: cannot import name 'RequirementInformation'
from 'pip._vendor.resolvelib.structs'

## Fix

Two changes in `pythonforandroid/build.py`:

1. **`--clear` flag to `python -m venv`** — wipes the old venv before
   recreating it so stale pip files don't survive between runs.

2. **Removed `pip install -U pip`** — the pip that ships with the host
   Python's `ensurepip` is perfectly capable of installing Cython and
   pure-Python `.whl` files. Self-upgrading pip adds risk with zero
   benefit.

## Testing

- `tox -e pep8` — passes
- `make test` — 460 passed, 2 failed (pre-existing failures in
  `test_pythonpackage_basic.py`, confirmed against base commit)