### PR TITLE
fix for freetypehost host

### DIFF
--- a/pythonforandroid/recipes/freetype/__init__.py
+++ b/pythonforandroid/recipes/freetype/__init__.py
@@ -25,7 +25,8 @@ class FreetypeRecipe(Recipe):
     """
 
     version = '2.14.1'
-    url = 'https://download.savannah.gnu.org/releases/freetype/freetype-{version}.tar.gz'  # noqa
+    # url = 'https://download.savannah.gnu.org/releases/freetype/freetype-{version}.tar.gz'  # noqa
+    url = 'https://download-mirror.savannah.gnu.org/releases/freetype/freetype-{version}.tar.gz'
     built_libraries = {'libfreetype.so': 'objs/.libs'}
 
     def get_recipe_env(self, arch=None, with_harfbuzz=False):


### PR DESCRIPTION
updated freetype source url
to https://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.gz