### PR TITLE
recipes: pyjnius: drop stale six dependency

### DIFF
--- a/pythonforandroid/recipes/pyjnius/__init__.py
+++ b/pythonforandroid/recipes/pyjnius/__init__.py
@@ -9,7 +9,7 @@ class PyjniusRecipe(PyProjectRecipe):
     version = '1.7.0'
     url = 'https://github.com/kivy/pyjnius/archive/{version}.zip'
     name = 'pyjnius'
-    depends = [('genericndkbuild', 'sdl2', 'sdl3'), 'six']
+    depends = [('genericndkbuild', 'sdl2', 'sdl3')]
     site_packages_name = 'jnius'
     hostpython_prerequisites = ["Cython<3.2"]
     patches = [

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -84,7 +84,7 @@ class TestToolchainCL:
             'hostpython3', 'libffi', 'openssl', 'sqlite3', 'python3',
             'genericndkbuild', 'pyjnius', 'android',
         ]
-        python_modules = ['six']
+        python_modules = []
         context = mock.ANY
         project_dir = None
         assert m_build_recipes.call_args_list == [


### PR DESCRIPTION
The six recipe was removed with the Python 3.14 update (#3242), but pyjnius kept 'six' in its depends. 
A dependency without a recipe is handed to pip as a plain python module, so every build that pulls in pyjnius installs six into the target site-packages for nothing: pyjnius dropped its six requirement in 1.5.0 (kivy/pyjnius#619) and 1.7.0 only declares dev/ci extras.