### PR TITLE
python3: keep the order of patches and configure args stable

### DIFF
--- a/pythonforandroid/recipes/python3/__init__.py
+++ b/pythonforandroid/recipes/python3/__init__.py
@@ -206,7 +206,7 @@ class Python3Recipe(TargetPythonRecipe):
             elif _p_version.minor >= 8:
                 self.patches.append("patches/py3.8.1_fix_cortex_a8.patch")
 
-        self.patches = list(set(self.patches))
+        self.patches = list(dict.fromkeys(self.patches))  # preserve order for reproducibility
         super().apply_patches(arch, build_dir)
 
     def include_root(self, arch_name):
@@ -333,7 +333,7 @@ class Python3Recipe(TargetPythonRecipe):
         if _p_version.minor >= 13 and self.disable_gil:
             self.configure_args.append("--disable-gil")
 
-        self.configure_args = list(set(self.configure_args))
+        self.configure_args = list(dict.fromkeys(self.configure_args))  # preserve order for reproducibility
 
         return env
 


### PR DESCRIPTION
`patches` and `configure_args` are deduplicated with `list(set(...))`,
whose order depends on PYTHONHASHSEED.
The configure arguments end up in the shipped `_sysconfigdata`
module (CONFIG_ARGS), so two otherwise identical builds can differ,
and the patches are applied in a different order on every run.
Use an order-preserving dedup instead to help with reproducible builds.

Upstreamed from https://github.com/spesmilo/python-for-android