### PR TITLE
Add --extra-manifest-application-xml for injecting elements inside <application>

### DIFF
--- a/pythonforandroid/bootstraps/_sdl_common/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/_sdl_common/build/templates/AndroidManifest.tmpl.xml
@@ -142,6 +142,7 @@
     {% for a in args.add_activity  %}
     <activity android:name="{{ a }}"></activity>
     {% endfor %}
+    {{ args.extra_manifest_application_xml }}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -1050,6 +1050,15 @@ tools directory of the Android SDK.
     ap.add_argument('--extra-manifest-application-arguments', default='',
                     help='Extra arguments to be added to the <manifest><application> tag of'
                          'AndroidManifest.xml')
+    ap.add_argument('--extra-manifest-application-xml', default='',
+                    help=('Extra xml to write directly inside the <manifest><application> '
+                          'element of AndroidManifest.xml, i.e. as a sibling of <activity>/'
+                          '<service>/etc, as opposed to --extra-manifest-application-arguments '
+                          'which only supports attributes on the <application> tag itself. '
+                          'Needed for e.g. a <provider> entry (such as a FileProvider), which '
+                          'neither --extra-manifest-xml (a sibling of <application>, at the '
+                          '<manifest> root) nor --extra-manifest-application-arguments '
+                          '(attributes only) can express.'))
     ap.add_argument('--manifest-placeholders', dest='manifest_placeholders',
                     default='[:]', help=('Inject build variables into the manifest '
                                          'via the manifestPlaceholders property'))

--- a/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/qt/build/templates/AndroidManifest.tmpl.xml
@@ -105,6 +105,7 @@
     {% for a in args.add_activity  %}
     <activity android:name="{{ a }}"></activity>
     {% endfor %}
+    {{ args.extra_manifest_application_xml }}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_library/build/templates/AndroidManifest.tmpl.xml
@@ -15,6 +15,7 @@
                  android:process=":service_{{ name }}"
                  android:exported="true" />
         {% endfor %}
+    {{ args.extra_manifest_application_xml }}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -94,6 +94,7 @@
             </intent-filter>
         </receiver>
         {% endif %}
+    {{ args.extra_manifest_application_xml }}
     </application>
 
 </manifest>

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -102,6 +102,7 @@
             </intent-filter>
         </receiver>
         {% endif %}
+    {{ args.extra_manifest_application_xml }}
     </application>
 
 </manifest>


### PR DESCRIPTION
There's currently no way to add an arbitrary child element (like a <provider>, needed for e.g. a FileProvider) inside <application> in the generated AndroidManifest.xml:

- --extra-manifest-xml writes at the <manifest> root, as a sibling of <application> -- a <provider> there is invalid, providers must be nested inside <application>.
- --extra-manifest-application-arguments only splices into the <application ...> opening tag's attribute list, so it can't hold a full child element either.

This is a real gap: a FileProvider (needed to hand another app, e.g. a camera app, a content:// Uri instead of a file:// one and avoid FileUriExposedException on API 24+) requires exactly this kind of <provider> entry, and there's currently no supported way to add one without patching the rendered manifest after the fact via a p4a.hook.

Adds --extra-manifest-application-xml, rendered immediately before </application> in every bootstrap's manifest template, alongside the two existing options.