### PR TITLE
:bug: Fix greenlet shared linking

### DIFF
--- a/pythonforandroid/recipes/greenlet/__init__.py
+++ b/pythonforandroid/recipes/greenlet/__init__.py
@@ -7,5 +7,10 @@ class GreenletRecipe(PyProjectRecipe):
     depends = ['setuptools']
     call_hostpython_via_targetpython = False
 
+    def get_recipe_env(self, arch, **kwargs):
+        env = super().get_recipe_env(arch, **kwargs)
+        env['LDCXXSHARED'] = env['CXX'] + ' -shared'
+        return env
+
 
 recipe = GreenletRecipe()

--- a/testapps/on_device_unit_tests/test_app/tests/test_requirements.py
+++ b/testapps/on_device_unit_tests/test_app/tests/test_requirements.py
@@ -86,6 +86,20 @@ class LibffiTestCase(PythonTestMixIn, TestCase):
         libc.printf(b"%s\n", b"Using the C printf function from Python ... ")
 
 
+class GreenletTestCase(PythonTestMixIn, TestCase):
+    module_import = 'greenlet._greenlet'
+
+    def test_run_module(self):
+        from greenlet import greenlet
+
+        def add_one(value):
+            return value + 1
+
+        worker = greenlet(add_one)
+        self.assertEqual(worker.switch(41), 42)
+        self.assertTrue(worker.dead)
+
+
 class RequestsTestCase(PythonTestMixIn, TestCase):
     module_import = 'requests'
 

--- a/tests/recipes/test_greenlet.py
+++ b/tests/recipes/test_greenlet.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+from tests.recipes.recipe_ctx import RecipeCtx
+
+
+class TestGreenletRecipe(RecipeCtx, unittest.TestCase):
+
+    recipe_name = "greenlet"
+
+    def test_get_recipe_env_sets_target_cxx_shared_linker(self):
+        parent_env = {
+            'CXX': (
+                '/ndk/bin/aarch64-linux-android24-clang++ '
+                '--target=aarch64-linux-android24'
+            ),
+            'LDCXXSHARED': 'clang++ -bundle -undefined dynamic_lookup',
+            'CFLAGS': '-DANDROID',
+        }
+
+        with patch(
+            'pythonforandroid.recipe.PyProjectRecipe.get_recipe_env',
+            return_value=parent_env,
+        ) as get_recipe_env:
+            env = self.recipe.get_recipe_env(self.arch)
+
+        get_recipe_env.assert_called_once_with(self.arch)
+        self.assertEqual(
+            env['LDCXXSHARED'],
+            parent_env['CXX'] + ' -shared',
+        )
+        self.assertEqual(env['CFLAGS'], '-DANDROID')


### PR DESCRIPTION
Use the target C++ compiler with -shared so setuptools does not inherit macOS bundle linker flags during Android cross-compilation.

Add recipe environment coverage and a dormant on-device smoke test for loading the native extension and switching greenlets.