### PR TITLE
qt: keyboard fixes

### DIFF
--- a/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/qt/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -123,7 +123,11 @@ public class PythonActivity extends QtActivity {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // If it wasn't the Back key or there's no web page history, bubble up to the default
+        if (keyCode != KeyEvent.KEYCODE_BACK) {
+            return super.onKeyDown(keyCode, event);
+        }
+
+        // If there's no web page history, bubble up to the default
         // system behavior (probably exit the activity)
         if (SystemClock.elapsedRealtime() - lastBackClick > 2000) {
             lastBackClick = SystemClock.elapsedRealtime();

--- a/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
@@ -60,6 +60,7 @@
                   android:label="@string/app_name"
                   android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|fontScale|uiMode{% if args.min_sdk_version >= 8 %}|uiMode{% endif %}{% if args.min_sdk_version >= 13 %}|screenSize|smallestScreenSize{% endif %}{% if args.min_sdk_version >= 17 %}|layoutDirection{% endif %}{% if args.min_sdk_version >= 24 %}|density{% endif %}"
                   android:screenOrientation="{{ args.manifest_orientation }}"
+                  android:windowSoftInputMode="adjustResize"
                   android:exported="true"
                   android:theme="@style/KivySupportCutout"
                   {% if args.activity_launch_mode %}


### PR DESCRIPTION
Fixed misc issues

- Only the Back key now triggers the double-press-to-exit toast; Previously, all keys on the keyboard were registered as "Back" keys (and an irrelevant toast keeps popping up).

- Added android:windowSoftInputMode="adjustResize" so the window resizes when the soft keyboard appears instead of being covered by it - default behavior of standard Android apps.